### PR TITLE
feat(club): ClubPlayerMembership resolver upgrades (BAD-129)

### DIFF
--- a/.maqa/state.json
+++ b/.maqa/state.json
@@ -1,0 +1,17 @@
+{
+  "features": {
+    "004-addplayertoclub-return-membership": {
+      "state": "in_review_qa_approved",
+      "branch": "004-addplayertoclub-return-membership",
+      "linear_id": "BAD-129",
+      "linear_status": "Ready for review",
+      "feature_status": "done",
+      "qa_status": "approved",
+      "tasks_done": "32/34",
+      "implementation_commit": "f3829f369",
+      "next_step": "open PR; merge to develop after human review"
+    }
+  },
+  "board": "linear",
+  "ci_gate": "none"
+}

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/003-linear-bad-127"
+  "feature_directory": "specs/004-addplayertoclub-return-membership"
 }

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,3 @@
-{"feature_directory": "specs/002-team-resolver-improvements"}
+{
+  "feature_directory": "specs/003-linear-bad-127"
+}

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,33 +1,33 @@
 <!--
 Sync Impact Report
 ==================
-Version change: (uninitialized template) → 1.0.0
-Bump rationale: Initial ratification of project constitution. MAJOR baseline.
+Version change: 1.0.0 → 1.1.0
+Bump rationale: MINOR — material expansion of Principle III (Transactional
+Mutations) to add an idempotency clause for create mutations with natural
+uniqueness keys. The pattern is already established in the codebase
+(`TeamResult.alreadyExisted`, `EnrollmentResult.alreadyExisted`) and is being
+applied to a third resolver (`addPlayerToClub` per spec 004); codifying it
+prevents future drift. No principles removed or redefined.
 
-Modified principles: (none — first ratification)
-Added principles:
-  - I. Code-First GraphQL via Sequelize Models
-  - II. Translation Discipline (NON-NEGOTIABLE)
-  - III. Transactional Mutations
-  - IV. Resolver Test Discipline
-  - V. Legacy Frontend Boundary (NON-NEGOTIABLE)
+Modified principles:
+  - III. Transactional Mutations — added idempotency-on-re-submission clause
+Added principles: (none)
 
-Added sections:
-  - Technology Stack & Constraints
-  - Development Workflow
-
+Added sections: (none)
 Removed sections: (none)
 
 Templates requiring updates:
-  - ✅ .specify/templates/plan-template.md (no edits needed; Constitution Check
-       gate references current principles by name through this file)
+  - ✅ .specify/templates/plan-template.md (no edits — Constitution Check gate
+       still references principles by name)
   - ✅ .specify/templates/spec-template.md (principle-agnostic; no edits)
   - ✅ .specify/templates/tasks-template.md (principle-agnostic; no edits)
-  - ✅ AGENTS.md / CLAUDE.md (already encode the same rules; no edits required)
+  - ✅ AGENTS.md / CLAUDE.md — added explicit "Idempotent create mutations"
+       bullet under Resolver Pattern referencing this principle and the two
+       reference implementations
 
 Deferred / TODO:
-  - TODO(RATIFICATION_DATE): Original adoption date unknown. Set to today
-    (2026-04-29) as a placeholder; replace once historical record is confirmed.
+  - TODO(RATIFICATION_DATE): Original adoption date unknown. Placeholder
+    2026-04-29 retained.
 -->
 
 # Badman Constitution
@@ -71,8 +71,21 @@ Slug-or-UUID lookups MUST branch on `IsUUID(id)` (`findByPk` vs.
 returning `{ count: number; rows: T[] }`, and filter operators MUST flow through
 `ListArgs` / `queryFixer()` rather than ad-hoc Sequelize `Op` translation.
 
+**Idempotent create mutations**: when a create mutation has a natural uniqueness
+key (e.g. `(link, season)` for teams, `(teamId, subEventId)` for enrollments,
+`(clubId, playerId, season, type)` for club memberships), it MUST be idempotent
+on re-submission. Such mutations MUST return a result `@ObjectType` carrying the
+entity's identifiers plus `alreadyExisted: boolean` — `true` when the existing
+row matched and no write occurred, `false` when a fresh row was created.
+Re-submission MUST NOT throw a "duplicate" error and MUST NOT produce a
+duplicate row. Reference implementations: `TeamResult` (`createTeam`) and
+`EnrollmentResult` (`createEnrollment`).
+
 **Rationale**: Partial writes corrupt competitive-state data (rankings, draws,
-enrollments). Uniform patterns make resolver behavior predictable and reviewable.
+enrollments). Re-submission is common (network retries, browser back-button,
+wizard re-saves); silent idempotency prevents spurious user-facing errors and
+preserves the client's ability to obtain server-assigned IDs without an extra
+lookup. Uniform patterns make resolver behavior predictable and reviewable.
 
 ### IV. Resolver Test Discipline
 
@@ -174,4 +187,4 @@ it does, the author MUST cite the relevant principle. Violations MUST either
 be fixed before merge or justified in `Complexity Tracking` of the feature's
 implementation plan.
 
-**Version**: 1.0.0 | **Ratified**: TODO(RATIFICATION_DATE): original adoption date unknown — placeholder 2026-04-29 | **Last Amended**: 2026-04-29
+**Version**: 1.1.0 | **Ratified**: TODO(RATIFICATION_DATE): original adoption date unknown — placeholder 2026-04-29 | **Last Amended**: 2026-04-30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,7 @@ Resolvers live in `libs/backend/graphql/src/resolvers/<domain>/`. Each domain ha
 - Paged results use inline `@ObjectType()` with `{ count: number; rows: T[] }`
 - `ListArgs` / `queryFixer()` utilities translate GraphQL filter operators to Sequelize `Op` symbols
 - **Classified errors**: when a mutation needs to expose distinct, machine-readable failure modes to clients, throw `GraphQLError` from the `graphql` package with `extensions.code` set to a constant from the shared registry [`libs/backend/graphql/src/utils/error-codes.ts`](libs/backend/graphql/src/utils/error-codes.ts) (`ErrorCode.PERMISSION_DENIED`, `ErrorCode.INTERNAL_ERROR`, etc.). Do NOT inline string literals — clients pin behavior to these codes and the registry is the single source of truth. Adding a new code: append a key to `error-codes.ts` and document the per-code `extensions` payload in the resolver's contract document under `specs/`. Reference implementations: [`enrollment.resolver.ts`](libs/backend/graphql/src/resolvers/event/competition/enrollment.resolver.ts) and [`team.resolver.ts`](libs/backend/graphql/src/resolvers/team/team.resolver.ts) (`createEnrollment` / `createTeam`).
+- **Idempotent create mutations**: when a create mutation has a natural uniqueness key (e.g. `(link, season)` for teams, `(teamId, subEventId)` for enrollments, `(clubId, playerId, season, type)` for club memberships), it MUST be idempotent on re-submission. Return a result `@ObjectType` carrying the entity's identifiers plus `alreadyExisted: boolean` (`true` = existing row matched, no write; `false` = fresh row created). Do NOT throw a duplicate error. Reference implementations: `TeamResult` ([`team-result.object.ts`](libs/backend/graphql/src/resolvers/team/team-result.object.ts)) and `EnrollmentResult` ([`enrollment-result.object.ts`](libs/backend/graphql/src/resolvers/event/competition/enrollment-result.object.ts)). See Constitution Principle III.
 
 ### Auth Flow
 
@@ -188,6 +189,6 @@ Long-form internal docs live under [`docs/`](docs/). Skim the relevant ones befo
 
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-[specs/003-linear-bad-127/plan.md](specs/003-linear-bad-127/plan.md)
+[specs/004-addplayertoclub-return-membership/plan.md](specs/004-addplayertoclub-return-membership/plan.md)
 
 <!-- SPECKIT END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,6 @@ Long-form internal docs live under [`docs/`](docs/). Skim the relevant ones befo
 
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-[specs/002-team-resolver-improvements/plan.md](specs/002-team-resolver-improvements/plan.md)
+[specs/003-linear-bad-127/plan.md](specs/003-linear-bad-127/plan.md)
 
 <!-- SPECKIT END -->

--- a/libs/backend/graphql/src/resolvers/club/add-player-to-club-result.object.ts
+++ b/libs/backend/graphql/src/resolvers/club/add-player-to-club-result.object.ts
@@ -1,0 +1,31 @@
+import { Field, ID, ObjectType } from "@nestjs/graphql";
+
+@ObjectType({
+  description:
+    "Result of addPlayerToClub. Idempotent on (clubId, playerId, start): when alreadyExisted is true, the player was already a member for that (club, player, start) combination and no write occurred. False when a fresh membership was created.",
+})
+export class AddPlayerToClubResult {
+  @Field(() => ID)
+  declare id: string;
+
+  @Field(() => ID)
+  declare clubId: string;
+
+  @Field(() => ID)
+  declare playerId: string;
+
+  @Field(() => Date)
+  declare start: Date;
+
+  @Field(() => Date, { nullable: true })
+  declare end: Date | null;
+
+  @Field(() => String)
+  declare membershipType: string;
+
+  @Field(() => Boolean, {
+    description:
+      "True when an existing membership matched (clubId, playerId, start) and no write occurred. False when a fresh membership was created.",
+  })
+  declare alreadyExisted: boolean;
+}

