### PR TITLE
fixed some things based on feedback

### DIFF
--- a/database/migrations/20250827084948-add_comments_field_to_encounter.js
+++ b/database/migrations/20250827084948-add_comments_field_to_encounter.js
@@ -1,0 +1,39 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+
+const columnsToAdd = ["comments"];
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all(
+        columnsToAdd.map((column) =>
+          queryInterface.addColumn(
+            { tableName: "EncounterCompetitions", schema: "event" },
+            column,
+            {
+              type: Sequelize.DataTypes.TEXT,
+              allowNull: true,
+            },
+            { transaction: t }
+          )
+        )
+      );
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all(
+        columnsToAdd.map((column) =>
+          queryInterface.removeColumn(
+            { tableName: "EncounterCompetitions", schema: "event" },
+            column,
+            { transaction: t }
+          )
+        )
+      );
+    });
+  },
+};

--- a/database/migrations/20250827085819-convert_game_leader_comments_to_encounter_comments.js
+++ b/database/migrations/20250827085819-convert_game_leader_comments_to_encounter_comments.js
@@ -1,0 +1,121 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction(async (t) => {
+      // 1. Query all game leader comments, organized by linkId with latest first
+      const gameLeaderComments = await queryInterface.sequelize.query(
+        `
+        SELECT c.*, 
+               ROW_NUMBER() OVER (PARTITION BY c."linkId" ORDER BY c."createdAt" DESC) as rn
+        FROM public."Comments" c
+        WHERE c."linkType" = 'game_leader_comment'
+        ORDER BY c."linkId", c."createdAt" DESC
+      `,
+        {
+          type: Sequelize.QueryTypes.SELECT,
+          transaction: t,
+        }
+      );
+
+      // 2. Get only the most recent comment per linkId (encounter)
+      const latestComments = gameLeaderComments.filter((comment) => comment.rn === 1);
+
+      // 3. Update encounters with the latest comment message
+      for (const comment of latestComments) {
+        await queryInterface.sequelize.query(
+          `
+          UPDATE event."EncounterCompetitions" 
+          SET "gameLeaderComment" = :message
+          WHERE id = :encounterId
+        `,
+          {
+            replacements: {
+              message: comment.message,
+              encounterId: comment.linkId,
+            },
+            transaction: t,
+          }
+        );
+      }
+
+      // 4. Delete all game leader comments after conversion
+      if (gameLeaderComments.length > 0) {
+        const commentIds = gameLeaderComments.map((c) => c.id);
+        await queryInterface.sequelize.query(
+          `
+          DELETE FROM public."Comments" 
+          WHERE id IN (:commentIds)
+        `,
+          {
+            replacements: { commentIds },
+            transaction: t,
+          }
+        );
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction(async (t) => {
+      // 1. Query encounters that have game leader comments
+      const encountersWithComments = await queryInterface.sequelize.query(
+        `
+        SELECT ec.id as "encounterId", 
+               ec."gameLeaderComment" as message,
+               ec."gameLeaderId",
+               p."clubId"
+        FROM event."EncounterCompetitions" ec
+        LEFT JOIN public."Players" p ON ec."gameLeaderId" = p.id
+        WHERE ec."gameLeaderComment" IS NOT NULL 
+          AND ec."gameLeaderComment" != ''
+      `,
+        {
+          type: Sequelize.QueryTypes.SELECT,
+          transaction: t,
+        }
+      );
+
+      // 2. Create comment records from encounter comments
+      for (const encounter of encountersWithComments) {
+        await queryInterface.sequelize.query(
+          `
+          INSERT INTO public."Comments" (
+            id, message, "linkId", "linkType", "playerId", "clubId", 
+            "createdAt", "updatedAt"
+          ) VALUES (
+            gen_random_uuid(), 
+            :message, 
+            :encounterId, 
+            'game_leader_comment',
+            :gameLeaderId,
+            :clubId,
+            NOW(),
+            NOW()
+          )
+        `,
+          {
+            replacements: {
+              message: encounter.message,
+              encounterId: encounter.encounterId,
+              gameLeaderId: encounter.gameLeaderId,
+              clubId: encounter.clubId,
+            },
+            transaction: t,
+          }
+        );
+      }
+
+      // 3. Clear the game leader comments from encounters
+      await queryInterface.sequelize.query(
+        `
+        UPDATE event."EncounterCompetitions" 
+        SET "gameLeaderComment" = NULL
+        WHERE "gameLeaderComment" IS NOT NULL
+      `,
+        { transaction: t }
+      );
+    });
+  },
+};

--- a/libs/backend/database/src/models/event/competition/encounter-competition.model.ts
+++ b/libs/backend/database/src/models/event/competition/encounter-competition.model.ts
@@ -16,6 +16,7 @@ import {
   HasOneSetAssociationMixin,
   InferAttributes,
   InferCreationAttributes,
+  Op,
 } from "sequelize";
 import {
   BelongsTo,
@@ -267,6 +268,18 @@ export class EncounterCompetition extends Model<
     foreignKey: "linkId",
     constraints: false,
     scope: {
+      linkType: {
+        [Op.or]: ["home_comment", "away_comment", "game_leader_comment"],
+      },
+    },
+  })
+  confirmComments?: Relation<Comment[]>;
+
+  @Field(() => [Comment], { nullable: true })
+  @HasMany(() => Comment, {
+    foreignKey: "linkId",
+    constraints: false,
+    scope: {
       linkType: "home_comment",
     },
   })
