### PR TITLE
fix(api): resolve .env path from bundle location, not cwd

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -35,9 +35,14 @@ if (process.env.NODE_ENV === "production" || process.env.NODE_ENV === "test") {
     })
   );
 }
-const envFilePath = process.env.NODE_ENV === "test" ? ".env.test" : undefined;
 
-console.log("envFilePath", envFilePath, process.env.NODE_ENV);
+// Resolve .env relative to the project root, not process.cwd().
+// The webpack bundle outputs to dist/apps/api/, so __dirname is three levels
+// below the workspace root. Using an absolute path avoids failures when the
+// NX executor (or a deployment runner) sets a different working directory.
+const projectRoot = join(__dirname, "..", "..", "..");
+const envFileName = process.env.NODE_ENV === "test" ? ".env.test" : ".env";
+const envFilePath = join(projectRoot, envFileName);
 
 @Module({
   imports: [


### PR DESCRIPTION
ConfigModule defaulted to process.cwd()/.env for @nestjs/config v4. When the compiled app runs with a different working directory (e.g. external terminal vs IDE), validation failed because the workspace .env was not found.

Resolve project root from __dirname (dist/apps/api -> repo root) and pass an absolute envFilePath so config loading is independent of cwd.

Made-with: Cursor