### PR TITLE
feat: CP export email notifications via MailingService

### DIFF
--- a/.github/workflows/generate-cp.yml
+++ b/.github/workflows/generate-cp.yml
@@ -16,12 +16,14 @@ on:
 jobs:
   generate:
     runs-on: windows-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version-file: ".nvmrc"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/generate-cp.yml
+++ b/.github/workflows/generate-cp.yml
@@ -44,7 +44,7 @@ jobs:
         run: npx nx build backend-generator
 
       - name: Generate CP file
-        run: node dist/libs/backend/generator/scripts/cp-file-writer.js payload.json
+        run: node dist/libs/backend/generator/src/scripts/cp-file-writer.js payload.json
         env:
           CP_PASS: ${{ secrets.CP_PASS }}
 

--- a/apps/api/src/app/controllers/cp.controller.ts
+++ b/apps/api/src/app/controllers/cp.controller.ts
@@ -1,6 +1,7 @@
 import { User } from "@badman/backend-authorization";
 import { Player } from "@badman/backend-database";
 import { CpDataCollector } from "@badman/backend-generator";
+import { MailingService } from "@badman/backend-mailing";
 import { ConfigType } from "@badman/utils";
 import {
   Body,
@@ -42,7 +43,8 @@ export class CpController {
 
   constructor(
     private dataCollector: CpDataCollector,
-    private configService: ConfigService<ConfigType>
+    private configService: ConfigService<ConfigType>,
+    private mailingService: MailingService
   ) {}
 
   @Post("generate")
@@ -300,12 +302,9 @@ export class CpController {
       `CP file ready for user ${player.fullName} (${player.email}). Download: ${downloadUrl}`
     );
 
-    // TODO: Integrate with MailingService for proper templated email.
-    // For now, log the download URL. The MailingService uses Pug templates
-    // and we'd need to create a new template for this notification.
-    // This is acceptable for a once-a-year operation.
-    this.logger.log(
-      `[EMAIL PLACEHOLDER] To: ${player.email}, Subject: CP file ready, Body: Download at ${downloadUrl}`
+    await this.mailingService.sendCpExportReadyMail(
+      { fullName: player.fullName, email: player.email, slug: player.slug },
+      downloadUrl
     );
   }
 
@@ -316,9 +315,11 @@ export class CpController {
       return;
     }
 
-    this.logger.log(
-      `[EMAIL PLACEHOLDER] To: ${player.email}, Subject: CP generation failed, Body: Please try again or contact support.`
-    );
+    await this.mailingService.sendCpExportFailedMail({
+      fullName: player.fullName,
+      email: player.email,
+      slug: player.slug,
+    });
   }
 
   /**

--- a/libs/backend/mailing/src/compile/templates/cpExportFailed/html.pug
+++ b/libs/backend/mailing/src/compile/templates/cpExportFailed/html.pug
@@ -1,0 +1,18 @@
+extends ../../layouts/layout.pug
+
+block title
+  h1.text-center
+    | CP bestand mislukt
+
+block content
+  p.text-center
+    p
+      | Beste #{ user },
+      br
+      br
+      | Het genereren van je CP bestand is helaas mislukt. Probeer het opnieuw of neem contact op met de beheerder.
+    br
+    br
+    | Met sportieve groeten,
+    br
+    | Badman

--- a/libs/backend/mailing/src/compile/templates/cpExportReady/html.pug
+++ b/libs/backend/mailing/src/compile/templates/cpExportReady/html.pug
@@ -1,0 +1,21 @@
+extends ../../layouts/layout.pug
+
+block title
+  h1.text-center
+    | CP bestand klaar
+
+block content
+  p.text-center
+    p
+      | Beste #{ user },
+      br
+      br
+      | Je CP bestand is succesvol gegenereerd en klaar om te downloaden.
+    p
+      a(href=downloadUrl)
+        | Download CP bestand
+    br
+    br
+    | Met sportieve groeten,
+    br
+    | Badman

--- a/libs/backend/mailing/src/services/mailing/mailing.service.ts
+++ b/libs/backend/mailing/src/services/mailing/mailing.service.ts
@@ -596,6 +596,55 @@ export class MailingService {
     await this._sendMail(options);
   }
 
+  async sendCpExportReadyMail(
+    to: {
+      fullName: string;
+      email: string;
+      slug: string;
+    },
+    downloadUrl: string
+  ) {
+    const options = {
+      from: "info@badman.app",
+      to: to.email,
+      subject: "CP bestand klaar",
+      template: "cpExportReady",
+      context: {
+        user: to.fullName,
+        downloadUrl,
+        settingsSlug: to.slug,
+      },
+    } as MailOptions<{
+      user: string;
+      downloadUrl: string;
+      settingsSlug: string;
+    }>;
+
+    await this._sendMail(options);
+  }
+
+  async sendCpExportFailedMail(to: {
+    fullName: string;
+    email: string;
+    slug: string;
+  }) {
+    const options = {
+      from: "info@badman.app",
+      to: to.email,
+      subject: "CP bestand mislukt",
+      template: "cpExportFailed",
+      context: {
+        user: to.fullName,
+        settingsSlug: to.slug,
+      },
+    } as MailOptions<{
+      user: string;
+      settingsSlug: string;
+    }>;
+
+    await this._sendMail(options);
+  }
+
   private async _setupMailing() {
     if (this.initialized) return;
     if ((this.configService.get<boolean>("MAIL_ENABLED") ?? false) == false) {


### PR DESCRIPTION
## Summary
- Add Pug email templates for CP export success and failure notifications
- Wire `MailingService` into `CpController` to send real emails instead of logging placeholders
- Fix GitHub Actions workflow to use `.nvmrc` for Node.js version and opt into Node.js 24

## Test plan
- [ ] Trigger CP generation on staging and verify completion email arrives
- [ ] Verify failure email is sent when generation fails
- [ ] In dev mode with `MAIL_ENABLED=false`, check `mails/cpExportReady.html` is written
- [ ] Confirm `nx build api` and `nx build backend-mailing` succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)