@@ -282,15 +295,15 @@ export class EncounterCompetition extends Model<
   })
   awayComments?: Relation<Comment[]>;
 
-  @Field(() => Comment, { nullable: true })
-  @HasOne(() => Comment, {
+  @Field(() => [Comment], { nullable: true })
+  @HasMany(() => Comment, {
     foreignKey: "linkId",
     constraints: false,
     scope: {
       linkType: "game_leader_comment",
     },
   })
-  gameLeaderComment?: Relation<Comment>;
+  gameLeaderComments?: Relation<[Comment]>;
 
   @Field(() => [Comment], { nullable: true })
   @HasMany(() => Comment, {
@@ -312,15 +325,9 @@ export class EncounterCompetition extends Model<
   })
   awayCommentsChange?: Relation<Comment[]>;
 
-  @Field(() => Comment, { nullable: true })
-  @HasOne(() => Comment, {
-    foreignKey: "linkId",
-    constraints: true,
-    scope: {
-      linkType: "encounter",
-    },
-  })
-  encounterComment?: Relation<Comment>;
+  @Field(() => String, { nullable: true })
+  @Column(DataType.TEXT)
+  comments?: string;
 
   // Has many Game
   getGames!: HasManyGetAssociationsMixin<Game>;
@@ -384,9 +391,13 @@ export class EncounterCompetition extends Model<
   hasAssemblies!: HasManyHasAssociationsMixin<Assembly, string>;
   countAssemblies!: HasManyCountAssociationsMixin;
 
-  // Has one Location
-  getGameLeaderComment!: BelongsToGetAssociationMixin<Comment>;
-  setGameLeaderComment!: BelongsToSetAssociationMixin<Comment, string>;
+  // Has many GameLeaderComment
+  getGameLeaderComments!: HasManyGetAssociationsMixin<Comment>;
+  setGameLeaderComments!: HasManySetAssociationsMixin<Comment, string>;
+  addGameLeaderComments!: HasManyAddAssociationsMixin<Comment, string>;
+  addGameLeaderComment!: HasManyAddAssociationMixin<Comment, string>;
+  removeGameLeaderComment!: HasManyRemoveAssociationMixin<Comment, string>;
+  removeGameLeaderComments!: HasManyRemoveAssociationsMixin<Comment, string>;
 
   // Has many HomeComment
   getHomeComments!: HasManyGetAssociationsMixin<Comment>;
@@ -410,10 +421,6 @@ export class EncounterCompetition extends Model<
   hasAwayComments!: HasManyHasAssociationsMixin<Comment, string>;
   countAwayComments!: HasManyCountAssociationsMixin;
 
-  // Has one EncounterComment
-  getEncounterComment!: BelongsToGetAssociationMixin<Comment>;
-  setEncounterComment!: BelongsToSetAssociationMixin<Comment, string>;
-
   // Has many HomeCommentsChange
   getHomeCommentsChanges!: HasManyGetAssociationsMixin<Comment>;
   setHomeCommentsChanges!: HasManySetAssociationsMixin<Comment, string>;
@@ -435,6 +442,17 @@ export class EncounterCompetition extends Model<
   hasAwayCommentsChange!: HasManyHasAssociationMixin<Comment, string>;
   hasAwayCommentsChanges!: HasManyHasAssociationsMixin<Comment, string>;
   countAwayCommentsChanges!: HasManyCountAssociationsMixin;
+
+  // Has many ConfirmComments
+  getConfirmComments!: HasManyGetAssociationsMixin<Comment>;
+  setConfirmComments!: HasManySetAssociationsMixin<Comment, string>;
+  addConfirmComments!: HasManyAddAssociationsMixin<Comment, string>;
+  addConfirmComment!: HasManyAddAssociationMixin<Comment, string>;
+  removeConfirmComment!: HasManyRemoveAssociationMixin<Comment, string>;
+  removeConfirmComments!: HasManyRemoveAssociationsMixin<Comment, string>;
+  hasConfirmComment!: HasManyHasAssociationMixin<Comment, string>;
+  hasConfirmComments!: HasManyHasAssociationsMixin<Comment, string>;
+  countConfirmComments!: HasManyCountAssociationsMixin;
 }
 
 @InputType()
@@ -489,6 +507,9 @@ export class updateEncounterCompetitionInput {
 
   @Field(() => String, { nullable: true })
   tempAwayCaptainId?: string;
+
+  @Field(() => String, { nullable: true })
+  comments?: string;
 }
 
 @InputType()

--- a/libs/backend/database/src/models/event/game.model.ts
+++ b/libs/backend/database/src/models/event/game.model.ts
@@ -57,6 +57,7 @@ import { GamePlayerMembership } from "./game-player.model";
 import { DrawTournament } from "./tournament";
 
 export const WINNER_STATUS = {
+  NOT_YET_PLAYED: 0,
   HOME_TEAM_WIN: 1,
   AWAY_TEAM_WIN: 2,
   HOME_TEAM_FORFEIT: 4,

--- a/libs/backend/graphql/src/resolvers/game/game.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/game/game.resolver.ts
@@ -261,6 +261,8 @@ export class GamesResolver {
         throw new NotFoundException(`${Game.name}: ${gameData.gameId}`);
       }
 
+      const gameHasPlayedAt = game.playedAt !== null;
+
       // used to check the current winner of the game against the update data, to see if the score of the new loser needs to drop
       const oldGameWinner = game.winner;
 
@@ -274,6 +276,7 @@ export class GamesResolver {
           set3Team2: gameData.set3Team2,
           gameType: gameData.gameType,
           winner: gameData.winner,
+          playedAt: gameHasPlayedAt ? game.playedAt : gameData.playedAt,
         },
         { transaction }
       );

--- a/libs/backend/translate/assets/i18n/en/all.json
+++ b/libs/backend/translate/assets/i18n/en/all.json
@@ -3319,7 +3319,7 @@
         "shuttle": {
           "title": "Shuttle",
           "helpText": "List of approved shuttles",
-          "helpLink": "https://www.badmintonvlaanderen.be/file/973717/?dl=1"
+          "helpLink": "https://www.badmintonvlaanderen.be/page/27324/Goedgekeurde-shuttles"
         },
         "commentsOptional": "Comments (optional)"
       },