--- a/libs/backend/graphql/src/resolvers/club/club.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/club/club.resolver.spec.ts
@@ -1,0 +1,305 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { GraphQLError } from "graphql";
+import { Sequelize } from "sequelize-typescript";
+import {
+  Club,
+  ClubPlayerMembership,
+  ClubPlayerMembershipNewInput,
+  ClubPlayerMembershipUpdateInput,
+  Player,
+} from "@badman/backend-database";
+import { ClubsResolver } from "./club.resolver";
+
+describe("ClubsResolver", () => {
+  let resolver: ClubsResolver;
+  let mockTransaction: { commit: jest.Mock; rollback: jest.Mock };
+
+  const userWithPermission = (allowed: boolean) =>
+    ({
+      id: "user-uuid",
+      hasAnyPermission: jest.fn().mockResolvedValue(allowed),
+    }) as unknown as Player;
+
+  const fakeMembership = (overrides: Partial<ClubPlayerMembership> = {}) =>
+    ({
+      id: "membership-uuid",
+      clubId: "club-uuid",
+      playerId: "player-uuid",
+      start: new Date("2025-09-01"),
+      end: null,
+      membershipType: "NORMAL",
+      confirmed: false,
+      update: jest.fn().mockResolvedValue(undefined),
+      destroy: jest.fn().mockResolvedValue(undefined),
+      ...overrides,
+    }) as unknown as ClubPlayerMembership;
+
+  const fakeClub = (id = "club-uuid") => ({ id }) as unknown as Club;
+
+  const fakePlayer = (id = "player-uuid") => ({ id }) as unknown as Player;
+
+  const baseAddInput = (
+    overrides: Partial<ClubPlayerMembershipNewInput> = {}
+  ): ClubPlayerMembershipNewInput =>
+    ({
+      clubId: "club-uuid",
+      playerId: "player-uuid",
+      start: new Date("2025-09-01"),
+      end: undefined,
+      membershipType: "NORMAL" as never,
+      ...overrides,
+    }) as ClubPlayerMembershipNewInput;
+
+  const baseUpdateInput = (
+    overrides: Partial<ClubPlayerMembershipUpdateInput> = {}
+  ): ClubPlayerMembershipUpdateInput =>
+    ({
+      id: "membership-uuid",
+      membershipType: "LOAN" as never,
+      ...overrides,
+    }) as ClubPlayerMembershipUpdateInput;
+
+  beforeEach(async () => {
+    mockTransaction = {
+      commit: jest.fn().mockResolvedValue(undefined),
+      rollback: jest.fn().mockResolvedValue(undefined),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ClubsResolver,
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+        },
+      ],
+    }).compile();
+    resolver = module.get<ClubsResolver>(ClubsResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  // ---------------------------------------------------------------------------
+  // addPlayerToClub — 5 cases
+  // ---------------------------------------------------------------------------
+
+  describe("addPlayerToClub", () => {
+    it("rejects unauthorized with PERMISSION_DENIED", async () => {
+      const user = userWithPermission(false);
+
+      try {
+        await resolver.addPlayerToClub(user, baseAddInput());
+        fail("expected throw");
+      } catch (err) {
+        const e = err as GraphQLError;
+        expect(e).toBeInstanceOf(GraphQLError);
+        expect(e.extensions["code"]).toBe("PERMISSION_DENIED");
+      }
+
+      expect(mockTransaction.commit).not.toHaveBeenCalled();
+    });
+
+    it("throws CLUB_NOT_FOUND when club is missing", async () => {
+      const user = userWithPermission(true);
+      jest.spyOn(Club, "findByPk").mockResolvedValue(null);
+
+      try {
+        await resolver.addPlayerToClub(user, baseAddInput({ clubId: "missing-club" }));
+        fail("expected throw");
+      } catch (err) {
+        const e = err as GraphQLError;
+        expect(e).toBeInstanceOf(GraphQLError);
+        expect(e.extensions["code"]).toBe("CLUB_NOT_FOUND");
+        expect(e.extensions["clubId"]).toBe("missing-club");
+      }
+
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+      expect(mockTransaction.commit).not.toHaveBeenCalled();
+    });
+
+    it("throws PLAYER_NOT_FOUND when player is missing", async () => {
+      const user = userWithPermission(true);
+      jest.spyOn(Club, "findByPk").mockResolvedValue(fakeClub());
+      jest.spyOn(Player, "findByPk").mockResolvedValue(null);
+
+      try {
+        await resolver.addPlayerToClub(user, baseAddInput({ playerId: "missing-player" }));
+        fail("expected throw");
+      } catch (err) {
+        const e = err as GraphQLError;
+        expect(e).toBeInstanceOf(GraphQLError);
+        expect(e.extensions["code"]).toBe("PLAYER_NOT_FOUND");
+        expect(e.extensions["playerId"]).toBe("missing-player");
+      }
+
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+      expect(mockTransaction.commit).not.toHaveBeenCalled();
+    });
+
+    it("creates membership and returns alreadyExisted=false on first add", async () => {
+      const user = userWithPermission(true);
+      const membership = fakeMembership();
+      jest.spyOn(Club, "findByPk").mockResolvedValue(fakeClub());
+      jest.spyOn(Player, "findByPk").mockResolvedValue(fakePlayer());
+      jest
+        .spyOn(ClubPlayerMembership, "findOrCreate")
+        .mockResolvedValue([membership, true] as never);
+
+      const result = await resolver.addPlayerToClub(user, baseAddInput());
+
+      expect(result.alreadyExisted).toBe(false);
+      expect(result.id).toBe("membership-uuid");
+      expect(result.clubId).toBe("club-uuid");
+      expect(result.playerId).toBe("player-uuid");
+      expect(result.membershipType).toBe("NORMAL");
+      expect(mockTransaction.commit).toHaveBeenCalledTimes(1);
+      expect(mockTransaction.rollback).not.toHaveBeenCalled();
+    });
+
+    it("returns alreadyExisted=true on idempotent re-add", async () => {
+      const user = userWithPermission(true);
+      const existingMembership = fakeMembership({ id: "existing-membership-uuid" });
+      jest.spyOn(Club, "findByPk").mockResolvedValue(fakeClub());
+      jest.spyOn(Player, "findByPk").mockResolvedValue(fakePlayer());
+      jest
+        .spyOn(ClubPlayerMembership, "findOrCreate")
+        .mockResolvedValue([existingMembership, false] as never);
+
+      const result = await resolver.addPlayerToClub(user, baseAddInput());
+
+      expect(result.alreadyExisted).toBe(true);
+      expect(result.id).toBe("existing-membership-uuid");
+      expect(mockTransaction.commit).toHaveBeenCalledTimes(1);
+      expect(mockTransaction.rollback).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateClubPlayerMembership — 4 cases
+  // ---------------------------------------------------------------------------
+
+  describe("updateClubPlayerMembership", () => {
+    it("throws MEMBERSHIP_NOT_FOUND when membership is missing", async () => {
+      const user = userWithPermission(true);
+      jest.spyOn(ClubPlayerMembership, "findByPk").mockResolvedValue(null);
+
+      try {
+        await resolver.updateClubPlayerMembership(user, baseUpdateInput({ id: "missing-id" }));
+        fail("expected throw");
+      } catch (err) {
+        const e = err as GraphQLError;
+        expect(e).toBeInstanceOf(GraphQLError);
+        expect(e.extensions["code"]).toBe("MEMBERSHIP_NOT_FOUND");
+        expect(e.extensions["membershipId"]).toBe("missing-id");
+      }
+    });
+
+    it("rejects unauthorized with PERMISSION_DENIED", async () => {
+      const user = userWithPermission(false);
+      jest.spyOn(ClubPlayerMembership, "findByPk").mockResolvedValue(fakeMembership());
+
+      try {
+        await resolver.updateClubPlayerMembership(user, baseUpdateInput());
+        fail("expected throw");
+      } catch (err) {
+        const e = err as GraphQLError;
+        expect(e).toBeInstanceOf(GraphQLError);
+        expect(e.extensions["code"]).toBe("PERMISSION_DENIED");
+      }
+
+      expect(mockTransaction.commit).not.toHaveBeenCalled();
+    });
+
+    it("successful update commits transaction and returns true", async () => {
+      const user = userWithPermission(true);
+      const membership = fakeMembership();
+      jest.spyOn(ClubPlayerMembership, "findByPk").mockResolvedValue(membership);
+
+      const result = await resolver.updateClubPlayerMembership(user, baseUpdateInput());
+
+      expect(membership.update).toHaveBeenCalled();
+      expect(mockTransaction.commit).toHaveBeenCalledTimes(1);
+      expect(mockTransaction.rollback).not.toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it("rolls back when update throws", async () => {
+      const user = userWithPermission(true);
+      const membership = fakeMembership({
+        update: jest.fn().mockRejectedValue(new Error("boom")) as never,
+      } as Partial<ClubPlayerMembership>);
+      jest.spyOn(ClubPlayerMembership, "findByPk").mockResolvedValue(membership);
+
+      await expect(
+        resolver.updateClubPlayerMembership(user, baseUpdateInput())
+      ).rejects.toThrow("boom");
+
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+      expect(mockTransaction.commit).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // removePlayerFromClub — 4 cases
+  // ---------------------------------------------------------------------------
+
+  describe("removePlayerFromClub", () => {
+    it("throws MEMBERSHIP_NOT_FOUND when membership is missing", async () => {
+      const user = userWithPermission(true);
+      jest.spyOn(ClubPlayerMembership, "findByPk").mockResolvedValue(null);
+
+      try {
+        await resolver.removePlayerFromClub(user, "missing-id");
+        fail("expected throw");
+      } catch (err) {
+        const e = err as GraphQLError;
+        expect(e).toBeInstanceOf(GraphQLError);
+        expect(e.extensions["code"]).toBe("MEMBERSHIP_NOT_FOUND");
+        expect(e.extensions["membershipId"]).toBe("missing-id");
+      }
+    });
+
+    it("rejects unauthorized with PERMISSION_DENIED", async () => {
+      const user = userWithPermission(false);
+      jest.spyOn(ClubPlayerMembership, "findByPk").mockResolvedValue(fakeMembership());
+
+      try {
+        await resolver.removePlayerFromClub(user, "membership-uuid");
+        fail("expected throw");
+      } catch (err) {
+        const e = err as GraphQLError;
+        expect(e).toBeInstanceOf(GraphQLError);
+        expect(e.extensions["code"]).toBe("PERMISSION_DENIED");
+      }
+
+      expect(mockTransaction.commit).not.toHaveBeenCalled();
+    });
+
+    it("successful destroy commits transaction and returns true", async () => {
+      const user = userWithPermission(true);
+      const membership = fakeMembership();
+      jest.spyOn(ClubPlayerMembership, "findByPk").mockResolvedValue(membership);
+
+      const result = await resolver.removePlayerFromClub(user, "membership-uuid");
+
+      expect(membership.destroy).toHaveBeenCalled();
+      expect(mockTransaction.commit).toHaveBeenCalledTimes(1);
+      expect(mockTransaction.rollback).not.toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it("rolls back when destroy throws", async () => {
+      const user = userWithPermission(true);
+      const membership = fakeMembership({
+        destroy: jest.fn().mockRejectedValue(new Error("destroy-error")) as never,
+      } as Partial<ClubPlayerMembership>);
+      jest.spyOn(ClubPlayerMembership, "findByPk").mockResolvedValue(membership);
+
+      await expect(resolver.removePlayerFromClub(user, "membership-uuid")).rejects.toThrow(
+        "destroy-error"
+      );
+
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+      expect(mockTransaction.commit).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/club/club.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/club/club.resolver.ts
@@ -28,9 +28,12 @@ import {
   ResolveField,
   Resolver,
 } from "@nestjs/graphql";
+import { GraphQLError } from "graphql";
 import { Op } from "sequelize";
 import { Sequelize } from "sequelize-typescript";
 import { ListArgs } from "../../utils";
+import { ErrorCode } from "../../utils/error-codes";
+import { AddPlayerToClubResult } from "./add-player-to-club-result.object";
 
 @ObjectType()
 export class PagedClub {
@@ -244,15 +247,17 @@ export class ClubsResolver {
     }
   }
 
-  @Mutation(() => Boolean)
+  @Mutation(() => AddPlayerToClubResult)
   async addPlayerToClub(
     @User() user: Player,
     @Args("data") addPlayerToClubData: ClubPlayerMembershipNewInput
-  ) {
+  ): Promise<AddPlayerToClubResult> {
     if (
       !(await user.hasAnyPermission([`${addPlayerToClubData.clubId}_edit:club`, "edit-any:club"]))
     ) {
-      throw new UnauthorizedException(`You do not have permission to edit this club`);
+      throw new GraphQLError("Permission denied", {
+        extensions: { code: ErrorCode.PERMISSION_DENIED },
+      });
     }
 
     // Do transaction
@@ -261,34 +266,57 @@ export class ClubsResolver {
       const club = await Club.findByPk(addPlayerToClubData.clubId, {
         transaction,
       });
+
+      if (!club) {
+        throw new GraphQLError("Club not found", {
+          extensions: { code: ErrorCode.CLUB_NOT_FOUND, clubId: addPlayerToClubData.clubId },
+        });
+      }
+
       const player = await Player.findByPk(addPlayerToClubData.playerId, {
         transaction,
       });
 
-      if (!club) {
-        throw new NotFoundException(`${Club.name}: ${addPlayerToClubData.clubId}`);
-      }
       if (!player) {
-        throw new NotFoundException(`${Player.name}: ${addPlayerToClubData.playerId}`);
+        throw new GraphQLError("Player not found", {
+          extensions: {
+            code: ErrorCode.PLAYER_NOT_FOUND,
+            playerId: addPlayerToClubData.playerId,
+          },
+        });
       }
 
       const confirmed = await user.hasAnyPermission(["change:transfer"]);
 
-      // Add player to club
-      await club.addPlayer(player, {
-        transaction,
-        through: {
-          start: addPlayerToClubData.start,
+      const clubId = addPlayerToClubData.clubId as string;
+      const playerId = addPlayerToClubData.playerId as string;
+      const start = addPlayerToClubData.start as Date;
+
+      // Idempotent create: findOrCreate on natural key (clubId, playerId, start)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const [membership, created] = await (ClubPlayerMembership as any).findOrCreate({
+        where: { clubId, playerId, start },
+        defaults: {
+          start,
           end: addPlayerToClubData.end,
           membershipType: addPlayerToClubData.membershipType,
           confirmed,
         },
+        transaction,
       });
 
       // Commit transaction
       await transaction.commit();
 
-      return true;
+      return {
+        id: membership.id as string,
+        clubId,
+        playerId,
+        start: membership.start as Date,
+        end: (membership.end as Date | null | undefined) ?? null,
+        membershipType: membership.membershipType as string,
+        alreadyExisted: !created,
+      };
     } catch (error) {
       this.logger.error(error);
       await transaction.rollback();
@@ -304,13 +332,18 @@ export class ClubsResolver {
     const membership = await ClubPlayerMembership.findByPk(updateClubPlayerMembershipData.id);
 
     if (!membership) {
-      throw new NotFoundException(
-        `${ClubPlayerMembership.name}: ${updateClubPlayerMembershipData.id}`
-      );
+      throw new GraphQLError("Membership not found", {
+        extensions: {
+          code: ErrorCode.MEMBERSHIP_NOT_FOUND,
+          membershipId: updateClubPlayerMembershipData.id,
+        },
+      });
     }
 
     if (!(await user.hasAnyPermission([`${membership.clubId}_edit:club`, "edit-any:club"]))) {
-      throw new UnauthorizedException(`You do not have permission to edit this club`);
+      throw new GraphQLError("Permission denied", {
+        extensions: { code: ErrorCode.PERMISSION_DENIED },
+      });
     }
 
     // Do transaction
@@ -336,28 +369,20 @@ export class ClubsResolver {
     const membership = await ClubPlayerMembership.findByPk(id);
 
     if (!membership) {
-      throw new NotFoundException(`${ClubPlayerMembership.name}: ${id}`);
+      throw new GraphQLError("Membership not found", {
+        extensions: { code: ErrorCode.MEMBERSHIP_NOT_FOUND, membershipId: id },
+      });
     }
 
     if (!(await user.hasAnyPermission([`${membership.clubId}_edit:club`, "edit-any:club"]))) {
-      throw new UnauthorizedException(`You do not have permission to edit this club`);
+      throw new GraphQLError("Permission denied", {
+        extensions: { code: ErrorCode.PERMISSION_DENIED },
+      });
     }
 
     // Do transaction
     const transaction = await this._sequelize.transaction();
     try {
-      const club = await Club.findByPk(membership.clubId, { transaction });
-      const player = await Player.findByPk(membership.playerId, {
-        transaction,
-      });
-
-      if (!club) {
-        throw new NotFoundException(`${Club.name}: ${membership.clubId}`);
-      }
-      if (!player) {
-        throw new NotFoundException(`${Player.name}: ${membership.playerId}`);
-      }
-
       // remove membership
       await membership.destroy({ transaction });
 

--- a/libs/backend/graphql/src/utils/error-codes.ts
+++ b/libs/backend/graphql/src/utils/error-codes.ts
@@ -24,6 +24,9 @@ export const ErrorCode = {
   CLUB_NOT_FOUND: "CLUB_NOT_FOUND",
   PLAYER_NOT_FOUND: "PLAYER_NOT_FOUND",
   RANKING_NOT_FOUND: "RANKING_NOT_FOUND",
+
+  // Club membership (libs/backend/graphql/src/resolvers/club/club.resolver.ts)
+  MEMBERSHIP_NOT_FOUND: "MEMBERSHIP_NOT_FOUND",
 } as const;
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/libs/backend/translate/assets/i18n/en/all.json
+++ b/libs/backend/translate/assets/i18n/en/all.json
@@ -1518,7 +1518,12 @@
         "ariaDeselectLocation": "Deselect location",
         "emptyPlaceholder": "—",
         "noGameDays": "No game days",
-        "courts": "{count, plural, one {# court} other {# courts}}"
+        "courts": "{count, plural, one {# court} other {# courts}}",
+        "copyFromLastSeason": "Copy availability from last season",
+        "copyAvailabilitySuccess": "Availability copied successfully",
+        "copyAvailabilityError": "Failed to copy availability",
+        "manageAvailability": "Manage availability",
+        "hideAvailability": "Hide availability"
       },
       "team-enrollment": {
         "addBasePlayerDialog": {

--- a/libs/backend/translate/assets/i18n/fr_BE/all.json
+++ b/libs/backend/translate/assets/i18n/fr_BE/all.json
@@ -1826,7 +1826,12 @@
         "ariaDeselectLocation": "Désélectionner le lieu",
         "emptyPlaceholder": "—",
         "noGameDays": "Aucun jour de jeu",
-        "courts": "{count, plural, one {# terrain} other {# terrains}}"
+        "courts": "{count, plural, one {# terrain} other {# terrains}}",
+        "copyFromLastSeason": "Copier la disponibilité de la saison dernière",
+        "copyAvailabilitySuccess": "Disponibilité copiée avec succès",
+        "copyAvailabilityError": "Impossible de copier la disponibilité",
+        "manageAvailability": "Gérer la disponibilité",
+        "hideAvailability": "Masquer la disponibilité"
       },
       "team-enrollment": {
         "addBasePlayerDialog": {

--- a/libs/backend/translate/assets/i18n/nl_BE/all.json
+++ b/libs/backend/translate/assets/i18n/nl_BE/all.json
@@ -1236,7 +1236,12 @@
         "ariaDeselectLocation": "Locatie deselecteren",
         "emptyPlaceholder": "—",
         "noGameDays": "Geen speeldagen",
-        "courts": "{count, plural, one {# baan} other {# banen}}"
+        "courts": "{count, plural, one {# baan} other {# banen}}",
+        "copyFromLastSeason": "Beschikbaarheid van vorig seizoen kopiëren",
+        "copyAvailabilitySuccess": "Beschikbaarheid succesvol gekopieerd",
+        "copyAvailabilityError": "Beschikbaarheid kon niet worden gekopieerd",
+        "manageAvailability": "Beschikbaarheid beheren",
+        "hideAvailability": "Beschikbaarheid verbergen"
       },
       "team-enrollment": {
         "addBasePlayerDialog": {

--- a/libs/utils/src/lib/i18n.generated.ts
+++ b/libs/utils/src/lib/i18n.generated.ts
@@ -1537,6 +1537,11 @@ export type I18nTranslations = {
                     "emptyPlaceholder": string;
                     "noGameDays": string;
                     "courts": string;
+                    "copyFromLastSeason": string;
+                    "copyAvailabilitySuccess": string;
+                    "copyAvailabilityError": string;
+                    "manageAvailability": string;
+                    "hideAvailability": string;
                 };
                 "team-enrollment": {
                     "addBasePlayerDialog": {

--- a/specs/003-linear-bad-127/checklists/requirements.md
+++ b/specs/003-linear-bad-127/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Team Name Stays Current After Edit
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec populated from Linear BAD-127 content. Ready for `/speckit-plan`.

--- a/specs/003-linear-bad-127/data-model.md
+++ b/specs/003-linear-bad-127/data-model.md
@@ -1,0 +1,61 @@
+# Data Model: Team Name/Abbreviation On-Update Regeneration
+
+**Branch**: `003-linear-bad-127` | **Date**: 2026-04-30
+
+## No schema changes
+
+This fix is purely a lifecycle-hook addition. No new tables, columns, or migrations are required.
+
+## Affected entities
+
+### Team (existing — `libs/backend/database/src/models/team.model.ts`)
+
+Relevant fields:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `teamNumber` | `number` | Part of unique constraint `(name, clubId, teamNumber)`. Change triggers name/abbreviation regeneration. |
+| `type` | `SubEventTypeEnum` | Determines gender letter via `getLetterForRegion(type, "vl")`. Change triggers regeneration. |
+| `name` | `string?` | Derived. Computed from club display setting + teamNumber + regional letter. |
+| `abbreviation` | `string?` | Derived. Always `${club.abbreviation} ${teamNumber}${regionalLetter}`. |
+| `clubId` | `uuid?` | Used for club lookup during regeneration. Change excluded from this fix. |
+
+### Hook lifecycle (after fix)
+
+```
+BeforeCreate         → generateName + generateAbbreviation  (unchanged)
+BeforeBulkCreate     → generateName + generateAbbreviation per instance  (double-call bug fixed)
+BeforeUpdate (NEW)   → if teamNumber or type changed: generateName + generateAbbreviation
+BeforeBulkUpdate (NEW) → per-instance, same condition check
+```
+
+### Unique constraint implication
+
+The compound unique index on `(name, clubId, teamNumber)` means cascade renumbering (shifting sibling teams) requires a two-phase approach:
+
+**Phase 1** — set temp name (`_temp` suffix), `{ hooks: false }` to skip regeneration:
+
+```
+team.teamNumber = newNumber
+team.name = "<prefix> <newNumber><letter>_temp"
+team.save({ hooks: false })
+```
+
+**Phase 2** — final save without `hooks: false` triggers `@BeforeUpdate`:
+
+```
+team.name = undefined / stale   ← hook regenerates correct value
+team.save({ transaction })      ← hook fires: generateName + generateAbbreviation
+```
+
+### Error codes (after fix)
+
+New entry in `libs/backend/graphql/src/utils/error-codes.ts`:
+
+| Code | Trigger | Extensions payload |
+|------|---------|-------------------|
+| `TEAM_NUMBER_CONFLICT` | `updateTeam` called with `teamNumber` already held by another team in same (clubId, season, type) | `{ conflictingTeamId: string }` |
+
+## No migrations needed
+
+Derived fields (`name`, `abbreviation`) already exist and are nullable. No column additions, renames, or index changes required.

--- a/specs/003-linear-bad-127/plan.md
+++ b/specs/003-linear-bad-127/plan.md
@@ -1,0 +1,241 @@
+# Implementation Plan: Team Name/Abbreviation On-Update Regeneration
+
+**Branch**: `003-linear-bad-127` | **Date**: 2026-04-30 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+The `Team` Sequelize model regenerates `name` and `abbreviation` only on create. Adding `@BeforeUpdate` and `@BeforeBulkUpdate` hooks (guarded by `instance.changed()`) makes updates self-healing. The `updateTeam` resolver's manual — and partially incorrect — name construction is removed; the cascade renumber flow is updated to use `{ hooks: false }` for intermediate saves only.
+
+## Technical Context
+
+**Language/Version**: TypeScript (Node.js 20, Nx monorepo)
+**Primary Dependencies**: NestJS, Sequelize + sequelize-typescript, Apollo GraphQL
+**Storage**: PostgreSQL (multi-schema; Team is in `public` schema)
+**Testing**: Jest via Nx (`nx test backend-database`, `nx test backend-graphql`)
+**Target Platform**: Node.js API server (port 5010)
+**Project Type**: NestJS Nx monorepo — library patches only (`@badman/backend-database`, `@badman/backend-graphql`)
+**Performance Goals**: Hook overhead is a single DB read (club lookup) already done in current create hooks; no regression.
+**Constraints**: Unique constraint on `(name, clubId, teamNumber)` requires temp-name cascade during renumber. No migrations needed.
+**Scale/Scope**: Single model file + one resolver mutation + tests.
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Code-First GraphQL via Sequelize Models | PASS | Team model already exists; no new entities. Hook additions are additive. |
+| II. Translation Discipline | PASS | No i18n changes. |
+| III. Transactional Mutations | PASS | `updateTeam` already uses a transaction with commit/rollback. Preserved. |
+| IV. Resolver Test Discipline | REQUIRES WORK | `updateTeam` has zero tests. Fix must add full coverage per the reference pattern. |
+| V. Legacy Frontend Boundary | PASS | No frontend changes. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-linear-bad-127/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 findings
+├── data-model.md        ← Phase 1 entities + hook lifecycle
+└── tasks.md             ← Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (affected files)
+
+```text
+libs/backend/database/src/models/
+└── team.model.ts                              ← add @BeforeUpdate + @BeforeBulkUpdate; fix @BeforeBulkCreate double-call
+
+libs/backend/graphql/src/resolvers/team/
+├── team.resolver.ts                           ← remove manual name construction; update cascade to use hooks:false
+└── team.resolver.spec.ts                      ← add updateTeam test cases
+
+libs/backend/database/src/models/
+└── team.model.spec.ts                         ← new: unit tests for @BeforeUpdate hook
+
+libs/backend/graphql/src/utils/
+└── error-codes.ts                             ← add TEAM_NUMBER_CONFLICT
+```
+
+## Phase 0: Research (complete)
+
+See [research.md](research.md). All unknowns resolved. Key decisions:
+
+1. Hook added to model; cascade keeps temp-name approach with `{ hooks: false }` on intermediate saves.
+2. Resolver manual name construction removed — hook handles it correctly.
+3. `_setNameAndAbbreviation` retained, narrowed to temp-mode only.
+4. `TEAM_NUMBER_CONFLICT` error code added for FR-007.
+5. `@BeforeBulkCreate` double-call bug fixed in same PR.
+
+## Phase 1: Design & Contracts
+
+See [data-model.md](data-model.md). No schema changes. No migrations.
+
+### updateTeam mutation contract (existing — no signature change)
+
+```graphql
+type Mutation {
+  updateTeam(data: TeamUpdateInput!): Team!
+}
+```
+
+**New error code** thrown when teamNumber conflicts:
+
+```json
+{
+  "errors": [{
+    "extensions": {
+      "code": "TEAM_NUMBER_CONFLICT",
+      "conflictingTeamId": "<uuid>"
+    }
+  }]
+}
+```
+
+### Implementation steps (ordered)
+
+#### Step 1 — Add error code
+
+**File**: `libs/backend/graphql/src/utils/error-codes.ts`
+
+Add `TEAM_NUMBER_CONFLICT = 'TEAM_NUMBER_CONFLICT'` to the `ErrorCode` enum.
+
+---
+
+#### Step 2 — Add `@BeforeUpdate` and `@BeforeBulkUpdate` hooks to Team model
+
+**File**: `libs/backend/database/src/models/team.model.ts`
+
+Add imports: `BeforeUpdate`, `BeforeBulkUpdate`, `InstanceUpdateOptions`, `UpdateOptions` from `sequelize-typescript` / `sequelize`.
+
+```typescript
+@BeforeUpdate
+static async regenerateOnUpdate(instance: Team, options: InstanceUpdateOptions) {
+  if (instance.changed('teamNumber') || instance.changed('type')) {
+    await this.generateName(instance, options as CreateOptions);
+    await this.generateAbbreviation(instance, options as CreateOptions);
+  }
+}
+
+@BeforeBulkUpdate
+static async regenerateOnBulkUpdate(options: UpdateOptions & { instance?: Team }) {
+  // Bulk updates via instance hooks require individualHooks: true on the call site.
+  // This hook fires per-instance when individualHooks is true.
+  if (options.instance) {
+    await this.regenerateOnUpdate(options.instance, options as InstanceUpdateOptions);
+  }
+}
+```
+
+Fix the `@BeforeBulkCreate` double-call:
+
+```typescript
+@BeforeBulkCreate
+static async setAbbriviations(instances: Team[], options: CreateOptions) {
+  for (const instance of instances ?? []) {
+    await this.setAbbriviation(instance, options); // calls generateName + generateAbbreviation
+    // removed: await this.generateAbbreviation(instance, options); ← double-call
+  }
+}
+```
+
+---
+
+#### Step 3 — Update `updateTeam` resolver
+
+**File**: `libs/backend/graphql/src/resolvers/team/team.resolver.ts`
+
+**3a. Add duplicate-number guard** (implements FR-007) — after fetching `dbTeam`, before cascade:
+
+```typescript
+if (updateTeamData.teamNumber && updateTeamData.teamNumber !== dbTeam.teamNumber) {
+  const conflict = await Team.findOne({
+    where: {
+      clubId: dbTeam.clubId,
+      season: dbTeam.season,
+      type: dbTeam.type,
+      teamNumber: updateTeamData.teamNumber,
+    },
+    transaction,
+  });
+  if (conflict) {
+    throw new GraphQLError('Team number already in use', {
+      extensions: {
+        code: ErrorCode.TEAM_NUMBER_CONFLICT,
+        conflictingTeamId: conflict.id,
+      },
+    });
+  }
+}
+```
+
+**3b. Remove manual name/abbreviation construction** (lines 444–451):
+
+```typescript
+// DELETE these lines:
+updateTeamData.name = `${dbTeam.club?.name} ${updateTeamData.teamNumber}${getLetterForRegion(dbTeam.type, "vl")}`;
+updateTeamData.abbreviation = `${dbTeam.club?.abbreviation} ${updateTeamData.teamNumber}${getLetterForRegion(dbTeam.type, "vl")}`;
+```
+
+The `@BeforeUpdate` hook on `dbTeam.update(...)` handles this correctly.
+
+**3c. Update cascade saves to use `{ hooks: false }` for intermediate temp saves**:
+
+```typescript
+// Phase 1 — temp save (bypass hook so temp name is not overwritten):
+await dbLteam.save({ transaction, hooks: false });
+
+// Phase 2 — final save (hook fires, regenerates name/abbreviation from model methods):
+dbCteam.name = undefined; // clear stale/temp value; hook sets it
+await dbCteam.save({ transaction }); // @BeforeUpdate fires if teamNumber changed
+```
+
+**3d. Remove `_setNameAndAbbreviation` method** — after the above changes it is only called for temp-mode saves. Inline the temp-name construction directly at the two call sites (simpler than keeping the helper):
+
+```typescript
+// Inline replacement for _setNameAndAbbreviation(dbLteam, true):
+dbLteam.name = `${dbLteam.club?.name ?? ''} ${dbLteam.teamNumber}${getLetterForRegion(dbLteam.type, "vl")}_temp`;
+```
+
+Note: temp names only need to be unique; using `club.name` (ignoring enum) is fine here since they are temporary and immediately replaced by the hook on the next save.
+
+---
+
+#### Step 4 — Write model unit tests
+
+**File**: `libs/backend/database/src/models/team.model.spec.ts` (new)
+
+Test the `@BeforeUpdate` hook in isolation:
+
+1. `teamNumber` changed → `generateName` and `generateAbbreviation` called
+2. `type` changed → both called
+3. Neither changed → neither called (no-op)
+4. `@BeforeBulkCreate` — no double abbreviation call (spy on `generateAbbreviation`, expect exactly one call per instance)
+
+Pattern: spy on `Team.generateName` and `Team.generateAbbreviation` static methods. Create a mock instance with `changed()` returning true/false as needed.
+
+---
+
+#### Step 5 — Write resolver tests
+
+**File**: `libs/backend/graphql/src/resolvers/team/team.resolver.spec.ts`
+
+Add tests for `updateTeam`:
+
+1. Unauthorized → `UnauthorizedException`
+2. Team not found → `NotFoundException`
+3. Duplicate team number → `GraphQLError` with `TEAM_NUMBER_CONFLICT`
+4. Number changes → succeeds, commits transaction, returned team has correct name
+5. Type changes → succeeds, name reflects new type notation
+6. Unrelated field change → succeeds, name unchanged
+7. Exception mid-update → rolls back transaction
+
+Follow the reference pattern from `enrollmentSetting.resolver.spec.ts`:
+- `Test.createTestingModule` with mocked `Sequelize`
+- `jest.spyOn(Team, 'findByPk')`, `jest.spyOn(Team, 'findOne')`
+- Fake `Player` with `hasAnyPermission` jest.fn()
+- `afterEach(jest.restoreAllMocks)`
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.

--- a/specs/003-linear-bad-127/research.md
+++ b/specs/003-linear-bad-127/research.md
@@ -1,0 +1,79 @@
+# Research: Team Name/Abbreviation On-Update Regeneration
+
+**Branch**: `003-linear-bad-127` | **Date**: 2026-04-30
+
+## Finding 1: Model location and hook structure
+
+**Decision**: Fix lives in `libs/backend/database/src/models/team.model.ts`.
+
+Current hooks:
+- `@BeforeCreate` + `@BeforeBulkCreate` exist and call `generateName` / `generateAbbreviation`
+- No `@BeforeUpdate` or `@BeforeBulkUpdate` hooks exist
+- `generateName` and `generateAbbreviation` are already pure static methods that only mutate the passed `instance`
+
+**Rationale**: Both methods are side-effect-free and accept the same `instance` + optional `options` / `club` args. Adding `@BeforeUpdate`/`@BeforeBulkUpdate` is additive and has zero impact on create paths.
+
+## Finding 2: Unique-constraint cascade in updateTeam resolver
+
+**Decision**: Keep the two-phase temp-name cascade in the resolver; use `{ hooks: false }` on intermediate saves.
+
+The `name` field participates in a compound unique constraint `(name, clubId, teamNumber)`. When team 5 → 3 and sibling teams 3, 4 must shift to 4, 5, the intermediate state would cause constraint violations unless a temp name is used. PostgreSQL evaluates UNIQUE per statement (not per transaction) by default, so the workaround is necessary unless constraints are made `DEFERRABLE`.
+
+**Rationale**: Adding `DEFERRABLE INITIALLY DEFERRED` to the unique index is a migration-level change that is out of scope. The temp-name approach works; the only bug is that the final name is constructed manually (and incorrectly — `_setNameAndAbbreviation` ignores `FULL_NAME` and `TEAM_NAME` enum values). Fix: keep temp-phase saves with `{ hooks: false }`, then final saves without `hooks: false` so the hook regenerates correctly.
+
+**Alternatives considered**:
+- Add DEFERRABLE migration — out of scope, risky migration on production table.
+- Use `Team.bulkUpdate` with `individualHooks: true` — still needs the temp-name ordering, same problem.
+
+## Finding 3: Resolver manual name construction must be removed
+
+**Decision**: Lines 444–451 in `updateTeam` construct name/abbreviation manually using `club.name` regardless of `useForTeamName` enum. This logic is **incorrect** (misses `FULL_NAME`, `TEAM_NAME` cases) and **redundant** once the `@BeforeUpdate` hook is in place. Remove it; the hook on `dbTeam.update(...)` call handles it.
+
+**Rationale**: Keeping both the manual construction and the hook would cause double computation (hook wins anyway). Removing the manual construction eliminates the enum-mishandling bug.
+
+## Finding 4: `_setNameAndAbbreviation` private helper
+
+**Decision**: Retain but narrow its purpose to temp-name-only mode. After the fix, it only needs to produce the `_temp` suffix name for intermediate cascade saves. The final real-name regeneration is owned by the model hook.
+
+**Alternatives considered**: Delete it entirely and inline the temp-name string — keep it for readability; the logic is non-trivial.
+
+## Finding 5: New error code for duplicate team number (FR-007)
+
+**Decision**: Add `TEAM_NUMBER_CONFLICT` to `libs/backend/graphql/src/utils/error-codes.ts`. Throw it in `updateTeam` when the requested `teamNumber` is already occupied by a different team in the same club/season/type.
+
+**Rationale**: Error codes are the contract between backend and frontend per AGENTS.md. Clients can pin behavior to `TEAM_NUMBER_CONFLICT` for user-facing messaging.
+
+## Finding 6: `@BeforeBulkCreate` hook calls both `setAbbriviation` AND `generateAbbreviation` (double-call bug)
+
+```ts
+// Current (buggy):
+@BeforeBulkCreate
+static async setAbbriviations(instances: Team[], options: CreateOptions) {
+  for (const instance of instances ?? []) {
+    await this.setAbbriviation(instance, options);        // calls generateAbbreviation
+    await this.generateAbbreviation(instance, options);   // calls it AGAIN
+  }
+}
+```
+
+`setAbbriviation` (BeforeCreate) calls `generateName` + `generateAbbreviation`. Then `setAbbriviations` (BeforeBulkCreate) calls `setAbbriviation` AND `generateAbbreviation` again — double-computing abbreviation. This is a pre-existing bug; fix it in the same PR since we're touching the hooks region.
+
+**Decision**: Fix `BeforeBulkCreate` to only call `setAbbriviation` (which internally calls both methods). No behavior change for correct data; eliminates unnecessary DB round-trip for club lookup.
+
+## Finding 7: No tests for updateTeam, type-change, or cascade renumber
+
+**Decision**: Add tests per Constitution Principle IV. Required cases:
+1. `updateTeam` — team number changes → name and abbreviation regenerated correctly
+2. `updateTeam` — type changes → name and abbreviation regenerated
+3. `updateTeam` — unrelated field changes → name/abbreviation unchanged (no-op)
+4. `updateTeam` — unauthorized → `UnauthorizedException`
+5. `updateTeam` — team not found → `NotFoundException`
+6. `updateTeam` — duplicate number → `GraphQLError` with `TEAM_NUMBER_CONFLICT`
+7. `updateTeam` — success → commits transaction, returns team
+8. `updateTeam` — error mid-update → rolls back
+
+Team model hook tests (unit, in `team.model.spec.ts`):
+1. `@BeforeUpdate` — `teamNumber` changed → `generateName` and `generateAbbreviation` called
+2. `@BeforeUpdate` — `type` changed → both called
+3. `@BeforeUpdate` — no relevant field changed → neither called
+4. `@BeforeBulkUpdate` — multiple instances → all regenerate

--- a/specs/003-linear-bad-127/spec.md
+++ b/specs/003-linear-bad-127/spec.md
@@ -1,0 +1,98 @@
+# Feature Specification: Team Name Stays Current After Edit
+
+**Feature Branch**: `003-linear-bad-127`
+**Created**: 2026-04-30
+**Status**: Draft
+**Linear**: [BAD-127](https://linear.app/dashdot/issue/BAD-127) — Priority: High
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Admin edits team number and sees the correct name (Priority: P1)
+
+An admin changes a team's number (e.g. from 5 to 4 because another team was deleted). After saving, the displayed team name reflects the new number — the sport system of record, enrollment wizard, and any exported data all show the updated name immediately.
+
+**Why this priority**: Name/number drift corrupts enrollment documents and leaderboards. Every downstream user sees wrong data until manually corrected.
+
+**Independent Test**: Can be fully tested by updating a team's number and verifying the stored name matches, without touching any other feature.
+
+**Acceptance Scenarios**:
+
+1. **Given** a team named "Herne 5H" with number 5, **When** an admin updates the team number to 4, **Then** the team name is stored and displayed as "Herne 4H".
+2. **Given** a team with number 3 in a men's category, **When** nothing relevant changes (e.g. only a description field is touched), **Then** the team name is not regenerated unnecessarily.
+
+---
+
+### User Story 2 — Admin changes team type and sees correct gender notation (Priority: P2)
+
+An admin changes a team's type (e.g. from men's to mixed). After saving, the gender indicator in the team name updates to match (e.g. "H" becomes "G" in Belgian notation).
+
+**Why this priority**: Type changes are less frequent than number changes, but produce identical stale-name corruption with enrollment impact.
+
+**Independent Test**: Can be tested independently by updating a team's type and verifying the stored name reflects the new notation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a team with a men's type whose name ends in "H", **When** an admin updates the type to mixed, **Then** the team name is stored with the mixed gender indicator (e.g. "G").
+2. **Given** a team in a mixed category, **When** the type is updated to women's, **Then** the team name is stored with the women's gender indicator.
+
+---
+
+### User Story 3 — Enrollment wizard can update teams without delete-then-create workaround (Priority: P3)
+
+When the enrollment wizard renumbers teams (because a team is added or removed in the same gender category, or player changes shift base-index rankings), it can update team numbers directly. It no longer needs to delete and recreate teams to force name regeneration.
+
+**Why this priority**: Unblocks cleaner enrollment flow (BAD-17, BAD-121) and removes a data-integrity risk where delete-then-create drops relational history.
+
+**Independent Test**: Can be tested by simulating the enrollment renumbering path and verifying all affected teams have updated names without any delete operations.
+
+**Acceptance Scenarios**:
+
+1. **Given** a club with teams 1–5 in men's, **When** team 3 is deleted and the remaining teams are renumbered, **Then** all surviving teams have names matching their new numbers after a single update operation per team (no delete-then-create).
+2. **Given** the enrollment wizard updating multiple teams in one submission, **When** bulk team numbers change, **Then** all team names reflect their new numbers after the operation completes.
+
+---
+
+### Edge Cases
+
+- Team number changes to a value already held by another team — system must handle ordering/locking without name collision.
+- Bulk rename of multiple teams in one action — all must regenerate, not just the first.
+- Update touches only unrelated fields (notes, scheduling preference) — name must not change.
+- Club's display-name setting changes — regenerating names for all club teams is **out of scope** for this fix (separate ticket if needed).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When a team's number changes, the system MUST immediately update the team's stored name to reflect the new number.
+- **FR-002**: When a team's type changes, the system MUST immediately update the team's stored name to reflect the new type notation.
+- **FR-003**: When neither the team number nor the type changes during an update, the system MUST NOT regenerate the team name (no unnecessary churn).
+- **FR-004**: When multiple teams are updated in a single batch operation, the system MUST regenerate names for all affected teams, not only the first.
+- **FR-005**: The name regeneration on update MUST use the same logic as name generation on creation — no separate or divergent rules.
+- **FR-006**: The enrollment wizard MUST be able to renumber teams via direct update (no delete-then-create required to obtain correct names).
+
+### Key Entities
+
+- **Team**: Has a number, type, and a derived name and abbreviation. Name/abbreviation are computed from number + type + club display settings.
+- **Enrollment Wizard**: Process that assigns and renumbers teams within a gender category during a competition season enrollment.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of automated tests for number-change, type-change, and no-op update scenarios pass before release.
+- **SC-002**: Zero cases in post-release QA where a team's displayed name does not match its stored number after an admin update.
+- **SC-003**: Enrollment wizard renumbering produces correct names for all affected teams in a single pass — verified by automated test covering ≥5 teams renumbered in one operation.
+- **SC-004**: Existing enrollment and team-creation flows (BAD-121, BAD-17) pass their own acceptance criteria without relying on delete-then-create as a name-sync workaround.
+
+## Assumptions
+
+- Changing the club that owns a team (reassigning `clubId`) is extremely rare and excluded from automatic name regeneration in this fix; a separate ticket handles it if needed.
+- The existing name-generation logic (used on create) is correct; this fix only ensures it also runs on update.
+- Typo corrections in existing method names (`setAbbriviation`) are out of scope for this issue.
+- One-off migration to fix historically stale team names in production is out of scope; if needed, a separate data-repair task will be created.
+- BAD-119 (base-index formula correctness) is independent and not part of this fix.
+
+## Dependencies
+
+- BAD-121: Frontend enrollment bug (teams not created on backend) — benefits from this fix but is a separate issue.
+- BAD-17: Automatic team renumbering — this fix is a prerequisite for BAD-17's clean update path.

--- a/specs/003-linear-bad-127/spec.md
+++ b/specs/003-linear-bad-127/spec.md
@@ -54,21 +54,30 @@ When the enrollment wizard renumbers teams (because a team is added or removed i
 
 ### Edge Cases
 
-- Team number changes to a value already held by another team — system must handle ordering/locking without name collision.
+- Team number changes to a value already held by another team in the same club/category — the update MUST be rejected with an error; the caller is responsible for resolving the conflict before retrying.
 - Bulk rename of multiple teams in one action — all must regenerate, not just the first.
 - Update touches only unrelated fields (notes, scheduling preference) — name must not change.
 - Club's display-name setting changes — regenerating names for all club teams is **out of scope** for this fix (separate ticket if needed).
+
+## Clarifications
+
+### Session 2026-04-30
+
+- Q: Should name regeneration on update also regenerate the abbreviation in the same operation? → A: Yes — both name and abbreviation regenerate together on every relevant update.
+- Q: What happens when an update would assign a team number already held by another team in the same club/category? → A: Reject the update — return an error; caller must resolve the conflict explicitly.
+- Q: Should bulk team renumbering be atomic (all-or-nothing) or best-effort? → A: Atomic — entire batch rolls back if any single team update fails.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
-- **FR-001**: When a team's number changes, the system MUST immediately update the team's stored name to reflect the new number.
-- **FR-002**: When a team's type changes, the system MUST immediately update the team's stored name to reflect the new type notation.
-- **FR-003**: When neither the team number nor the type changes during an update, the system MUST NOT regenerate the team name (no unnecessary churn).
-- **FR-004**: When multiple teams are updated in a single batch operation, the system MUST regenerate names for all affected teams, not only the first.
+- **FR-001**: When a team's number changes, the system MUST immediately update the team's stored name and abbreviation to reflect the new number.
+- **FR-002**: When a team's type changes, the system MUST immediately update the team's stored name and abbreviation to reflect the new type notation.
+- **FR-003**: When neither the team number nor the type changes during an update, the system MUST NOT regenerate the team name or abbreviation (no unnecessary churn).
+- **FR-004**: When multiple teams are updated in a single batch operation, the system MUST regenerate names and abbreviations for all affected teams, not only the first. The batch MUST be atomic — if any single team update fails, the entire batch rolls back with no partial changes persisted.
 - **FR-005**: The name regeneration on update MUST use the same logic as name generation on creation — no separate or divergent rules.
 - **FR-006**: The enrollment wizard MUST be able to renumber teams via direct update (no delete-then-create required to obtain correct names).
+- **FR-007**: If a team update would assign a number already held by another team in the same club and gender category, the system MUST reject the update with a clear error before persisting any change.
 
 ### Key Entities
 
@@ -79,7 +88,7 @@ When the enrollment wizard renumbers teams (because a team is added or removed i
 
 ### Measurable Outcomes
 
-- **SC-001**: 100% of automated tests for number-change, type-change, and no-op update scenarios pass before release.
+- **SC-001**: 100% of automated tests for number-change, type-change, and no-op update scenarios pass before release — covering both name and abbreviation fields.
 - **SC-002**: Zero cases in post-release QA where a team's displayed name does not match its stored number after an admin update.
 - **SC-003**: Enrollment wizard renumbering produces correct names for all affected teams in a single pass — verified by automated test covering ≥5 teams renumbered in one operation.
 - **SC-004**: Existing enrollment and team-creation flows (BAD-121, BAD-17) pass their own acceptance criteria without relying on delete-then-create as a name-sync workaround.

--- a/specs/004-addplayertoclub-return-membership/checklists/requirements.md
+++ b/specs/004-addplayertoclub-return-membership/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: ClubPlayerMembership Resolver Upgrades
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec populated from Linear BAD-129. Ready for `/speckit-plan`.

--- a/specs/004-addplayertoclub-return-membership/data-model.md
+++ b/specs/004-addplayertoclub-return-membership/data-model.md
@@ -1,0 +1,86 @@
+# Data Model: ClubPlayerMembership Resolver Upgrades
+
+**Branch**: `004-addplayertoclub-return-membership` | **Date**: 2026-04-30
+
+## No schema changes
+
+This fix is purely resolver + result-object level. No new tables, columns, or migrations.
+
+## Existing entity (unchanged)
+
+### ClubPlayerMembership — `libs/backend/database/src/models/club-player-membership.model.ts`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | UUID | PK |
+| `playerId` | UUID | FK → Player. Required. Indexed `player_club_index`. |
+| `clubId` | UUID | FK → Club. Required. Indexed `player_club_index`. |
+| `start` | Date | Required. Part of compound unique constraint `ClubPlayerMemberships_playerId_clubId_unique`. |
+| `end` | Date \| null | Open-ended membership when null. |
+| `confirmed` | boolean | Default false. Set true when caller has `change:transfer` permission. |
+| `membershipType` | enum (`NORMAL`, `LOAN`, `TRANSFER`) | Default `NORMAL`. |
+
+**Compound unique constraint**: `(playerId, clubId, start)` — drives idempotency natural key.
+
+**No `season` column**. Season is implicit in `start` date.
+
+## New result type (Phase 1)
+
+### AddPlayerToClubResult — `libs/backend/graphql/src/resolvers/club/add-player-to-club-result.object.ts`
+
+| Field | Type | Source |
+|-------|------|--------|
+| `id` | ID | `ClubPlayerMembership.id` |
+| `clubId` | ID | `ClubPlayerMembership.clubId` |
+| `playerId` | ID | `ClubPlayerMembership.playerId` |
+| `start` | Date | `ClubPlayerMembership.start` |
+| `end` | Date \| null | `ClubPlayerMembership.end` |
+| `membershipType` | String | `ClubPlayerMembership.membershipType` |
+| `alreadyExisted` | Boolean | `true` when lookup matched, `false` when new row created |
+
+## Error code registry additions
+
+| Code | Trigger | Used by |
+|------|---------|---------|
+| `MEMBERSHIP_NOT_FOUND` (NEW) | `findByPk(membershipId)` returns null | `updateClubPlayerMembership`, `removePlayerFromClub` |
+
+Existing codes reused (no changes): `PERMISSION_DENIED`, `CLUB_NOT_FOUND`, `PLAYER_NOT_FOUND`.
+
+## State transitions
+
+### addPlayerToClub (idempotent)
+
+```
+INPUT: { clubId, playerId, start, end?, membershipType? }
+  ↓ auth check (PERMISSION_DENIED if fails)
+  ↓ Club.findByPk → null? → CLUB_NOT_FOUND
+  ↓ Player.findByPk → null? → PLAYER_NOT_FOUND
+  ↓ ClubPlayerMembership.findOrCreate({ where: { clubId, playerId, start }, defaults: { end, membershipType, confirmed } })
+  ↓ → returns [instance, created]
+  ↓
+RESULT: AddPlayerToClubResult { ...instance, alreadyExisted: !created }
+```
+
+### updateClubPlayerMembership
+
+```
+INPUT: { id, ...fields }
+  ↓ ClubPlayerMembership.findByPk(id) → null? → MEMBERSHIP_NOT_FOUND
+  ↓ auth check on membership.clubId → PERMISSION_DENIED if fails
+  ↓ membership.update(fields, { transaction })
+  ↓
+RESULT: Boolean (unchanged)
+```
+
+### removePlayerFromClub
+
+```
+INPUT: { id }
+  ↓ ClubPlayerMembership.findByPk(id) → null? → MEMBERSHIP_NOT_FOUND
+  ↓ auth check on membership.clubId → PERMISSION_DENIED if fails
+  ↓ membership.destroy({ transaction })
+  ↓
+RESULT: Boolean (unchanged)
+```
+
+Note: `update` and `remove` keep their `Boolean` return shape. Only `addPlayerToClub` gets the new result object — that's what BAD-129 requires and what aligns with idempotent-create pattern. Update/remove are not idempotent-create operations.

--- a/specs/004-addplayertoclub-return-membership/plan.md
+++ b/specs/004-addplayertoclub-return-membership/plan.md
@@ -1,0 +1,313 @@
+# Implementation Plan: ClubPlayerMembership Resolver Upgrades
+
+**Branch**: `004-addplayertoclub-return-membership` | **Date**: 2026-04-30 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Bring the three ClubPlayerMembership mutations (`addPlayerToClub`, `updateClubPlayerMembership`, `removePlayerFromClub`) up to the conventions established by 002 and codified in Constitution v1.1.0:
+
+1. `addPlayerToClub` returns a new `AddPlayerToClubResult` `@ObjectType` with idempotent `alreadyExisted` flag (was `Boolean`).
+2. All three mutations replace `UnauthorizedException` / `NotFoundException` with classified `GraphQLError` codes from the shared registry; new code `MEMBERSHIP_NOT_FOUND` added for update/remove.
+3. Co-located `*.spec.ts` covers the standard CRUD case matrix plus idempotent re-add for `addPlayerToClub`.
+4. Implementation switches `addPlayerToClub` from `club.addPlayer()` (which has no return handle) to `ClubPlayerMembership.findOrCreate({ where: { clubId, playerId, start } })`, which returns `[instance, created]` mapping cleanly to `alreadyExisted = !created`.
+
+## Technical Context
+
+**Language/Version**: TypeScript (Node.js 20, Nx monorepo)
+**Primary Dependencies**: NestJS, Sequelize + sequelize-typescript, Apollo GraphQL, `graphql` (for `GraphQLError`)
+**Storage**: PostgreSQL — `ClubPlayerMembership` table in `public` schema
+**Testing**: Jest via Nx (`nx test backend-graphql`)
+**Target Platform**: Node.js API server (port 5010)
+**Project Type**: NestJS Nx monorepo — library patches only (`@badman/backend-graphql`, `@badman/backend-database` model unchanged)
+**Performance Goals**: One `findByPk` per mutation (existing) plus one `findOrCreate` for `addPlayerToClub` (replaces current `addPlayer` association call). Net: ±0 round-trips.
+**Constraints**: No DB schema changes. Must maintain backwards-compatible auth (`${clubId}_edit:club` / `edit-any:club`).
+**Scale/Scope**: Single resolver file + one new result object + one error code addition + tests.
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Code-First GraphQL via Sequelize Models | PASS | `ClubPlayerMembership` model unchanged. New `@ObjectType` `AddPlayerToClubResult` is a thin result wrapper, not an entity — same convention as `TeamResult` / `EnrollmentResult`. |
+| II. Translation Discipline | PASS | No i18n changes. |
+| III. Transactional Mutations | PASS | All three mutations remain transactional. Idempotency clause (v1.1.0) explicitly satisfied for `addPlayerToClub`. |
+| IV. Resolver Test Discipline | REQUIRES WORK | Three mutations have zero/insufficient test coverage. Spec FR-011/FR-012 mandate full matrix. |
+| V. Legacy Frontend Boundary | PASS | No frontend changes. |
+
+No violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-addplayertoclub-return-membership/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 findings
+├── data-model.md        ← Phase 1 entities + state transitions
+└── tasks.md             ← Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (affected files)
+
+```text
+libs/backend/graphql/src/utils/
+└── error-codes.ts                                   ← add MEMBERSHIP_NOT_FOUND
+
+libs/backend/graphql/src/resolvers/club/
+├── add-player-to-club-result.object.ts              ← NEW @ObjectType
+├── club.resolver.ts                                 ← upgrade three mutations
+└── club.resolver.spec.ts                            ← NEW or extend with full case matrix
+```
+
+## Phase 0: Research (complete)
+
+See [research.md](research.md). Key decisions:
+
+1. Idempotency natural key = `(clubId, playerId, start)` — matches DB unique constraint. No `season` column to worry about.
+2. Implementation uses `ClubPlayerMembership.findOrCreate` — built-in Sequelize idempotency primitive that maps cleanly to `alreadyExisted = !created`.
+3. New `MEMBERSHIP_NOT_FOUND` error code for update/remove paths.
+4. Dead `Club.findByPk`/`Player.findByPk` lookups in `removePlayerFromClub` removed (FK guarantees).
+5. Reference impls: `TeamResult`, `EnrollmentResult` for the `@ObjectType`; `team.resolver.spec.ts`, `enrollmentSetting.resolver.spec.ts` for tests.
+6. `confirmed` derivation (from `change:transfer` permission) preserved unchanged.
+
+## Phase 1: Design & Contracts
+
+See [data-model.md](data-model.md). No schema changes.
+
+### Mutation contracts (after fix)
+
+```graphql
+type Mutation {
+  addPlayerToClub(data: ClubPlayerMembershipNewInput!): AddPlayerToClubResult!
+  updateClubPlayerMembership(data: ClubPlayerMembershipUpdateInput!): Boolean!
+  removePlayerFromClub(id: ID!): Boolean!
+}
+
+type AddPlayerToClubResult {
+  id: ID!
+  clubId: ID!
+  playerId: ID!
+  start: Date!
+  end: Date
+  membershipType: String!
+  alreadyExisted: Boolean!
+}
+```
+
+**Breaking change**: `addPlayerToClub` previously returned `Boolean!`. Frontend callers must update — this is the explicit intent of BAD-129.
+
+### Error contract
+
+| Resolver | Failure | Code | Extensions |
+|----------|---------|------|------------|
+| addPlayerToClub | Caller lacks permission | `PERMISSION_DENIED` | — |
+| addPlayerToClub | Club ID not found | `CLUB_NOT_FOUND` | `{ clubId }` |
+| addPlayerToClub | Player ID not found | `PLAYER_NOT_FOUND` | `{ playerId }` |
+| updateClubPlayerMembership | Membership ID not found | `MEMBERSHIP_NOT_FOUND` | `{ membershipId }` |
+| updateClubPlayerMembership | Caller lacks permission | `PERMISSION_DENIED` | — |
+| removePlayerFromClub | Membership ID not found | `MEMBERSHIP_NOT_FOUND` | `{ membershipId }` |
+| removePlayerFromClub | Caller lacks permission | `PERMISSION_DENIED` | — |
+
+### Implementation steps (ordered)
+
+#### Step 1 — Add error code
+
+**File**: `libs/backend/graphql/src/utils/error-codes.ts`
+
+Append to the `ErrorCode` const, under a new "Club membership" comment block:
+
+```ts
+// Club membership (libs/backend/graphql/src/resolvers/club/club.resolver.ts)
+MEMBERSHIP_NOT_FOUND: "MEMBERSHIP_NOT_FOUND",
+```
+
+---
+
+#### Step 2 — Create `AddPlayerToClubResult` ObjectType
+
+**File**: `libs/backend/graphql/src/resolvers/club/add-player-to-club-result.object.ts` (NEW)
+
+Mirror the shape of `TeamResult` / `EnrollmentResult`. Fields per data-model.md.
+
+---
+
+#### Step 3 — Upgrade `addPlayerToClub` mutation
+
+**File**: `libs/backend/graphql/src/resolvers/club/club.resolver.ts`
+
+Change return type: `@Mutation(() => Boolean)` → `@Mutation(() => AddPlayerToClubResult)`.
+
+Replace body:
+
+```ts
+async addPlayerToClub(
+  @User() user: Player,
+  @Args("data") data: ClubPlayerMembershipNewInput,
+): Promise<AddPlayerToClubResult> {
+  if (!(await user.hasAnyPermission([`${data.clubId}_edit:club`, "edit-any:club"]))) {
+    throw new GraphQLError("Permission denied", {
+      extensions: { code: ErrorCode.PERMISSION_DENIED },
+    });
+  }
+
+  const transaction = await this._sequelize.transaction();
+  try {
+    const club = await Club.findByPk(data.clubId, { transaction });
+    if (!club) {
+      throw new GraphQLError(`Club not found`, {
+        extensions: { code: ErrorCode.CLUB_NOT_FOUND, clubId: data.clubId },
+      });
+    }
+    const player = await Player.findByPk(data.playerId, { transaction });
+    if (!player) {
+      throw new GraphQLError(`Player not found`, {
+        extensions: { code: ErrorCode.PLAYER_NOT_FOUND, playerId: data.playerId },
+      });
+    }
+
+    const confirmed = await user.hasAnyPermission(["change:transfer"]);
+
+    const [membership, created] = await ClubPlayerMembership.findOrCreate({
+      where: { clubId: data.clubId, playerId: data.playerId, start: data.start },
+      defaults: {
+        end: data.end,
+        membershipType: data.membershipType,
+        confirmed,
+      },
+      transaction,
+    });
+
+    await transaction.commit();
+
+    return {
+      id: membership.id,
+      clubId: membership.clubId!,
+      playerId: membership.playerId!,
+      start: membership.start,
+      end: membership.end ?? null,
+      membershipType: membership.membershipType as string,
+      alreadyExisted: !created,
+    };
+  } catch (error) {
+    this.logger.error(error);
+    await transaction.rollback();
+    throw error;
+  }
+}
+```
+
+Note: `findOrCreate` runs inside the transaction so concurrent re-submits serialize on the unique constraint.
+
+---
+
+#### Step 4 — Upgrade `updateClubPlayerMembership` mutation
+
+**File**: same
+
+Replace `NotFoundException` and `UnauthorizedException` with `GraphQLError`:
+
+```ts
+const membership = await ClubPlayerMembership.findByPk(data.id);
+if (!membership) {
+  throw new GraphQLError("Membership not found", {
+    extensions: { code: ErrorCode.MEMBERSHIP_NOT_FOUND, membershipId: data.id },
+  });
+}
+
+if (!(await user.hasAnyPermission([`${membership.clubId}_edit:club`, "edit-any:club"]))) {
+  throw new GraphQLError("Permission denied", {
+    extensions: { code: ErrorCode.PERMISSION_DENIED },
+  });
+}
+// transaction body unchanged
+```
+
+---
+
+#### Step 5 — Upgrade `removePlayerFromClub` mutation
+
+**File**: same
+
+Replace `NotFoundException` for membership with `MEMBERSHIP_NOT_FOUND`. Replace `UnauthorizedException` with `PERMISSION_DENIED`. **Remove** the dead `Club.findByPk` / `Player.findByPk` lookups (current lines 349–359) — FK constraints make them redundant.
+
+```ts
+async removePlayerFromClub(@User() user: Player, @Args("id", { type: () => ID }) id: string) {
+  const membership = await ClubPlayerMembership.findByPk(id);
+  if (!membership) {
+    throw new GraphQLError("Membership not found", {
+      extensions: { code: ErrorCode.MEMBERSHIP_NOT_FOUND, membershipId: id },
+    });
+  }
+
+  if (!(await user.hasAnyPermission([`${membership.clubId}_edit:club`, "edit-any:club"]))) {
+    throw new GraphQLError("Permission denied", {
+      extensions: { code: ErrorCode.PERMISSION_DENIED },
+    });
+  }
+
+  const transaction = await this._sequelize.transaction();
+  try {
+    await membership.destroy({ transaction });
+    await transaction.commit();
+    return true;
+  } catch (error) {
+    this.logger.error(error);
+    await transaction.rollback();
+    throw error;
+  }
+}
+```
+
+Imports cleanup: drop `NotFoundException`, `UnauthorizedException` from `@nestjs/common`; add `GraphQLError` from `graphql`; add `ErrorCode` from `../../utils/error-codes`.
+
+---
+
+#### Step 6 — Write resolver tests
+
+**File**: `libs/backend/graphql/src/resolvers/club/club.resolver.spec.ts` (NEW or extend)
+
+Follow `team.resolver.spec.ts` pattern.
+
+**`addPlayerToClub` cases** (5):
+
+1. Unauthorized → `GraphQLError` with `extensions.code === PERMISSION_DENIED`
+2. Club not found → `GraphQLError` with `CLUB_NOT_FOUND` and `extensions.clubId`
+3. Player not found → `GraphQLError` with `PLAYER_NOT_FOUND` and `extensions.playerId`
+4. Success — first add → returns result with `alreadyExisted: false`, transaction committed
+5. Idempotent re-add → returns same result with `alreadyExisted: true`, no fresh row
+
+**`updateClubPlayerMembership` cases** (4):
+
+1. Unauthorized → `PERMISSION_DENIED`
+2. Membership not found → `MEMBERSHIP_NOT_FOUND`
+3. Success → `update` called, transaction committed, returns `true`
+4. Exception during update → transaction rolled back, error rethrown
+
+**`removePlayerFromClub` cases** (4):
+
+1. Unauthorized → `PERMISSION_DENIED`
+2. Membership not found → `MEMBERSHIP_NOT_FOUND`
+3. Success → `destroy` called, transaction committed, returns `true`
+4. Exception during destroy → rolled back
+
+Mock setup mirrors `team.resolver.spec.ts`:
+
+```ts
+const mockSequelize = {
+  transaction: jest.fn().mockResolvedValue({
+    commit: jest.fn().mockResolvedValue(undefined),
+    rollback: jest.fn().mockResolvedValue(undefined),
+  }),
+};
+
+jest.spyOn(ClubPlayerMembership, "findByPk").mockResolvedValue(...);
+jest.spyOn(ClubPlayerMembership, "findOrCreate").mockResolvedValue([fakeMembership, true]);
+
+const fakeUser = { hasAnyPermission: jest.fn().mockResolvedValue(true) } as unknown as Player;
+```
+
+Assertions: catch the thrown `GraphQLError` and assert `error.extensions.code` equals the expected constant.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.

--- a/specs/004-addplayertoclub-return-membership/research.md
+++ b/specs/004-addplayertoclub-return-membership/research.md
@@ -1,0 +1,100 @@
+# Research: ClubPlayerMembership Resolver Upgrades
+
+**Branch**: `004-addplayertoclub-return-membership` | **Date**: 2026-04-30
+
+## Finding 1: ClubPlayerMembership model — no `season` field
+
+**Decision**: Use `start` date as the season anchor; no `season` column added. Idempotency natural key = `(clubId, playerId, start)`.
+
+The model at `libs/backend/database/src/models/club-player-membership.model.ts` has fields `id`, `playerId`, `clubId`, `start` (date, NOT NULL), `end` (date, nullable), `confirmed` (boolean), `membershipType` (enum). The compound unique constraint is `ClubPlayerMemberships_playerId_clubId_unique` on `start` (with `playerId` + `clubId` via the Sequelize hack noted at line 91–97 of the model).
+
+**Rationale**: Adding a `season` column would require a migration and backfill — out of scope. The DB-level unique constraint already aligns with `(clubId, playerId, start)`; idempotency in the resolver mirrors the constraint.
+
+**Alternatives considered**:
+- Idempotency on `(clubId, playerId, membershipType)` ignoring date — wrong; same player can be `NORMAL` member in season A and `LOAN` in season B at different start dates.
+- Idempotency on overlapping date ranges — too permissive; would match `(2025-09-01 → 2026-08-31)` against `(2025-12-01 → 2026-03-01)`. Out of scope; matches what BAD-120 frontend re-submits anyway.
+
+## Finding 2: Current `addPlayerToClub` uses `club.addPlayer()` association — does not return the membership
+
+```ts
+// Current (club.resolver.ts:278–286):
+await club.addPlayer(player, {
+  transaction,
+  through: { start, end, membershipType, confirmed },
+});
+return true;
+```
+
+**Decision**: Replace `club.addPlayer()` with `ClubPlayerMembership.create()` so we have a direct handle on the created row to return. Pre-check for existing row via `findOne({ where: { clubId, playerId, start } })` for idempotency.
+
+**Rationale**: The `addPlayer` BelongsToMany association does not return the through-row. Calling `ClubPlayerMembership.create` directly keeps the same DB result with a returnable handle.
+
+**Alternatives considered**:
+- Keep `club.addPlayer` and re-query the through row — extra round-trip and timing race risk.
+- Use `ClubPlayerMembership.findOrCreate` — built-in Sequelize idempotency. Considered: it returns `[instance, created: boolean]` matching our `alreadyExisted` semantic. **Pick this** — cleaner than manual find-then-create.
+
+**Revised decision**: Use `ClubPlayerMembership.findOrCreate({ where: { clubId, playerId, start }, defaults: { end, membershipType, confirmed }, transaction })`. The `created` boolean inverts to `alreadyExisted = !created`.
+
+## Finding 3: Error code registry needs `MEMBERSHIP_NOT_FOUND`
+
+**Decision**: Append `MEMBERSHIP_NOT_FOUND` to `libs/backend/graphql/src/utils/error-codes.ts` under a new "Club membership" section.
+
+**Rationale**: `updateClubPlayerMembership` and `removePlayerFromClub` both look up a membership by ID and currently throw `NotFoundException`. They need a stable code per FR-009.
+
+## Finding 4: `removePlayerFromClub` has dead `Club.findByPk` / `Player.findByPk` calls
+
+Lines 349–359 of `club.resolver.ts` look up club + player after the membership was already loaded, only to throw `NotFoundException` if either is missing. The membership already has FK guarantees — these lookups are dead weight.
+
+**Decision**: Remove the dead lookups and dead-throws in the same PR. Replace the membership-not-found `NotFoundException` with `MEMBERSHIP_NOT_FOUND` classified error. The per-FK throws had no behavioral value (FK constraint guarantees club/player exist or membership wouldn't).
+
+**Alternatives considered**: Leave the lookups in place — no, they confuse the test matrix and add latency for no benefit.
+
+## Finding 5: Reference implementations for idempotent create
+
+`createTeam` in `team.resolver.ts:177–386` and `createEnrollment` in `enrollment.resolver.ts` both use the pattern:
+
+1. Lookup by natural key with transaction.
+2. If found → return result with `alreadyExisted: true`, no write.
+3. If not found → create, return result with `alreadyExisted: false`.
+
+Result objects: `TeamResult` (team-result.object.ts) and `EnrollmentResult` (enrollment-result.object.ts) — both `@ObjectType` classes with `@Field` ID echoes plus `alreadyExisted: boolean`.
+
+**Decision**: New `AddPlayerToClubResult` `@ObjectType` follows the same shape:
+
+```ts
+@ObjectType({ description: "Result of addPlayerToClub. Idempotent on (clubId, playerId, start)." })
+export class AddPlayerToClubResult {
+  @Field(() => ID) declare id: string;
+  @Field(() => ID) declare clubId: string;
+  @Field(() => ID) declare playerId: string;
+  @Field(() => Date) declare start: Date;
+  @Field(() => Date, { nullable: true }) declare end: Date | null;
+  @Field(() => String) declare membershipType: string;
+  @Field(() => Boolean, { description: "True when an existing membership matched (clubId, playerId, start) and no write occurred. False when a fresh membership was created." })
+  declare alreadyExisted: boolean;
+}
+```
+
+## Finding 6: Test pattern reference
+
+`libs/backend/graphql/src/resolvers/team/team.resolver.spec.ts` and `enrollmentSetting.resolver.spec.ts` are the closest references. Both:
+
+- `Test.createTestingModule` with mocked `Sequelize` (transaction returns `{ commit, rollback }` jest stubs)
+- `jest.spyOn(Model, 'staticMethod')` for model statics
+- Fake `Player` with `hasAnyPermission: jest.fn()`
+- `afterEach(jest.restoreAllMocks)`
+- Cases: success-with-commit, unauthorized → classified error code, not-found → classified error code, exception → rollback
+
+**Decision**: New `club.resolver.spec.ts` (or extend if exists) mirrors this layout for the three target mutations. Each gets the standard 4-case matrix; `addPlayerToClub` gets a 5th case for idempotent re-add.
+
+## Finding 7: `confirmed` flag derivation
+
+Current `addPlayerToClub` sets `confirmed = await user.hasAnyPermission(["change:transfer"])`. This logic must be preserved as-is — orthogonal to this fix.
+
+**Decision**: Keep `confirmed` derivation unchanged. Pass it as a `default` to `findOrCreate`.
+
+## Finding 8: Permission check order
+
+Currently auth is checked **before** the lookup. This is correct (don't leak existence to unauthorized callers). Keep this order in all three mutations.
+
+**Decision**: All three mutations: auth check first → lookup → mutate. No changes to ordering.

--- a/specs/004-addplayertoclub-return-membership/spec.md
+++ b/specs/004-addplayertoclub-return-membership/spec.md
@@ -1,0 +1,147 @@
+# Feature Specification: ClubPlayerMembership Resolver Upgrades
+
+**Feature Branch**: `004-addplayertoclub-return-membership`
+**Created**: 2026-04-30
+**Status**: Draft
+**Linear**: [BAD-129](https://linear.app/dashdot/issue/BAD-129) — Priority: High
+
+## Clarifications
+
+### Session 2026-04-30
+
+- Q: Should adding a player who is already a member return an error, or return the existing membership record idempotently? → A: Idempotent — return existing `ClubPlayerMembership` with `alreadyExisted: true`; no write occurs. Consistent with `TeamResult` / `EnrollmentResult` pattern.
+
+## Scope note
+
+This spec extends the BAD-129 fix beyond `addPlayerToClub` to bring the entire ClubPlayerMembership domain (`addPlayerToClub`, `updateClubPlayerMembership`, `removePlayerFromClub`) up to the conventions established by 002 (team-resolver-improvements):
+
+- Classified `GraphQLError` codes from the shared registry instead of `UnauthorizedException` / `NotFoundException`
+- Idempotency on create (already covered by FR-001..FR-005)
+- Resolver test coverage per Constitution IV
+- Result `@ObjectType` for `addPlayerToClub`
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Enrollment wizard adds a transfer/loan and can immediately remove it (Priority: P1)
+
+During enrollment, a club admin adds a player as a transfer or loan to a club. The system confirms the membership was created and returns enough information for the admin to remove that same membership in the same workflow session — without needing to navigate away or reload.
+
+**Why this priority**: Without the membership record in the response, the wizard has no way to delete the membership it just created. This blocks the core transfer/loan management flow (BAD-120).
+
+**Independent Test**: Can be fully tested by adding a player to a club and verifying the response contains a membership record with an ID, then using that ID to delete the membership.
+
+**Acceptance Scenarios**:
+
+1. **Given** an admin adds a player as a transfer to a club, **When** the operation succeeds, **Then** the response contains a membership record including at minimum: a unique membership ID, the membership type, the season, the club identifier, and the player identifier.
+2. **Given** an admin receives the membership record from step 1, **When** they immediately delete it using the membership ID, **Then** the deletion succeeds without any additional lookups.
+3. **Given** an admin adds a player as a loan to a club, **When** the operation succeeds, **Then** the returned membership record reflects the loan type.
+
+---
+
+### User Story 2 — Clients receive machine-readable error codes (Priority: P1)
+
+When any of the three ClubPlayerMembership mutations fail, the response carries a stable error code from the shared registry that clients can pin behavior to (display localized messages, redirect to login on permission denial, etc.).
+
+**Why this priority**: Without classified codes, clients must parse error messages — fragile and locale-dependent. Aligns with 002's resolver upgrade pattern and Constitution Principle III.
+
+**Independent Test**: Each error path is covered by a unit test that asserts the exact `extensions.code` value.
+
+**Acceptance Scenarios**:
+
+1. **Given** a caller without club edit permission, **When** they call any of the three mutations, **Then** the error response contains `extensions.code = "PERMISSION_DENIED"`.
+2. **Given** the referenced club does not exist (add path), **When** the mutation is called, **Then** the error response contains `extensions.code = "CLUB_NOT_FOUND"`.
+3. **Given** the referenced player does not exist (add path), **When** the mutation is called, **Then** the error response contains `extensions.code = "PLAYER_NOT_FOUND"`.
+4. **Given** the referenced membership does not exist (update or remove path), **When** the mutation is called, **Then** the error response contains `extensions.code = "MEMBERSHIP_NOT_FOUND"`.
+
+---
+
+### User Story 3 — Existing callers continue to work without breaking (Priority: P2)
+
+Any existing caller that previously checked a simple success/failure result for these mutations continues to function correctly after the change.
+
+**Why this priority**: Existing callers must not break when the `addPlayerToClub` response shape changes from a simple boolean to a richer record.
+
+**Independent Test**: Verified by running existing functionality that adds, updates, or removes club memberships and confirming no regressions.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing caller that only checks whether `addPlayerToClub` succeeded, **When** the operation runs after this change, **Then** the caller can still determine success by checking that a result was returned (non-null).
+2. **Given** the operation fails, **When** the caller handles the error, **Then** error semantics remain unchanged from before (still throws; just with a stable code now).
+
+---
+
+### User Story 4 — Resolver test coverage matches the rest of the codebase (Priority: P2)
+
+The three mutations follow Constitution Principle IV: each one has a co-located `*.spec.ts` covering the standard cases.
+
+**Why this priority**: Without these tests, regressions in auth, not-found, and rollback paths slip through silently. The other resolvers (`enrollmentSetting`, `team`, `enrollment`) all have this coverage.
+
+**Independent Test**: `nx test backend-graphql` covers all three mutations across the standard CRUD case matrix.
+
+**Acceptance Scenarios**:
+
+1. **Given** the test suite, **When** it runs, **Then** every mutation has tests for: query/lookup-returns-data, mutation-rejects-unauthorized (PERMISSION_DENIED), mutation-handles-not-found (CLUB/PLAYER/MEMBERSHIP_NOT_FOUND), mutation-success-with-commit, mutation-rolls-back-on-error.
+2. **Given** the `addPlayerToClub` test, **When** it runs, **Then** it additionally verifies idempotent return (`alreadyExisted: true`) when the player is already a member of the same club/season/type.
+
+---
+
+### Edge Cases
+
+- A membership row already exists for the same `(clubId, playerId, start)` — operation is idempotent: returns the existing membership with `alreadyExisted: true`; no error and no duplicate row.
+- Caller lacks `${clubId}_edit:club` and `edit-any:club` permissions — authorization error returned with `PERMISSION_DENIED`; no membership created/modified/removed.
+- Update or remove called with a membership ID that does not exist — error with `MEMBERSHIP_NOT_FOUND`; no partial state.
+- Membership created successfully but caller discards the ID — no functional regression; deletion still possible via other lookup paths (out of scope for this ticket).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Add player to club
+
+- **FR-001**: When `addPlayerToClub` succeeds, the system MUST return a result containing at minimum: membership ID, membership type, start date, end date (nullable), club identifier, player identifier, and an `alreadyExisted` flag. (Note: the model has no `season` field — start date is the season anchor.)
+- **FR-002**: The result returned MUST reflect the exact membership created or matched (not a cached or approximate value).
+- **FR-003**: Callers that previously checked a boolean success result MUST be updated to check for a non-null result as the success signal.
+- **FR-004**: When a membership already exists for the same `(clubId, playerId, start)`, the system MUST return that existing membership idempotently with `alreadyExisted: true`; no write occurs and no error is raised.
+- **FR-005**: When `addPlayerToClub` fails for reasons other than duplicate membership (authorization, validation, missing player/club), the system MUST throw a classified error — not a null result.
+
+#### Classified errors (all three mutations)
+
+- **FR-006**: When the caller lacks club-edit permission for the targeted club, the system MUST throw `GraphQLError` with `extensions.code = ErrorCode.PERMISSION_DENIED`. This applies to `addPlayerToClub`, `updateClubPlayerMembership`, and `removePlayerFromClub`.
+- **FR-007**: When `addPlayerToClub` references a club ID that does not exist, the system MUST throw `GraphQLError` with `extensions.code = ErrorCode.CLUB_NOT_FOUND`.
+- **FR-008**: When `addPlayerToClub` references a player ID that does not exist, the system MUST throw `GraphQLError` with `extensions.code = ErrorCode.PLAYER_NOT_FOUND`.
+- **FR-009**: When `updateClubPlayerMembership` or `removePlayerFromClub` references a membership ID that does not exist, the system MUST throw `GraphQLError` with `extensions.code = ErrorCode.MEMBERSHIP_NOT_FOUND` (new code).
+- **FR-010**: All thrown error codes MUST come from the shared registry [`libs/backend/graphql/src/utils/error-codes.ts`](../../libs/backend/graphql/src/utils/error-codes.ts). Inline string-literal codes are forbidden.
+
+#### Test coverage
+
+- **FR-011**: Each of the three mutations MUST have a co-located `*.spec.ts` covering: success path with transaction commit, unauthorized → `PERMISSION_DENIED`, not-found → appropriate `*_NOT_FOUND`, and error path with transaction rollback. Tests MUST follow the pattern in `enrollmentSetting.resolver.spec.ts` (mocked `Sequelize`, `jest.spyOn` on model statics, fake `Player` with `hasAnyPermission` jest.fn(), `afterEach(jest.restoreAllMocks)`).
+- **FR-012**: `addPlayerToClub` tests MUST additionally cover the idempotent return path (`alreadyExisted: true` on duplicate add).
+
+### Key Entities
+
+- **ClubPlayerMembership**: Represents a player's association with a club for a specific season. Fields: unique ID, membership type (transfer/loan/regular), season, club ID, player ID.
+- **AddPlayerToClubResult**: Result returned by `addPlayerToClub`. Wraps `ClubPlayerMembership` fields plus `alreadyExisted: boolean` (true when the player was already a member of the same club/season/type and no write occurred).
+- **ErrorCode.MEMBERSHIP_NOT_FOUND**: New entry in the shared error-code registry, used by `updateClubPlayerMembership` and `removePlayerFromClub` when the referenced membership ID does not exist.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of automated tests for the three ClubPlayerMembership mutations pass, covering success, idempotent re-add, authorization rejection, all not-found paths, and rollback.
+- **SC-002**: Zero regressions in existing callers — all features that add, update, or remove club memberships continue to work after the change.
+- **SC-003**: BAD-120 frontend can complete a full transfer/loan add-then-delete flow in a single session without an additional lookup call, verified by end-to-end test.
+- **SC-004**: Zero `UnauthorizedException` or `NotFoundException` throws remain in `club.resolver.ts` for the three target mutations — all replaced by classified `GraphQLError` per FR-006..FR-010.
+
+## Assumptions
+
+- Membership type values (transfer, loan, regular) already exist and are unchanged by this fix.
+- The season field in the membership record corresponds to the active enrollment season at time of creation.
+- Existing callers of the three mutations are known and can be audited before shipping.
+- No new membership fields beyond the five listed are required by downstream consumers at this time.
+- The natural uniqueness key for idempotency on `addPlayerToClub` is `(clubId, playerId, start)` — matching the existing DB unique constraint `ClubPlayerMemberships_playerId_clubId_unique`. The model has no `season` field; "season" in the result object will be derived from `start` (the badminton season the start date falls in).
+
+## Dependencies
+
+- BAD-120: Persist transfers and loans in enrollment wizard — `addPlayerToClub` change is a hard prerequisite for that feature's FR-003 and FR-005 (immediate delete after add).
+- 002 (team-resolver-improvements): established the result-object + classified-error + idempotency conventions this spec applies to the ClubPlayerMembership domain.
+- Constitution Principle III (v1.1.0): codifies the idempotency rule.

--- a/specs/004-addplayertoclub-return-membership/tasks.md
+++ b/specs/004-addplayertoclub-return-membership/tasks.md
@@ -1,0 +1,228 @@
+---
+
+description: "Tasks for ClubPlayerMembership Resolver Upgrades (BAD-129)"
+---
+
+# Tasks: ClubPlayerMembership Resolver Upgrades
+
+**Input**: Design documents from `/specs/004-addplayertoclub-return-membership/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md
+
+**Tests**: Required per Constitution Principle IV and spec FR-011/FR-012. Test tasks are included.
+
+**Organization**: Tasks grouped by user story for independent implementation and verification.
+
+## Format: `[ID] [P?] [Story?] Description with file path`
+
+## Path Conventions
+
+NestJS Nx monorepo. Affected paths:
+- `libs/backend/graphql/src/utils/` — error codes
+- `libs/backend/graphql/src/resolvers/club/` — resolver, result object, tests
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: No project initialization needed — operating in existing libs. Single sanity-check task.
+
+- [ ] T001 Verify local API + Postgres + Redis stack is healthy (`npm run docker:up` already running; `nx test backend-graphql` baseline run produces a clean pass before changes)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared registry change that all classified-error work depends on.
+
+**⚠️ CRITICAL**: T002 must complete before any task in Phase 4 or Phase 5 can compile cleanly.
+
+- [ ] T002 Add `MEMBERSHIP_NOT_FOUND: "MEMBERSHIP_NOT_FOUND"` under a new `// Club membership (libs/backend/graphql/src/resolvers/club/club.resolver.ts)` comment block in `libs/backend/graphql/src/utils/error-codes.ts`
+
+**Checkpoint**: Error registry includes `MEMBERSHIP_NOT_FOUND`. User story implementation can begin.
+
+---
+
+## Phase 3: User Story 1 — Enrollment wizard adds transfer/loan and gets membership ID back (Priority: P1) 🎯 MVP
+
+**Goal**: `addPlayerToClub` returns the created/existing `ClubPlayerMembership` (via `AddPlayerToClubResult`) so the BAD-120 frontend wizard can immediately delete the membership without a second lookup.
+
+**Independent Test**: Call `addPlayerToClub` mutation; assert response carries `id`, `clubId`, `playerId`, `start`, `end`, `membershipType`, `alreadyExisted`. Call again with same `(clubId, playerId, start)`; assert `alreadyExisted: true` and the same `id`.
+
+### Implementation for User Story 1
+
+- [ ] T003 [P] [US1] Create `AddPlayerToClubResult` `@ObjectType` in `libs/backend/graphql/src/resolvers/club/add-player-to-club-result.object.ts` with fields `id: ID`, `clubId: ID`, `playerId: ID`, `start: Date`, `end: Date (nullable)`, `membershipType: String`, `alreadyExisted: Boolean` — mirror the description style of `TeamResult`/`EnrollmentResult`
+
+- [ ] T004 [US1] In `libs/backend/graphql/src/resolvers/club/club.resolver.ts`: change `@Mutation(() => Boolean)` decorator on `addPlayerToClub` to `@Mutation(() => AddPlayerToClubResult)`; update return type annotation to `Promise<AddPlayerToClubResult>`; import the new result class
+
+- [ ] T005 [US1] In `addPlayerToClub` body: replace `throw new UnauthorizedException(...)` with `throw new GraphQLError("Permission denied", { extensions: { code: ErrorCode.PERMISSION_DENIED } })`; ensure auth check runs before the transaction is opened
+
+- [ ] T006 [US1] In `addPlayerToClub` body: replace the two `NotFoundException` throws (club, player) with `GraphQLError` carrying `extensions.code` `CLUB_NOT_FOUND` (with `{ clubId }`) and `PLAYER_NOT_FOUND` (with `{ playerId }`) respectively
+
+- [ ] T007 [US1] In `addPlayerToClub` body: replace `await club.addPlayer(player, { transaction, through: { ... } })` + `return true` with `await ClubPlayerMembership.findOrCreate({ where: { clubId, playerId, start }, defaults: { end, membershipType, confirmed }, transaction })`; build and return an `AddPlayerToClubResult` from the resolved `[membership, created]` tuple with `alreadyExisted: !created`
+
+- [ ] T008 [US1] Update imports in `club.resolver.ts`: add `GraphQLError` from `graphql`, `ErrorCode` from `../../utils/error-codes`, and `AddPlayerToClubResult` from `./add-player-to-club-result.object`; verify `ClubPlayerMembership` is already imported from `@badman/backend-database`
+
+**Checkpoint**: `addPlayerToClub` returns `AddPlayerToClubResult` with idempotent `alreadyExisted` flag and classified errors. The frontend can delete by `id` immediately. US1 is functionally complete.
+
+---
+
+## Phase 4: User Story 2 — Clients receive machine-readable error codes (Priority: P1)
+
+**Goal**: All three ClubPlayerMembership mutations throw `GraphQLError` with `extensions.code` from the shared registry — never `UnauthorizedException` / `NotFoundException`.
+
+**Independent Test**: Call each mutation under each failure path (unauthorized, not-found); assert `error.extensions.code` matches the contract table from `plan.md`.
+
+> Note: `addPlayerToClub` error-code work is bundled into US1 (T005, T006). This phase upgrades the remaining two mutations.
+
+### Implementation for User Story 2
+
+- [ ] T009 [US2] In `updateClubPlayerMembership` (`club.resolver.ts`): replace `throw new NotFoundException(\`${ClubPlayerMembership.name}: ${data.id}\`)` with `throw new GraphQLError("Membership not found", { extensions: { code: ErrorCode.MEMBERSHIP_NOT_FOUND, membershipId: data.id } })`
+
+- [ ] T010 [US2] In `updateClubPlayerMembership`: replace `throw new UnauthorizedException(...)` with `throw new GraphQLError("Permission denied", { extensions: { code: ErrorCode.PERMISSION_DENIED } })`
+
+- [ ] T011 [US2] In `removePlayerFromClub` (`club.resolver.ts`): replace the membership-lookup `NotFoundException` with `GraphQLError` carrying `MEMBERSHIP_NOT_FOUND` (with `{ membershipId: id }`)
+
+- [ ] T012 [US2] In `removePlayerFromClub`: replace `UnauthorizedException` with `GraphQLError` carrying `PERMISSION_DENIED`
+
+- [ ] T013 [US2] In `removePlayerFromClub`: remove the dead `Club.findByPk` and `Player.findByPk` lookups and their associated `NotFoundException` throws (per research.md Finding 4 — FK constraints make them redundant)
+
+- [ ] T014 [US2] Drop unused `NotFoundException` and `UnauthorizedException` imports from `@nestjs/common` in `club.resolver.ts`; verify no other resolver mutation in this file still uses them. If other mutations still use them (e.g. `createClub`, `updateClub`), keep the imports.
+
+**Checkpoint**: All three target mutations throw classified `GraphQLError`s. Zero `NotFoundException`/`UnauthorizedException` left in the three target mutations. SC-004 satisfied.
+
+---
+
+## Phase 5: User Story 4 — Resolver test coverage matches the rest of the codebase (Priority: P2)
+
+**Goal**: Co-located `club.resolver.spec.ts` covers the standard CRUD case matrix per Constitution IV, including idempotent re-add for `addPlayerToClub`.
+
+**Independent Test**: `nx test backend-graphql --testPathPattern=club.resolver.spec.ts` runs all 13 cases green.
+
+> Note: Spec US3 (no regressions) is verified by Phase 6 polish tasks (running the full backend-graphql test suite + typecheck).
+
+### Test scaffolding
+
+- [ ] T015 [US4] If `libs/backend/graphql/src/resolvers/club/club.resolver.spec.ts` does not exist, create it; if it exists, add a new `describe("ClubsResolver", ...)` with `beforeEach` setting up `Test.createTestingModule` with `ClubsResolver` and a fake `Sequelize` (transaction returns `{ commit: jest.fn(), rollback: jest.fn() }`). Add `afterEach(() => jest.restoreAllMocks())`. Mirror layout of `team.resolver.spec.ts`.
+
+### Tests for `addPlayerToClub` (5 cases)
+
+- [ ] T016 [P] [US4] Add test "rejects unauthorized" — fake `Player` with `hasAnyPermission` returning `false`; expect `GraphQLError` with `extensions.code === "PERMISSION_DENIED"`
+
+- [ ] T017 [P] [US4] Add test "throws CLUB_NOT_FOUND when club missing" — `jest.spyOn(Club, "findByPk").mockResolvedValue(null)`; expect `GraphQLError` with `extensions.code === "CLUB_NOT_FOUND"` and `extensions.clubId` set
+
+- [ ] T018 [P] [US4] Add test "throws PLAYER_NOT_FOUND when player missing" — `Club.findByPk` returns fake club, `Player.findByPk` returns null; expect `GraphQLError` with `extensions.code === "PLAYER_NOT_FOUND"` and `extensions.playerId` set
+
+- [ ] T019 [P] [US4] Add test "creates membership and returns alreadyExisted=false" — spy `ClubPlayerMembership.findOrCreate` to return `[fakeMembership, true]`; assert returned `AddPlayerToClubResult` has `alreadyExisted: false`, `id`, `clubId`, `playerId`, `start`, `membershipType` from the fake; assert `transaction.commit` called
+
+- [ ] T020 [P] [US4] Add test "idempotent re-add returns alreadyExisted=true" — spy `ClubPlayerMembership.findOrCreate` to return `[fakeExistingMembership, false]`; assert returned `AddPlayerToClubResult` has `alreadyExisted: true` and the existing `id`; assert no fresh row created (the `created` flag from Sequelize is the source of truth)
+
+### Tests for `updateClubPlayerMembership` (4 cases)
+
+- [ ] T021 [P] [US4] Add test "throws MEMBERSHIP_NOT_FOUND when membership missing" — `jest.spyOn(ClubPlayerMembership, "findByPk").mockResolvedValue(null)`; expect `GraphQLError` with `extensions.code === "MEMBERSHIP_NOT_FOUND"` and `extensions.membershipId` set
+
+- [ ] T022 [P] [US4] Add test "rejects unauthorized" — `findByPk` returns fake membership; fake user `hasAnyPermission` returns `false`; expect `PERMISSION_DENIED`
+
+- [ ] T023 [P] [US4] Add test "successful update commits transaction" — `findByPk` returns fake membership with `update: jest.fn().mockResolvedValue(...)`; assert `transaction.commit` called and resolver returns `true`
+
+- [ ] T024 [P] [US4] Add test "rolls back when update throws" — `update` rejects with `new Error("boom")`; assert `transaction.rollback` called and the error is rethrown
+
+### Tests for `removePlayerFromClub` (4 cases)
+
+- [ ] T025 [P] [US4] Add test "throws MEMBERSHIP_NOT_FOUND when membership missing" — `findByPk` returns null; expect `GraphQLError` with `MEMBERSHIP_NOT_FOUND` and `membershipId` extension
+
+- [ ] T026 [P] [US4] Add test "rejects unauthorized" — `findByPk` returns fake membership; user permission false; expect `PERMISSION_DENIED`
+
+- [ ] T027 [P] [US4] Add test "successful destroy commits transaction" — fake membership with `destroy: jest.fn().mockResolvedValue(...)`; assert `transaction.commit` called and resolver returns `true`
+
+- [ ] T028 [P] [US4] Add test "rolls back when destroy throws" — `destroy` rejects; assert `transaction.rollback` called and error rethrown
+
+**Checkpoint**: All 13 test cases pass. Constitution IV satisfied for the three target mutations.
+
+---
+
+## Phase 6: Polish & Cross-Cutting (verifies US3 — no regressions)
+
+**Purpose**: Ensure existing callers and the wider backend-graphql suite still work; verify spec SC-001 (100% test pass) and SC-002 (zero regressions).
+
+- [ ] T029 Run `nx test backend-graphql` — all suites must pass
+
+- [ ] T030 Run `nx lint backend-graphql` — must pass
+
+- [ ] T031 Run `nx build backend-graphql` and `nx build api` — both must compile cleanly (catches missed import / missing field issues that ts-tests can't)
+
+- [ ] T032 Boot the API once (`nx run api:serve` until "Listening" log) so `nestjs-i18n` regenerates `i18n.generated.ts` if it touched anything tangential; commit the regen if changed (per Constitution Principle II)
+
+- [ ] T033 [P] Manual smoke: with the API running, exercise the new mutation via an introspection client — call `addPlayerToClub` with a valid `(clubId, playerId, start)`; verify response shape matches `AddPlayerToClubResult`. Call again with the same values; verify `alreadyExisted: true`.
+
+- [ ] T034 [P] Update the per-code `extensions` payload documentation: append a "Error Codes" section to `specs/004-addplayertoclub-return-membership/plan.md` (or this tasks.md notes section) confirming `MEMBERSHIP_NOT_FOUND` carries `{ membershipId: string }` — already documented in plan.md Error contract table. Verify still accurate after implementation.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: T001 — independent.
+- **Phase 2 (Foundational)**: T002 must complete before T009/T011/T021/T025 can compile.
+- **Phase 3 (US1)**: Depends on Phase 2 (T002). T003 is parallelizable with T002.
+- **Phase 4 (US2)**: Depends on Phase 2 (T002).
+- **Phase 5 (US4 tests)**: Depends on T015 (file scaffold) for all subsequent tests; the test file imports from the resolver, so T004–T014 should land first to make the tests realistic. Tests can be written before the impl if TDD is preferred — they will fail until impl lands.
+- **Phase 6 (Polish)**: Depends on Phases 3–5 complete.
+
+### User Story Independence
+
+- **US1 (Phase 3)**: Independently testable — `addPlayerToClub` works with new shape.
+- **US2 (Phase 4)**: Independently testable — `update` and `remove` throw classified codes; can be implemented and shipped without US1 (but the BAD-120 frontend needs US1).
+- **US4 (Phase 5)**: Tests depend on US1+US2 implementation; can be staged in parallel by writing them as red tests first.
+
+### Parallel Opportunities
+
+- T003 (result object) parallel with T002 (error code).
+- All of T016–T020 ([P] [US4]) parallel with each other once T015 + impl land.
+- All of T021–T024 ([P] [US4]) parallel.
+- All of T025–T028 ([P] [US4]) parallel.
+- T033, T034 ([P]) parallel polish.
+
+---
+
+## Parallel Example: User Story 4 Test Block
+
+```bash
+# After T015 scaffold and US1/US2 impl land, run all addPlayerToClub tests in parallel:
+Task: "Add test 'rejects unauthorized' for addPlayerToClub in club.resolver.spec.ts"
+Task: "Add test 'throws CLUB_NOT_FOUND when club missing' in club.resolver.spec.ts"
+Task: "Add test 'throws PLAYER_NOT_FOUND when player missing' in club.resolver.spec.ts"
+Task: "Add test 'creates membership and returns alreadyExisted=false' in club.resolver.spec.ts"
+Task: "Add test 'idempotent re-add returns alreadyExisted=true' in club.resolver.spec.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. T001 baseline.
+2. T002 error code (foundational).
+3. T003–T008 `addPlayerToClub` upgrade.
+4. **STOP and VALIDATE**: BAD-120 frontend can now call `addPlayerToClub` and receive a membership ID. Ship.
+
+### Incremental Delivery
+
+1. MVP (above) → ship for BAD-120 unblock.
+2. US2 sweep (T009–T014) → consistent error contract across the domain.
+3. US4 tests (T015–T028) → Constitution IV compliance.
+4. Polish (T029–T034) → regression check + docs.
+
+### Solo Developer Sequence
+
+T001 → T002 → T003 → T004 → T005 → T006 → T007 → T008 → T009 → T010 → T011 → T012 → T013 → T014 → T015 → (T016..T028 in any order) → T029 → T030 → T031 → T032 → T033 → T034.
+
+---
+
+## Notes
+
+- All test cases use mocked `Sequelize` and model statics — never hit the real DB (Constitution IV).
+- `findOrCreate` runs **inside** the transaction so concurrent re-submits serialize on the unique constraint `ClubPlayerMemberships_playerId_clubId_unique`.
+- Breaking change: `addPlayerToClub` return type. Frontend must update its mutation document. The existing badman-frontend repo's `mutations.gql` likely already targets the new shape (BAD-129 was driven by frontend need); verify in the frontend repo that the document expects an object, not a boolean.
+- Commit after each numbered task or logical group (US-level checkpoints recommended).

--- a/specs/004-addplayertoclub-return-membership/tasks.md
+++ b/specs/004-addplayertoclub-return-membership/tasks.md
@@ -26,7 +26,7 @@ NestJS Nx monorepo. Affected paths:
 
 **Purpose**: No project initialization needed — operating in existing libs. Single sanity-check task.
 
-- [ ] T001 Verify local API + Postgres + Redis stack is healthy (`npm run docker:up` already running; `nx test backend-graphql` baseline run produces a clean pass before changes)
+- [x] T001 Verify local API + Postgres + Redis stack is healthy (`npm run docker:up` already running; `nx test backend-graphql` baseline run produces a clean pass before changes)
 
 ---
 
@@ -36,7 +36,7 @@ NestJS Nx monorepo. Affected paths:
 
 **⚠️ CRITICAL**: T002 must complete before any task in Phase 4 or Phase 5 can compile cleanly.
 
-- [ ] T002 Add `MEMBERSHIP_NOT_FOUND: "MEMBERSHIP_NOT_FOUND"` under a new `// Club membership (libs/backend/graphql/src/resolvers/club/club.resolver.ts)` comment block in `libs/backend/graphql/src/utils/error-codes.ts`
+- [x] T002 Add `MEMBERSHIP_NOT_FOUND: "MEMBERSHIP_NOT_FOUND"` under a new `// Club membership (libs/backend/graphql/src/resolvers/club/club.resolver.ts)` comment block in `libs/backend/graphql/src/utils/error-codes.ts`
 
 **Checkpoint**: Error registry includes `MEMBERSHIP_NOT_FOUND`. User story implementation can begin.
 
@@ -50,17 +50,17 @@ NestJS Nx monorepo. Affected paths:
 
 ### Implementation for User Story 1
 
-- [ ] T003 [P] [US1] Create `AddPlayerToClubResult` `@ObjectType` in `libs/backend/graphql/src/resolvers/club/add-player-to-club-result.object.ts` with fields `id: ID`, `clubId: ID`, `playerId: ID`, `start: Date`, `end: Date (nullable)`, `membershipType: String`, `alreadyExisted: Boolean` — mirror the description style of `TeamResult`/`EnrollmentResult`
+- [x] T003 [P] [US1] Create `AddPlayerToClubResult` `@ObjectType` in `libs/backend/graphql/src/resolvers/club/add-player-to-club-result.object.ts` with fields `id: ID`, `clubId: ID`, `playerId: ID`, `start: Date`, `end: Date (nullable)`, `membershipType: String`, `alreadyExisted: Boolean` — mirror the description style of `TeamResult`/`EnrollmentResult`
 
-- [ ] T004 [US1] In `libs/backend/graphql/src/resolvers/club/club.resolver.ts`: change `@Mutation(() => Boolean)` decorator on `addPlayerToClub` to `@Mutation(() => AddPlayerToClubResult)`; update return type annotation to `Promise<AddPlayerToClubResult>`; import the new result class
+- [x] T004 [US1] In `libs/backend/graphql/src/resolvers/club/club.resolver.ts`: change `@Mutation(() => Boolean)` decorator on `addPlayerToClub` to `@Mutation(() => AddPlayerToClubResult)`; update return type annotation to `Promise<AddPlayerToClubResult>`; import the new result class
 
-- [ ] T005 [US1] In `addPlayerToClub` body: replace `throw new UnauthorizedException(...)` with `throw new GraphQLError("Permission denied", { extensions: { code: ErrorCode.PERMISSION_DENIED } })`; ensure auth check runs before the transaction is opened
+- [x] T005 [US1] In `addPlayerToClub` body: replace `throw new UnauthorizedException(...)` with `throw new GraphQLError("Permission denied", { extensions: { code: ErrorCode.PERMISSION_DENIED } })`; ensure auth check runs before the transaction is opened
 
-- [ ] T006 [US1] In `addPlayerToClub` body: replace the two `NotFoundException` throws (club, player) with `GraphQLError` carrying `extensions.code` `CLUB_NOT_FOUND` (with `{ clubId }`) and `PLAYER_NOT_FOUND` (with `{ playerId }`) respectively
+- [x] T006 [US1] In `addPlayerToClub` body: replace the two `NotFoundException` throws (club, player) with `GraphQLError` carrying `extensions.code` `CLUB_NOT_FOUND` (with `{ clubId }`) and `PLAYER_NOT_FOUND` (with `{ playerId }`) respectively
 
-- [ ] T007 [US1] In `addPlayerToClub` body: replace `await club.addPlayer(player, { transaction, through: { ... } })` + `return true` with `await ClubPlayerMembership.findOrCreate({ where: { clubId, playerId, start }, defaults: { end, membershipType, confirmed }, transaction })`; build and return an `AddPlayerToClubResult` from the resolved `[membership, created]` tuple with `alreadyExisted: !created`
+- [x] T007 [US1] In `addPlayerToClub` body: replace `await club.addPlayer(player, { transaction, through: { ... } })` + `return true` with `await ClubPlayerMembership.findOrCreate({ where: { clubId, playerId, start }, defaults: { end, membershipType, confirmed }, transaction })`; build and return an `AddPlayerToClubResult` from the resolved `[membership, created]` tuple with `alreadyExisted: !created`
 
-- [ ] T008 [US1] Update imports in `club.resolver.ts`: add `GraphQLError` from `graphql`, `ErrorCode` from `../../utils/error-codes`, and `AddPlayerToClubResult` from `./add-player-to-club-result.object`; verify `ClubPlayerMembership` is already imported from `@badman/backend-database`
+- [x] T008 [US1] Update imports in `club.resolver.ts`: add `GraphQLError` from `graphql`, `ErrorCode` from `../../utils/error-codes`, and `AddPlayerToClubResult` from `./add-player-to-club-result.object`; verify `ClubPlayerMembership` is already imported from `@badman/backend-database`
 
 **Checkpoint**: `addPlayerToClub` returns `AddPlayerToClubResult` with idempotent `alreadyExisted` flag and classified errors. The frontend can delete by `id` immediately. US1 is functionally complete.
 
@@ -76,17 +76,17 @@ NestJS Nx monorepo. Affected paths:
 
 ### Implementation for User Story 2
 
-- [ ] T009 [US2] In `updateClubPlayerMembership` (`club.resolver.ts`): replace `throw new NotFoundException(\`${ClubPlayerMembership.name}: ${data.id}\`)` with `throw new GraphQLError("Membership not found", { extensions: { code: ErrorCode.MEMBERSHIP_NOT_FOUND, membershipId: data.id } })`
+- [x] T009 [US2] In `updateClubPlayerMembership` (`club.resolver.ts`): replace `throw new NotFoundException(\`${ClubPlayerMembership.name}: ${data.id}\`)` with `throw new GraphQLError("Membership not found", { extensions: { code: ErrorCode.MEMBERSHIP_NOT_FOUND, membershipId: data.id } })`
 
-- [ ] T010 [US2] In `updateClubPlayerMembership`: replace `throw new UnauthorizedException(...)` with `throw new GraphQLError("Permission denied", { extensions: { code: ErrorCode.PERMISSION_DENIED } })`
+- [x] T010 [US2] In `updateClubPlayerMembership`: replace `throw new UnauthorizedException(...)` with `throw new GraphQLError("Permission denied", { extensions: { code: ErrorCode.PERMISSION_DENIED } })`
 
-- [ ] T011 [US2] In `removePlayerFromClub` (`club.resolver.ts`): replace the membership-lookup `NotFoundException` with `GraphQLError` carrying `MEMBERSHIP_NOT_FOUND` (with `{ membershipId: id }`)
+- [x] T011 [US2] In `removePlayerFromClub` (`club.resolver.ts`): replace the membership-lookup `NotFoundException` with `GraphQLError` carrying `MEMBERSHIP_NOT_FOUND` (with `{ membershipId: id }`)
 
-- [ ] T012 [US2] In `removePlayerFromClub`: replace `UnauthorizedException` with `GraphQLError` carrying `PERMISSION_DENIED`
+- [x] T012 [US2] In `removePlayerFromClub`: replace `UnauthorizedException` with `GraphQLError` carrying `PERMISSION_DENIED`
 
-- [ ] T013 [US2] In `removePlayerFromClub`: remove the dead `Club.findByPk` and `Player.findByPk` lookups and their associated `NotFoundException` throws (per research.md Finding 4 — FK constraints make them redundant)
+- [x] T013 [US2] In `removePlayerFromClub`: remove the dead `Club.findByPk` and `Player.findByPk` lookups and their associated `NotFoundException` throws (per research.md Finding 4 — FK constraints make them redundant)
 
-- [ ] T014 [US2] Drop unused `NotFoundException` and `UnauthorizedException` imports from `@nestjs/common` in `club.resolver.ts`; verify no other resolver mutation in this file still uses them. If other mutations still use them (e.g. `createClub`, `updateClub`), keep the imports.
+- [x] T014 [US2] Drop unused `NotFoundException` and `UnauthorizedException` imports from `@nestjs/common` in `club.resolver.ts`; verify no other resolver mutation in this file still uses them. If other mutations still use them (e.g. `createClub`, `updateClub`), keep the imports.
 
 **Checkpoint**: All three target mutations throw classified `GraphQLError`s. Zero `NotFoundException`/`UnauthorizedException` left in the three target mutations. SC-004 satisfied.
 
@@ -102,39 +102,39 @@ NestJS Nx monorepo. Affected paths:
 
 ### Test scaffolding
 
-- [ ] T015 [US4] If `libs/backend/graphql/src/resolvers/club/club.resolver.spec.ts` does not exist, create it; if it exists, add a new `describe("ClubsResolver", ...)` with `beforeEach` setting up `Test.createTestingModule` with `ClubsResolver` and a fake `Sequelize` (transaction returns `{ commit: jest.fn(), rollback: jest.fn() }`). Add `afterEach(() => jest.restoreAllMocks())`. Mirror layout of `team.resolver.spec.ts`.
+- [x] T015 [US4] If `libs/backend/graphql/src/resolvers/club/club.resolver.spec.ts` does not exist, create it; if it exists, add a new `describe("ClubsResolver", ...)` with `beforeEach` setting up `Test.createTestingModule` with `ClubsResolver` and a fake `Sequelize` (transaction returns `{ commit: jest.fn(), rollback: jest.fn() }`). Add `afterEach(() => jest.restoreAllMocks())`. Mirror layout of `team.resolver.spec.ts`.
 
 ### Tests for `addPlayerToClub` (5 cases)
 
-- [ ] T016 [P] [US4] Add test "rejects unauthorized" — fake `Player` with `hasAnyPermission` returning `false`; expect `GraphQLError` with `extensions.code === "PERMISSION_DENIED"`
+- [x] T016 [P] [US4] Add test "rejects unauthorized" — fake `Player` with `hasAnyPermission` returning `false`; expect `GraphQLError` with `extensions.code === "PERMISSION_DENIED"`
 
-- [ ] T017 [P] [US4] Add test "throws CLUB_NOT_FOUND when club missing" — `jest.spyOn(Club, "findByPk").mockResolvedValue(null)`; expect `GraphQLError` with `extensions.code === "CLUB_NOT_FOUND"` and `extensions.clubId` set
+- [x] T017 [P] [US4] Add test "throws CLUB_NOT_FOUND when club missing" — `jest.spyOn(Club, "findByPk").mockResolvedValue(null)`; expect `GraphQLError` with `extensions.code === "CLUB_NOT_FOUND"` and `extensions.clubId` set
 
-- [ ] T018 [P] [US4] Add test "throws PLAYER_NOT_FOUND when player missing" — `Club.findByPk` returns fake club, `Player.findByPk` returns null; expect `GraphQLError` with `extensions.code === "PLAYER_NOT_FOUND"` and `extensions.playerId` set
+- [x] T018 [P] [US4] Add test "throws PLAYER_NOT_FOUND when player missing" — `Club.findByPk` returns fake club, `Player.findByPk` returns null; expect `GraphQLError` with `extensions.code === "PLAYER_NOT_FOUND"` and `extensions.playerId` set
 
-- [ ] T019 [P] [US4] Add test "creates membership and returns alreadyExisted=false" — spy `ClubPlayerMembership.findOrCreate` to return `[fakeMembership, true]`; assert returned `AddPlayerToClubResult` has `alreadyExisted: false`, `id`, `clubId`, `playerId`, `start`, `membershipType` from the fake; assert `transaction.commit` called
+- [x] T019 [P] [US4] Add test "creates membership and returns alreadyExisted=false" — spy `ClubPlayerMembership.findOrCreate` to return `[fakeMembership, true]`; assert returned `AddPlayerToClubResult` has `alreadyExisted: false`, `id`, `clubId`, `playerId`, `start`, `membershipType` from the fake; assert `transaction.commit` called
 
-- [ ] T020 [P] [US4] Add test "idempotent re-add returns alreadyExisted=true" — spy `ClubPlayerMembership.findOrCreate` to return `[fakeExistingMembership, false]`; assert returned `AddPlayerToClubResult` has `alreadyExisted: true` and the existing `id`; assert no fresh row created (the `created` flag from Sequelize is the source of truth)
+- [x] T020 [P] [US4] Add test "idempotent re-add returns alreadyExisted=true" — spy `ClubPlayerMembership.findOrCreate` to return `[fakeExistingMembership, false]`; assert returned `AddPlayerToClubResult` has `alreadyExisted: true` and the existing `id`; assert no fresh row created (the `created` flag from Sequelize is the source of truth)
 
 ### Tests for `updateClubPlayerMembership` (4 cases)
 
-- [ ] T021 [P] [US4] Add test "throws MEMBERSHIP_NOT_FOUND when membership missing" — `jest.spyOn(ClubPlayerMembership, "findByPk").mockResolvedValue(null)`; expect `GraphQLError` with `extensions.code === "MEMBERSHIP_NOT_FOUND"` and `extensions.membershipId` set
+- [x] T021 [P] [US4] Add test "throws MEMBERSHIP_NOT_FOUND when membership missing" — `jest.spyOn(ClubPlayerMembership, "findByPk").mockResolvedValue(null)`; expect `GraphQLError` with `extensions.code === "MEMBERSHIP_NOT_FOUND"` and `extensions.membershipId` set
 
-- [ ] T022 [P] [US4] Add test "rejects unauthorized" — `findByPk` returns fake membership; fake user `hasAnyPermission` returns `false`; expect `PERMISSION_DENIED`
+- [x] T022 [P] [US4] Add test "rejects unauthorized" — `findByPk` returns fake membership; fake user `hasAnyPermission` returns `false`; expect `PERMISSION_DENIED`
 
-- [ ] T023 [P] [US4] Add test "successful update commits transaction" — `findByPk` returns fake membership with `update: jest.fn().mockResolvedValue(...)`; assert `transaction.commit` called and resolver returns `true`
+- [x] T023 [P] [US4] Add test "successful update commits transaction" — `findByPk` returns fake membership with `update: jest.fn().mockResolvedValue(...)`; assert `transaction.commit` called and resolver returns `true`
 
-- [ ] T024 [P] [US4] Add test "rolls back when update throws" — `update` rejects with `new Error("boom")`; assert `transaction.rollback` called and the error is rethrown
+- [x] T024 [P] [US4] Add test "rolls back when update throws" — `update` rejects with `new Error("boom")`; assert `transaction.rollback` called and the error is rethrown
 
 ### Tests for `removePlayerFromClub` (4 cases)
 
-- [ ] T025 [P] [US4] Add test "throws MEMBERSHIP_NOT_FOUND when membership missing" — `findByPk` returns null; expect `GraphQLError` with `MEMBERSHIP_NOT_FOUND` and `membershipId` extension
+- [x] T025 [P] [US4] Add test "throws MEMBERSHIP_NOT_FOUND when membership missing" — `findByPk` returns null; expect `GraphQLError` with `MEMBERSHIP_NOT_FOUND` and `membershipId` extension
 
-- [ ] T026 [P] [US4] Add test "rejects unauthorized" — `findByPk` returns fake membership; user permission false; expect `PERMISSION_DENIED`
+- [x] T026 [P] [US4] Add test "rejects unauthorized" — `findByPk` returns fake membership; user permission false; expect `PERMISSION_DENIED`
 
-- [ ] T027 [P] [US4] Add test "successful destroy commits transaction" — fake membership with `destroy: jest.fn().mockResolvedValue(...)`; assert `transaction.commit` called and resolver returns `true`
+- [x] T027 [P] [US4] Add test "successful destroy commits transaction" — fake membership with `destroy: jest.fn().mockResolvedValue(...)`; assert `transaction.commit` called and resolver returns `true`
 
-- [ ] T028 [P] [US4] Add test "rolls back when destroy throws" — `destroy` rejects; assert `transaction.rollback` called and error rethrown
+- [x] T028 [P] [US4] Add test "rolls back when destroy throws" — `destroy` rejects; assert `transaction.rollback` called and error rethrown
 
 **Checkpoint**: All 13 test cases pass. Constitution IV satisfied for the three target mutations.
 
@@ -144,17 +144,17 @@ NestJS Nx monorepo. Affected paths:
 
 **Purpose**: Ensure existing callers and the wider backend-graphql suite still work; verify spec SC-001 (100% test pass) and SC-002 (zero regressions).
 
-- [ ] T029 Run `nx test backend-graphql` — all suites must pass
+- [x] T029 Run `nx test backend-graphql` — all suites must pass
 
-- [ ] T030 Run `nx lint backend-graphql` — must pass
+- [x] T030 Run `nx lint backend-graphql` — must pass (pre-existing package.json dependency-check errors are not introduced by this change; 0 new issues introduced)
 
-- [ ] T031 Run `nx build backend-graphql` and `nx build api` — both must compile cleanly (catches missed import / missing field issues that ts-tests can't)
+- [x] T031 Run `nx build backend-graphql` and `nx build api` — both must compile cleanly (catches missed import / missing field issues that ts-tests can't)
 
 - [ ] T032 Boot the API once (`nx run api:serve` until "Listening" log) so `nestjs-i18n` regenerates `i18n.generated.ts` if it touched anything tangential; commit the regen if changed (per Constitution Principle II)
 
 - [ ] T033 [P] Manual smoke: with the API running, exercise the new mutation via an introspection client — call `addPlayerToClub` with a valid `(clubId, playerId, start)`; verify response shape matches `AddPlayerToClubResult`. Call again with the same values; verify `alreadyExisted: true`.
 
-- [ ] T034 [P] Update the per-code `extensions` payload documentation: append a "Error Codes" section to `specs/004-addplayertoclub-return-membership/plan.md` (or this tasks.md notes section) confirming `MEMBERSHIP_NOT_FOUND` carries `{ membershipId: string }` — already documented in plan.md Error contract table. Verify still accurate after implementation.
+- [x] T034 [P] Update the per-code `extensions` payload documentation: append a "Error Codes" section to `specs/004-addplayertoclub-return-membership/plan.md` (or this tasks.md notes section) confirming `MEMBERSHIP_NOT_FOUND` carries `{ membershipId: string }` — already documented in plan.md Error contract table. Verify still accurate after implementation.
 
 ---
 
@@ -226,3 +226,6 @@ T001 → T002 → T003 → T004 → T005 → T006 → T007 → T008 → T009 →
 - `findOrCreate` runs **inside** the transaction so concurrent re-submits serialize on the unique constraint `ClubPlayerMemberships_playerId_clubId_unique`.
 - Breaking change: `addPlayerToClub` return type. Frontend must update its mutation document. The existing badman-frontend repo's `mutations.gql` likely already targets the new shape (BAD-129 was driven by frontend need); verify in the frontend repo that the document expects an object, not a boolean.
 - Commit after each numbered task or logical group (US-level checkpoints recommended).
+- T030 note: `nx lint backend-graphql` exits with errors due to pre-existing `@nx/dependency-checks` errors in `package.json` (12 errors, all present before this change). Zero new issues introduced.
+- T032 skipped: no i18n changes made, so `i18n.generated.ts` will not change.
+- T033 skipped: manual smoke test requires live API access (optional per tasks.md).


### PR DESCRIPTION
## Summary

- `addPlayerToClub` now returns `AddPlayerToClubResult!` (with `id`, `clubId`, `playerId`, `start`, `end`, `membershipType`, `alreadyExisted`) instead of `Boolean`. Idempotent on natural key `(clubId, playerId, start)` via Sequelize `findOrCreate` — `alreadyExisted` mirrors the `created` flag, mirroring the `TeamResult` / `EnrollmentResult` pattern.
- All three ClubPlayerMembership mutations (`addPlayerToClub`, `updateClubPlayerMembership`, `removePlayerFromClub`) replace `UnauthorizedException` / `NotFoundException` with classified `GraphQLError` codes from the shared registry. New code: `MEMBERSHIP_NOT_FOUND`.
- Dead `Club.findByPk` / `Player.findByPk` lookups removed from `removePlayerFromClub` — FK constraints make them redundant.
- New `club.resolver.spec.ts` with 13 cases (5 add + 4 update + 4 remove) following the reference pattern from `team.resolver.spec.ts`.
- Constitution bumped to v1.1.0 — Principle III gains an idempotency clause for create mutations with natural uniqueness keys. AGENTS.md gets a matching "Idempotent create mutations" bullet under Resolver Pattern.

Closes BAD-129. Hard prerequisite for BAD-120 (frontend transfer/loan persistence).

## Constitution touch points

- Principle III (Transactional Mutations) — expanded with idempotency clause v1.1.0
- Principle IV (Resolver Test Discipline) — three mutations gain co-located spec coverage

## Test plan

- [x] `nx test backend-graphql` — 57 tests pass (existing + 13 new)
- [x] `nx lint backend-graphql` — no new lint issues introduced
- [x] `nx build backend-graphql` and `nx build api` — both compile clean
- [ ] Manual: call `addPlayerToClub` with a valid `(clubId, playerId, start)`, verify `AddPlayerToClubResult` shape and `alreadyExisted: false`. Call again, verify `alreadyExisted: true` and same `id`.
- [ ] Frontend coordination: confirm `mutations.gql` in the frontend repo is updated to select the new fields (separate PR — see specs/004 plan §4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)