### PR TITLE
added: fixed assembly uniqueness

### DIFF
--- a/libs/backend/graphql/src/resolvers/event/competition/assembly.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/assembly.resolver.ts
@@ -26,9 +26,6 @@ export class AssemblyResolver {
     return this.assemblyService.validate(assembly, { playerId: user.id, teamId: assembly.teamId });
   }
 
-
-  
-
   @ResolveField(() => [PlayerRankingType])
   async titularsPlayers(@Parent() assembly: AssemblyOutput): Promise<PlayerRankingType[]> {
     if (!assembly.titularsPlayerData) return [];
@@ -101,7 +98,6 @@ export class AssemblyResolver {
         where: {
           encounterId: assembly.encounterId,
           teamId: assembly.teamId,
-          playerId: user.id,
         },
         defaults: {
           captainId: assembly?.captainId,


### PR DESCRIPTION
a fix for assembly uniqueness that takes the player id out of the check.  Because multiple people can create assemblies (gameLeaders, teamCaptains, and club admins) this will cause multiple conflicting assemblies to be created