### PR TITLE
fix(sync): add protocol timeout guard to check-encounters and share u…

### DIFF
--- a/apps/worker/sync/src/app/processors/check-encounters/__tests__/encounter-detail-page.service.spec.ts
+++ b/apps/worker/sync/src/app/processors/check-encounters/__tests__/encounter-detail-page.service.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for EncounterDetailPageService (guard lifecycle and delegation).
+ */
+
+jest.mock("@badman/backend-pupeteer", () => ({
+  getPage: jest.fn(),
+  acceptCookies: jest.fn(),
+  signIn: jest.fn(),
+  createProtocolTimeoutGuard: jest.fn(),
+}));
+
+import { getPage, createProtocolTimeoutGuard } from "@badman/backend-pupeteer";
+import { EncounterDetailPageService } from "../encounter-detail-page.service";
+
+function makeFakePage(closed = false) {
+  return {
+    setDefaultTimeout: jest.fn(),
+    setViewport: jest.fn().mockResolvedValue(undefined),
+    isClosed: jest.fn().mockReturnValue(closed),
+    close: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("EncounterDetailPageService", () => {
+  let service: EncounterDetailPageService;
+  let mockGuard: { install: jest.Mock; remove: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGuard = { install: jest.fn(), remove: jest.fn() };
+    (createProtocolTimeoutGuard as jest.Mock).mockReturnValue(mockGuard);
+    service = new EncounterDetailPageService();
+  });
+
+  describe("open()", () => {
+    it("calls getPage, installs protocol timeout guard, sets timeout and viewport", async () => {
+      const fakePage = makeFakePage();
+      (getPage as jest.Mock).mockResolvedValue(fakePage);
+
+      await service.open();
+
+      expect(getPage).toHaveBeenCalledWith();
+      expect(mockGuard.install).toHaveBeenCalledTimes(1);
+      expect(fakePage.setDefaultTimeout).toHaveBeenCalledWith(10000);
+      expect(fakePage.setViewport).toHaveBeenCalledWith({ width: 1691, height: 1337 });
+    });
+
+    it("throws when getPage returns null", async () => {
+      (getPage as jest.Mock).mockResolvedValue(null);
+
+      await expect(service.open()).rejects.toThrow("Failed to create browser page");
+      expect(mockGuard.install).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("close()", () => {
+    it("removes guard then closes page when open", async () => {
+      const fakePage = makeFakePage(false);
+      (getPage as jest.Mock).mockResolvedValue(fakePage);
+      await service.open();
+
+      await service.close();
+
+      expect(mockGuard.remove).toHaveBeenCalledTimes(1);
+      expect(fakePage.close).toHaveBeenCalledTimes(1);
+    });
+
+    it("removes guard even when page already closed", async () => {
+      const fakePage = makeFakePage(true);
+      (getPage as jest.Mock).mockResolvedValue(fakePage);
+      await service.open();
+
+      await service.close();
+
+      expect(mockGuard.remove).toHaveBeenCalledTimes(1);
+      expect(fakePage.close).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/worker/sync/src/app/processors/check-encounters/encounter-detail-page.service.ts
+++ b/apps/worker/sync/src/app/processors/check-encounters/encounter-detail-page.service.ts
@@ -1,5 +1,10 @@
 import { EncounterCompetition } from "@badman/backend-database";
-import { acceptCookies, getPage, signIn } from "@badman/backend-pupeteer";
+import {
+  acceptCookies,
+  createProtocolTimeoutGuard,
+  getPage,
+  signIn,
+} from "@badman/backend-pupeteer";
 import { Injectable, Logger } from "@nestjs/common";
 import { Page } from "puppeteer";
 import {
@@ -23,17 +28,20 @@ import {
 export class EncounterDetailPageService {
   private readonly logger = new Logger(EncounterDetailPageService.name);
   private page: Page | null = null;
+  private readonly _protocolTimeoutGuard = createProtocolTimeoutGuard(this.logger);
 
   async open(): Promise<void> {
     this.page = await getPage();
     if (!this.page) {
       throw new Error("Failed to create browser page");
     }
+    this._protocolTimeoutGuard.install();
     this.page.setDefaultTimeout(10000);
     await this.page.setViewport({ width: 1691, height: 1337 });
   }
 
   async close(): Promise<void> {
+    this._protocolTimeoutGuard.remove();
     if (this.page && !this.page.isClosed()) {
       await this.page.close();
     }

--- a/apps/worker/sync/src/app/processors/enter-scores/__tests__/encounter-form-page.service.spec.ts
+++ b/apps/worker/sync/src/app/processors/enter-scores/__tests__/encounter-form-page.service.spec.ts
@@ -7,6 +7,7 @@ jest.mock("@badman/backend-pupeteer", () => ({
   getPage: jest.fn(),
   acceptCookies: jest.fn(),
   signIn: jest.fn(),
+  createProtocolTimeoutGuard: jest.fn(() => ({ install: jest.fn(), remove: jest.fn() })),
 }));
 
 jest.mock("../pupeteer", () => ({

--- a/apps/worker/sync/src/app/processors/enter-scores/encounter-form-page.service.ts
+++ b/apps/worker/sync/src/app/processors/enter-scores/encounter-form-page.service.ts
@@ -1,5 +1,10 @@
 import { EncounterCompetition } from "@badman/backend-database";
-import { acceptCookies, getPage, signIn } from "@badman/backend-pupeteer";
+import {
+  acceptCookies,
+  createProtocolTimeoutGuard,
+  getPage,
+  signIn,
+} from "@badman/backend-pupeteer";
 import { Injectable, Logger } from "@nestjs/common";
 import { Page } from "puppeteer";
 import { Transaction } from "sequelize";
@@ -31,21 +36,20 @@ import { enterGames } from "./pupeteer/enterGames";
 export class EncounterFormPageService {
   private readonly logger = new Logger(EncounterFormPageService.name);
   private page: Page | null = null;
-  private _unhandledRejectionHandler: ((reason: unknown) => void) | null = null;
+  private readonly _protocolTimeoutGuard = createProtocolTimeoutGuard(this.logger);
 
   async open(headless: boolean, flags: string[]): Promise<void> {
     this.page = await getPage(headless, flags);
     if (!this.page) {
       throw new Error("Failed to create browser page");
     }
+    this._protocolTimeoutGuard.install();
     this.page.setDefaultTimeout(30000);
     await this.page.setViewport({ width: 1691, height: 1337 });
-
-    this._installUnhandledRejectionGuard();
   }
 
   async close(): Promise<void> {
-    this._removeUnhandledRejectionGuard();
+    this._protocolTimeoutGuard.remove();
 
     const pageToClose = this.page;
     if (pageToClose && !pageToClose.isClosed()) {
@@ -54,35 +58,6 @@ export class EncounterFormPageService {
     }
     if (this.page === pageToClose) {
       this.page = null;
-    }
-  }
-
-  /**
-   * Catches unhandled ProtocolError rejections from internal Puppeteer frame initialization
-   * (FrameManager.onAttachedToTarget -> Network.enable / Page.addScriptToEvaluateOnNewDocument).
-   * These are fire-and-forget inside Puppeteer and can't be caught via the Page API.
-   */
-  private _installUnhandledRejectionGuard(): void {
-    this._unhandledRejectionHandler = (reason: unknown) => {
-      const msg = reason instanceof Error ? reason.message : String(reason);
-      if (
-        msg.includes("protocolTimeout") ||
-        msg.includes("Network.enable timed out") ||
-        msg.includes("Page.addScriptToEvaluateOnNewDocument timed out")
-      ) {
-        this.logger.warn(
-          `Suppressed internal Puppeteer ProtocolError (non-fatal): ${msg}`
-        );
-        return;
-      }
-    };
-    process.on("unhandledRejection", this._unhandledRejectionHandler);
-  }
-
-  private _removeUnhandledRejectionGuard(): void {
-    if (this._unhandledRejectionHandler) {
-      process.removeListener("unhandledRejection", this._unhandledRejectionHandler);
-      this._unhandledRejectionHandler = null;
     }
   }
 

--- a/libs/backend/pupeteer/src/__tests__/shared.spec.ts
+++ b/libs/backend/pupeteer/src/__tests__/shared.spec.ts
@@ -51,6 +51,10 @@ type SharedModule = {
   getPage: (headless?: boolean, args?: string[]) => Promise<unknown>;
   getBrowser: (headless?: boolean, args?: string[]) => Promise<unknown>;
   restartBrowser: () => Promise<void>;
+  createProtocolTimeoutGuard: (logger: { warn: (...args: unknown[]) => void }) => {
+    install: () => void;
+    remove: () => void;
+  };
 };
 
 let shared: SharedModule;
@@ -183,5 +187,91 @@ describe("getBrowser", () => {
     expect(firstBrowser.close).toHaveBeenCalled();
     expect(mockLaunch).toHaveBeenCalledTimes(2);
     jest.useRealTimers();
+  });
+});
+
+describe("createProtocolTimeoutGuard", () => {
+  let logger: { warn: jest.Mock };
+
+  beforeEach(() => {
+    logger = { warn: jest.fn() };
+  });
+
+  it("returns install and remove functions", () => {
+    const guard = shared.createProtocolTimeoutGuard(logger);
+    expect(guard.install).toBeDefined();
+    expect(guard.remove).toBeDefined();
+    expect(typeof guard.install).toBe("function");
+    expect(typeof guard.remove).toBe("function");
+  });
+
+  it("install adds unhandledRejection listener, remove removes it", () => {
+    const guard = shared.createProtocolTimeoutGuard(logger);
+    const countBefore = process.listenerCount("unhandledRejection");
+
+    guard.install();
+    expect(process.listenerCount("unhandledRejection")).toBe(countBefore + 1);
+
+    guard.remove();
+    expect(process.listenerCount("unhandledRejection")).toBe(countBefore);
+  });
+
+  it("suppresses matching ProtocolError timeout and calls logger.warn", () => {
+    const guard = shared.createProtocolTimeoutGuard(logger);
+    guard.install();
+
+    const reason = new Error(
+      "Page.addScriptToEvaluateOnNewDocument timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed."
+    );
+    // Invoke the handler directly to avoid triggering Jest's unhandledRejection handling
+    const listeners = process.rawListeners("unhandledRejection");
+    const ourListener = listeners[listeners.length - 1] as (reason: unknown, promise: Promise<unknown>) => void;
+    ourListener(reason, Promise.resolve());
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Suppressed internal Puppeteer ProtocolError (non-fatal):",
+      reason.message
+    );
+
+    guard.remove();
+  });
+
+  it("suppresses Network.enable timed out message", () => {
+    const guard = shared.createProtocolTimeoutGuard(logger);
+    guard.install();
+
+    const reason = new Error("Network.enable timed out");
+    const listeners = process.rawListeners("unhandledRejection");
+    const ourListener = listeners[listeners.length - 1] as (reason: unknown, promise: Promise<unknown>) => void;
+    ourListener(reason, Promise.resolve());
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Suppressed internal Puppeteer ProtocolError (non-fatal):",
+      reason.message
+    );
+
+    guard.remove();
+  });
+
+  it("double install does not add duplicate listener", () => {
+    const guard = shared.createProtocolTimeoutGuard(logger);
+    const countBefore = process.listenerCount("unhandledRejection");
+
+    guard.install();
+    guard.install();
+    expect(process.listenerCount("unhandledRejection")).toBe(countBefore + 1);
+
+    guard.remove();
+    expect(process.listenerCount("unhandledRejection")).toBe(countBefore);
+  });
+
+  it("remove is idempotent", () => {
+    const guard = shared.createProtocolTimeoutGuard(logger);
+    guard.install();
+    const countAfterInstall = process.listenerCount("unhandledRejection");
+
+    guard.remove();
+    guard.remove();
+    expect(process.listenerCount("unhandledRejection")).toBe(countAfterInstall - 1);
   });
 });

--- a/libs/backend/pupeteer/src/shared.ts
+++ b/libs/backend/pupeteer/src/shared.ts
@@ -300,3 +300,39 @@ export function startBrowserHealthMonitoring(): () => void {
   // Return cleanup function
   return () => clearInterval(interval);
 }
+
+/**
+ * Creates an install/remove pair for a process-level unhandled rejection handler that
+ * suppresses internal Puppeteer ProtocolError timeouts (Page.addScriptToEvaluateOnNewDocument,
+ * Network.enable). These are fire-and-forget inside Puppeteer and cannot be caught via the Page API.
+ * Call install() when opening a page and remove() when closing so the guard is only active during
+ * page operations.
+ */
+export function createProtocolTimeoutGuard(logger: {
+  warn: (...args: unknown[]) => void;
+}): { install: () => void; remove: () => void } {
+  let handler: ((reason: unknown) => void) | null = null;
+  return {
+    install() {
+      if (handler) return;
+      handler = (reason: unknown) => {
+        const msg = reason instanceof Error ? reason.message : String(reason);
+        if (
+          msg.includes("protocolTimeout") ||
+          msg.includes("Network.enable timed out") ||
+          msg.includes("Page.addScriptToEvaluateOnNewDocument timed out")
+        ) {
+          logger.warn("Suppressed internal Puppeteer ProtocolError (non-fatal):", msg);
+          return;
+        }
+      };
+      process.on("unhandledRejection", handler);
+    },
+    remove() {
+      if (handler) {
+        process.removeListener("unhandledRejection", handler);
+        handler = null;
+      }
+    },
+  };
+}


### PR DESCRIPTION
…tility

- Extract createProtocolTimeoutGuard() to @badman/backend-pupeteer so both enter-scores and check-encounters can use it.
- Add guard to EncounterDetailPageService (open/close) so check-encounters no longer crashes on unhandled 'Page.addScriptToEvaluateOnNewDocument timed out' rejections when running without an active enter-scores page.
- Refactor EncounterFormPageService to use shared createProtocolTimeoutGuard instead of inline _installUnhandledRejectionGuard.
- Add unit tests for createProtocolTimeoutGuard in shared.spec.ts.
- Add encounter-detail-page.service.spec.ts to verify guard lifecycle.

Made-with: Cursor