### PR TITLE
fix(api): migrate webpack config from deprecated NxWebpackPlugin to c…

### DIFF
--- a/apps/api/webpack.config.js
+++ b/apps/api/webpack.config.js
@@ -1,20 +1,25 @@
-const { NxWebpackPlugin } = require("@nx/webpack");
+const { composePlugins, withNx } = require("@nx/webpack");
 const { join } = require("path");
 
-module.exports = {
-  output: {
-    path: join(__dirname, "../../dist/apps/api"),
-  },
-  plugins: [
-    new NxWebpackPlugin({
-      target: "node",
-      compiler: "tsc",
-      main: "./src/main.ts",
-      tsConfig: "./tsconfig.app.json",
-      assets: ["./src/assets"],
-      optimization: process.env["NODE_ENV"] === "production",
-      outputHashing: "none",
-      sourceMap: true,
-    }),
-  ],
-};
+module.exports = composePlugins(withNx(), (config) => {
+  return {
+    ...config,
+    // keep existing output, just override path
+    output: {
+      ...config.output,
+      path: join(__dirname, "../../dist/apps/api"),
+    },
+    // keep existing externals and append our own
+    // webpack accepts arrays of externals (objects, functions, regexps, etc.)
+    externals: [
+      ...(Array.isArray(config.externals)
+        ? config.externals
+        : config.externals
+          ? [config.externals]
+          : []),
+      {
+        "node-adodb": "commonjs node-adodb",
+      },
+    ],
+  };
+});


### PR DESCRIPTION
…omposePlugins

- Replace deprecated NxWebpackPlugin with composePlugins(withNx()) API
- Add node-adodb to externals to prevent webpack bundling errors
- Use array-based externals configuration for cleaner code
- node-adodb is an optional Windows-only dependency handled at runtime

Fixes webpack deprecation warning and module resolution errors during build. The externals configuration ensures node-adodb is resolved at runtime by Node.js rather than being bundled by webpack, which is necessary since it's only installed on Windows platforms (see scripts/pre-install.js).