### PR TITLE
Fixes "Invalid TournamentDraw response from Visual API" (BACKEND-G on Sentry)

### DIFF
--- a/libs/backend/visual/src/utils/__tests__/visual-result.spec.ts
+++ b/libs/backend/visual/src/utils/__tests__/visual-result.spec.ts
@@ -1,7 +1,9 @@
 import {
+  XmlItemSchema,
   XmlRankingCategorySchema,
   XmlRankingPublicationSchema,
   XmlRankingSchema,
+  XmlTournamentDrawSchema,
   XmlTournamentMatchSchema,
 } from "../visual-result";
 
@@ -131,6 +133,32 @@ describe("requiredCoercedString invariant", () => {
       MatchDate: "2026-04-15T19:00:00",
     });
     expect(result.success).toBe(false);
+  });
+
+  // Visual API emits empty `<Team/>` elements which fast-xml-parser deserializes
+  // to "" instead of an object. Schema must tolerate that without throwing.
+  it("XmlItemSchema: coerces empty-string Team to undefined", () => {
+    const result = XmlItemSchema.safeParse({ Code: "X", Team: "" });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.Team).toBeUndefined();
+  });
+
+  it("XmlTournamentDrawSchema: accepts mixed string/object Team values across Items", () => {
+    const result = XmlTournamentDrawSchema.safeParse({
+      Code: "DR1",
+      Name: "Draw 1",
+      Structure: {
+        Item: [
+          { Code: "1", Team: "" },
+          { Code: "2", Team: { Code: "T1", Name: "Foo" } },
+        ],
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.Structure?.Item[0].Team).toBeUndefined();
+      expect(result.data.Structure?.Item[1].Team).toEqual({ Code: "T1", Name: "Foo" });
+    }
   });
 
   it("XmlTournamentMatchSchema: accepts numeric MatchID", () => {

--- a/libs/backend/visual/src/utils/visual-result.ts
+++ b/libs/backend/visual/src/utils/visual-result.ts
@@ -377,7 +377,10 @@ export const XmlItemSchema = z
     Code: requiredCoercedString,
     Winner: z.coerce.string().optional(),
     ScoreStatus: z.coerce.string().optional(),
-    Team: TeamClassSchema.optional(),
+    Team: z.preprocess(
+      (v) => (typeof v === "string" ? undefined : v),
+      TeamClassSchema.optional()
+    ),
     MatchTime: z.string().optional(),
     Sets: XmlSetsSchema.optional(),
   })


### PR DESCRIPTION
Now allows empty strings instead of <Team /> structures and transforms these empty strings into "undefined" that is handled by the rest of the code.