--- a/libs/backend/translate/assets/i18n/nl_BE/all.json
+++ b/libs/backend/translate/assets/i18n/nl_BE/all.json
@@ -3069,7 +3069,7 @@
         "shuttle": {
           "title": "Shuttle",
           "helpText": "Lijst met gehomologeerde shuttles",
-          "helpLink": "https://www.badmintonvlaanderen.be/file/973717/?dl=1"
+          "helpLink": "https://www.badmintonvlaanderen.be/page/27324/Goedgekeurde-shuttles"
         },
         "commentsOptional": "Opmerkingen (optioneel)"
       },

--- a/libs/utils/src/config/configuration.ts
+++ b/libs/utils/src/config/configuration.ts
@@ -40,6 +40,8 @@ export const configSchema = Joi.object({
   DB_CACHE: Joi.boolean().default(false),
   DB_CACHE_PREFIX: Joi.string().optional(),
   DB_LOGGING: Joi.boolean().optional(),
+  ENTER_SCORES_ENABLED: Joi.boolean().optional(),
+  VISUAL_SYNC_ENABLED: Joi.boolean().optional(),
   REDIS_DATABASE: Joi.number().integer().optional(),
   REDIS_HOST: Joi.when("DB_CACHE", {
     is: true,
@@ -162,6 +164,7 @@ export const load = () => ({
   PUSH_ENABLED: process.env?.["PUSH_ENABLED"] === "true",
   VR_CHANGE_DATES: process.env?.["VR_CHANGE_DATES"] === "true",
   VR_ACCEPT_ENCOUNTERS: process.env?.["VR_ACCEPT_ENCOUNTERS"] === "true",
+  VISUAL_SYNC_ENABLED: process.env?.["VISUAL_SYNC_ENABLED"] === "true",
 });
 
 export type ConfigType = {
@@ -187,6 +190,8 @@ export type ConfigType = {
   LOGTAIL_TOKEN?: string;
   AUTH0_ISSUER_URL: string;
   AUTH0_AUDIENCE: string;
+  VISUAL_SYNC_ENABLED: boolean;
+  ENTER_SCORES_ENABLED: boolean;
   MAIL_ENABLED: boolean;
   MAIL_PASS?: string;
   MAIL_USER?: string;


### PR DESCRIPTION
- added a more performant fetch for a player's recent encounters, which uses raw sql to better determine connections between a playher and an encounter
- changed the link for recommended shuttles
- added two migrations to add a comments column to the encounter record, to simplify encounter comments
- added a migration to convert game leader comments (old way of storing encounter comments) to encounter comments
- ensured game leader comments are now handled similar to home and away comments
- added a confirmComments resolver to enable fetching of comments related to the confirm encounter page
- ensured that the playedAt value gets stored on a game on save, when the game is complete
- added some feature flags to enable pupeteer to start up a visual browser when needed, and also a flag to enable saving of scores in development