### PR TITLE
feat(club): typed clubMembership filter on Club.players (BAD-132)

### DIFF
--- a/.maqa/state.json
+++ b/.maqa/state.json
@@ -1,0 +1,19 @@
+{
+  "features": {
+    "001-fix-enrollment-submit-error": {
+      "status": "done"
+    },
+    "002-team-resolver-improvements": {
+      "status": "done"
+    },
+    "003-linear-bad-127": {
+      "status": "done"
+    },
+    "005-club-players-nested-where": {
+      "status": "done",
+      "board": "linear",
+      "card_id": "BAD-132",
+      "branch": "005-club-players-nested-where"
+    }
+  }
+}

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/003-linear-bad-127"
+  "feature_directory": "specs/005-club-players-nested-where"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,6 @@ Long-form internal docs live under [`docs/`](docs/). Skim the relevant ones befo
 
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-[specs/003-linear-bad-127/plan.md](specs/003-linear-bad-127/plan.md)
+[specs/005-club-players-nested-where/plan.md](specs/005-club-players-nested-where/plan.md)
 
 <!-- SPECKIT END -->

--- a/libs/backend/graphql/src/resolvers/club/club-membership-filter.input.ts
+++ b/libs/backend/graphql/src/resolvers/club/club-membership-filter.input.ts
@@ -1,0 +1,41 @@
+import { Field, ID, InputType } from "@nestjs/graphql";
+
+@InputType({
+  description:
+    "Filter Club.players by associated ClubPlayerMembership fields. Supplying this argument (even as {}) opts the call into 'include unconfirmed memberships' behavior; omitting it preserves the legacy implicit confirmed=true filter.",
+})
+export class ClubMembershipFilterInput {
+  @Field(() => [ID], {
+    nullable: true,
+    description:
+      "Match memberships whose id is in this list (SQL IN). Empty array means 'no match'.",
+  })
+  id?: string[];
+
+  @Field(() => [String], {
+    nullable: true,
+    description:
+      "Match memberships whose membershipType is in this list (SQL IN). Allowed values: NORMAL, LOAN.",
+  })
+  membershipType?: string[];
+
+  @Field(() => Date, {
+    nullable: true,
+    description: "Match memberships where start <= startBefore.",
+  })
+  startBefore?: Date;
+
+  @Field(() => Date, {
+    nullable: true,
+    description:
+      "Match memberships where end >= endAfter (NULL end excluded). To include open-ended memberships, the caller must run a separate query or accept the exclusion.",
+  })
+  endAfter?: Date;
+
+  @Field(() => Boolean, {
+    nullable: true,
+    description:
+      "Exact match on confirmed. Omit to include both confirmed and unconfirmed (when this argument is supplied at all).",
+  })
+  confirmed?: boolean;
+}

--- a/libs/backend/graphql/src/resolvers/club/club.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/club/club.resolver.spec.ts
@@ -1,0 +1,203 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { Sequelize } from "sequelize-typescript";
+import { FindOptions, Op } from "sequelize";
+import { Club, ClubPlayerMembership, Player } from "@badman/backend-database";
+import { ClubsResolver } from "./club.resolver";
+import { ClubMembershipFilterInput } from "./club-membership-filter.input";
+
+describe("ClubsResolver", () => {
+  let resolver: ClubsResolver;
+  let mockTransaction: { commit: jest.Mock; rollback: jest.Mock };
+
+  beforeEach(async () => {
+    mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ClubsResolver,
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+        },
+      ],
+    }).compile();
+    resolver = module.get<ClubsResolver>(ClubsResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("players()", () => {
+    const makeListArgs = (whereOverride?: Record<string, unknown>) => ({
+      skip: undefined,
+      take: undefined,
+      where: whereOverride,
+      order: undefined,
+    });
+
+    function setupFakeClub(resolvedPlayers: unknown[] = []) {
+      let capturedOptions: FindOptions;
+      const fakeClub = { getPlayers: jest.fn() } as unknown as Club;
+      jest.spyOn(Club, "findByPk").mockResolvedValue(fakeClub);
+      (fakeClub.getPlayers as jest.Mock).mockImplementation((opts: FindOptions) => {
+        capturedOptions = opts;
+        return Promise.resolve(resolvedPlayers);
+      });
+      return {
+        fakeClub,
+        getOptions: () => capturedOptions,
+      };
+    }
+
+    it("omitted clubMembership preserves legacy confirmed=true filter", async () => {
+      const { fakeClub, getOptions } = setupFakeClub([]);
+
+      await resolver.players(fakeClub, makeListArgs() as never, true, undefined);
+
+      const opts = getOptions();
+      const confirmedKey = `$${ClubPlayerMembership.name}.confirmed$`;
+      expect((opts.where as Record<string, unknown>)[confirmedKey]).toBe(true);
+    });
+
+    it("clubMembership: {} opts in (LEFT JOIN, no implicit confirmed)", async () => {
+      const { fakeClub, getOptions } = setupFakeClub([]);
+      const filter: ClubMembershipFilterInput = {};
+
+      await resolver.players(fakeClub, makeListArgs() as never, true, filter);
+
+      const opts = getOptions();
+      const confirmedKey = `$${ClubPlayerMembership.name}.confirmed$`;
+      // Legacy confirmed key should NOT be present — either where is undefined or doesn't have the key
+      const whereObj = (opts.where as Record<string, unknown>) ?? {};
+      expect(whereObj[confirmedKey]).toBeUndefined();
+      // Include should be present with required: false (LEFT JOIN)
+      const includes = opts.include as unknown[];
+      expect(includes).toBeDefined();
+      const membershipInclude = (includes as Array<Record<string, unknown>>).find(
+        (i) => i["as"] === "ClubPlayerMembership"
+      );
+      expect(membershipInclude).toBeDefined();
+      expect(membershipInclude!["required"]).toBe(false);
+    });
+
+    it("LOAN + season window returns matching memberships including unconfirmed", async () => {
+      const { fakeClub, getOptions } = setupFakeClub([]);
+      const startBefore = new Date("2026-04-30");
+      const endAfter = new Date("2025-09-01");
+      const filter: ClubMembershipFilterInput = {
+        membershipType: ["LOAN"],
+        startBefore,
+        endAfter,
+      };
+
+      await resolver.players(fakeClub, makeListArgs() as never, true, filter);
+
+      const opts = getOptions();
+      const includes = opts.include as Array<Record<string, unknown>>;
+      const membershipInclude = includes.find((i) => i["as"] === "ClubPlayerMembership");
+      expect(membershipInclude).toBeDefined();
+      expect(membershipInclude!["required"]).toBe(true);
+      const where = membershipInclude!["where"] as Record<string, unknown>;
+      expect(where["membershipType"]).toEqual({ [Op.in]: ["LOAN"] });
+      expect(where["start"]).toEqual({ [Op.lte]: startBefore });
+      expect(where["end"]).toEqual({ [Op.gte]: endAfter });
+      // No legacy confirmed filter
+      const confirmedKey = `$${ClubPlayerMembership.name}.confirmed$`;
+      const whereObj = (opts.where as Record<string, unknown>) ?? {};
+      expect(whereObj[confirmedKey]).toBeUndefined();
+    });
+
+    it("empty result is not an error", async () => {
+      const { fakeClub } = setupFakeClub([]);
+      const filter: ClubMembershipFilterInput = {
+        membershipType: ["LOAN"],
+        startBefore: new Date("2026-04-30"),
+        endAfter: new Date("2025-09-01"),
+      };
+
+      const result = await resolver.players(fakeClub, makeListArgs() as never, true, filter);
+
+      expect(result).toEqual([]);
+    });
+
+    it("NORMAL + confirmed:false + season window returns transfers", async () => {
+      const { fakeClub, getOptions } = setupFakeClub([]);
+      const startBefore = new Date("2026-04-30");
+      const endAfter = new Date("2025-09-01");
+      const filter: ClubMembershipFilterInput = {
+        membershipType: ["NORMAL"],
+        confirmed: false,
+        startBefore,
+        endAfter,
+      };
+
+      await resolver.players(fakeClub, makeListArgs() as never, true, filter);
+
+      const opts = getOptions();
+      const includes = opts.include as Array<Record<string, unknown>>;
+      const membershipInclude = includes.find((i) => i["as"] === "ClubPlayerMembership");
+      expect(membershipInclude).toBeDefined();
+      const where = membershipInclude!["where"] as Record<string, unknown>;
+      expect(where["membershipType"]).toEqual({ [Op.in]: ["NORMAL"] });
+      expect(where["confirmed"]).toBe(false);
+      expect(where["start"]).toEqual({ [Op.lte]: startBefore });
+      expect(where["end"]).toEqual({ [Op.gte]: endAfter });
+      const confirmedKey = `$${ClubPlayerMembership.name}.confirmed$`;
+      const whereObj = (opts.where as Record<string, unknown>) ?? {};
+      expect(whereObj[confirmedKey]).toBeUndefined();
+    });
+
+    it("explicit confirmed: false does not inject legacy filter", async () => {
+      const { fakeClub, getOptions } = setupFakeClub([]);
+      const filter: ClubMembershipFilterInput = { confirmed: false };
+
+      await resolver.players(fakeClub, makeListArgs() as never, true, filter);
+
+      const opts = getOptions();
+      const includes = opts.include as Array<Record<string, unknown>>;
+      const membershipInclude = includes.find((i) => i["as"] === "ClubPlayerMembership");
+      expect(membershipInclude).toBeDefined();
+      const where = membershipInclude!["where"] as Record<string, unknown>;
+      expect(where["confirmed"]).toBe(false);
+      const confirmedKey = `$${ClubPlayerMembership.name}.confirmed$`;
+      const whereObj = (opts.where as Record<string, unknown>) ?? {};
+      expect(whereObj[confirmedKey]).toBeUndefined();
+    });
+
+    it("empty id array short-circuits to empty result", async () => {
+      const { fakeClub } = setupFakeClub([]);
+      const filter: ClubMembershipFilterInput = { id: [] };
+
+      const result = await resolver.players(fakeClub, makeListArgs() as never, true, filter);
+
+      expect(result).toEqual([]);
+      expect(fakeClub.getPlayers).not.toHaveBeenCalled();
+    });
+
+    it("membership filter composes with player-level where", async () => {
+      const { fakeClub, getOptions } = setupFakeClub([]);
+      const filter: ClubMembershipFilterInput = { membershipType: ["LOAN"] };
+      const listArgsWithWhere = makeListArgs({ firstName: { [Op.eq]: "Anna" } });
+
+      await resolver.players(fakeClub, listArgsWithWhere as never, true, filter);
+
+      const opts = getOptions();
+      // Player-level where should include firstName filter
+      expect(opts.where).toMatchObject({ firstName: { [Op.eq]: "Anna" } });
+      // Membership include should also be present
+      const includes = opts.include as Array<Record<string, unknown>>;
+      const membershipInclude = includes.find((i) => i["as"] === "ClubPlayerMembership");
+      expect(membershipInclude).toBeDefined();
+      const where = membershipInclude!["where"] as Record<string, unknown>;
+      expect(where["membershipType"]).toEqual({ [Op.in]: ["LOAN"] });
+    });
+
+    it("single-query: getPlayers called once for 50-row result", async () => {
+      const fiftyPlayers = Array.from({ length: 50 }, (_, i) => ({ id: `player-${i}` }));
+      const { fakeClub } = setupFakeClub(fiftyPlayers as unknown[]);
+      const filter: ClubMembershipFilterInput = { membershipType: ["NORMAL"] };
+
+      await resolver.players(fakeClub, makeListArgs() as never, true, filter);
+
+      expect(fakeClub.getPlayers).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/club/club.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/club/club.resolver.ts
@@ -31,6 +31,7 @@ import {
 import { Op } from "sequelize";
 import { Sequelize } from "sequelize-typescript";
 import { ListArgs } from "../../utils";
+import { ClubMembershipFilterInput } from "./club-membership-filter.input";
 
 @ObjectType()
 export class PagedClub {
@@ -93,11 +94,52 @@ export class ClubsResolver {
   async players(
     @Parent() club: Club,
     @Args() listArgs: ListArgs,
-    @Args("active", { type: () => Boolean, nullable: true, defaultValue: true }) active = true
+    @Args("active", { type: () => Boolean, nullable: true, defaultValue: true }) active = true,
+    @Args("clubMembership", { type: () => ClubMembershipFilterInput, nullable: true })
+    clubMembership?: ClubMembershipFilterInput
   ): Promise<(Player & { ClubMembership: ClubPlayerMembership })[] | Player[] | undefined> {
     const options = ListArgs.toFindOptions(listArgs);
 
-    if (active) {
+    const optingIn = clubMembership !== undefined && clubMembership !== null;
+
+    if (optingIn) {
+      if (clubMembership.id !== undefined && clubMembership.id.length === 0) {
+        return [];
+      }
+
+      const membershipWhere: Record<string, unknown> = {};
+      if (clubMembership.id?.length) {
+        membershipWhere["id"] = { [Op.in]: clubMembership.id };
+      }
+      if (clubMembership.membershipType?.length) {
+        membershipWhere["membershipType"] = { [Op.in]: clubMembership.membershipType };
+      }
+      if (clubMembership.startBefore !== undefined) {
+        membershipWhere["start"] = { [Op.lte]: clubMembership.startBefore };
+      }
+      if (clubMembership.endAfter !== undefined) {
+        membershipWhere["end"] = { [Op.gte]: clubMembership.endAfter };
+      }
+      if (clubMembership.confirmed !== undefined) {
+        membershipWhere["confirmed"] = clubMembership.confirmed;
+      }
+
+      const anyFieldSet = Object.keys(membershipWhere).length > 0;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const existingIncludes: any[] = Array.isArray(options.include) ? options.include : [];
+      options.include = [
+        ...existingIncludes,
+        {
+          model: ClubPlayerMembership,
+          as: "ClubPlayerMembership",
+          required: anyFieldSet,
+          where: anyFieldSet ? membershipWhere : undefined,
+        },
+      ];
+    }
+
+    if (active && !optingIn) {
       /*
       see: ClubPlayerMembership.active
       // but this prevents fetching it from the database to speed up the query

--- a/specs/005-club-players-nested-where/checklists/requirements.md
+++ b/specs/005-club-players-nested-where/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Filter Club Players by Membership Fields
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec populated from Linear BAD-132. Ready for `/speckit-plan`.

--- a/specs/005-club-players-nested-where/data-model.md
+++ b/specs/005-club-players-nested-where/data-model.md
@@ -1,0 +1,116 @@
+# Data Model: Filter Club Players by Membership Fields
+
+**Branch**: `005-club-players-nested-where` | **Date**: 2026-04-30 (revised after BAD-132 v2)
+
+## No schema changes (no DB migration)
+
+GraphQL schema + resolver level only.
+
+## Existing entities (read-only references)
+
+### Player — `libs/backend/database/src/models/player.model.ts`
+Returned by the resolver. No changes.
+
+### ClubPlayerMembership — `libs/backend/database/src/models/club-player-membership.model.ts`
+Through-model. Fields used by the filter:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | UUID | Filterable via `id: [ID!]` |
+| `membershipType` | enum (`NORMAL`, `LOAN`) | Filterable via `membershipType: [String!]` |
+| `start` | Date | Filterable upper-bound via `startBefore: DateTime` (`start <= startBefore`) |
+| `end` | Date \| null | Filterable lower-bound via `endAfter: DateTime` (`end >= endAfter`) |
+| `confirmed` | boolean | Filterable via `confirmed: Boolean` (exact match) |
+| `active` (virtual) | boolean | **NOT exposed** in the input (clarify Q2) |
+
+### Club — `libs/backend/database/src/models/club.model.ts`
+Owns the `players` BelongsToMany association. No changes.
+
+## New GraphQL input type
+
+### ClubMembershipFilterInput
+
+File: `libs/backend/graphql/src/resolvers/club/club-membership-filter.input.ts` (NEW)
+
+```ts
+import { Field, ID, InputType } from "@nestjs/graphql";
+
+@InputType({
+  description:
+    "Filter Club.players by associated ClubPlayerMembership fields. Supplying this argument (even as {}) opts the call into 'include unconfirmed memberships' behavior; omitting it preserves the legacy implicit confirmed=true filter.",
+})
+export class ClubMembershipFilterInput {
+  @Field(() => [ID], { nullable: true, description: "Match memberships whose id is in this list (SQL IN). Empty array means 'no match'." })
+  id?: string[];
+
+  @Field(() => [String], { nullable: true, description: "Match memberships whose membershipType is in this list (SQL IN). Allowed values: NORMAL, LOAN." })
+  membershipType?: string[];
+
+  @Field(() => Date, { nullable: true, description: "Match memberships where start <= startBefore." })
+  startBefore?: Date;
+
+  @Field(() => Date, { nullable: true, description: "Match memberships where end >= endAfter (NULL end excluded). To include open-ended memberships, the caller must run a separate query or accept the exclusion." })
+  endAfter?: Date;
+
+  @Field(() => Boolean, { nullable: true, description: "Exact match on confirmed. Omit to include both confirmed and unconfirmed (when this argument is supplied at all)." })
+  confirmed?: boolean;
+}
+```
+
+## Resolver argument additions
+
+`Club.players` field arg list:
+
+```graphql
+# Before
+players(skip: Int, take: Int, where: JSONObject, order: [SortOrderType!], active: Boolean): [PlayerWithClubMembershipType!]!
+
+# After
+players(
+  skip: Int,
+  take: Int,
+  where: JSONObject,
+  order: [SortOrderType!],
+  active: Boolean,
+  clubMembership: ClubMembershipFilterInput   # ← NEW
+): [PlayerWithClubMembershipType!]!
+```
+
+## Filter translation rules
+
+For each field present on `clubMembership`, the resolver builds a Sequelize `where` object on the through-model:
+
+| Input field | SQL where built |
+|-------------|-----------------|
+| `id: ["uuid-1", "uuid-2"]` | `{ [Op.in]: ["uuid-1", "uuid-2"] }` keyed by `id` |
+| `id: []` | `{ [Op.in]: [] }` — Postgres `IN ()` returns zero rows; resolver may short-circuit to empty result |
+| `membershipType: ["LOAN"]` | `{ [Op.in]: ["LOAN"] }` keyed by `membershipType` |
+| `startBefore: <date>` | `{ [Op.lte]: <date> }` keyed by `start` |
+| `endAfter: <date>` | `{ [Op.gte]: <date> }` keyed by `end` |
+| `confirmed: true` | `{ [Op.eq]: true }` keyed by `confirmed` |
+
+The combined where is attached to `include: [{ model: ClubPlayerMembership, as: 'ClubPlayerMembership', required: <bool>, where: <built> }]` in the `findAll` options. `required` toggles between `INNER` and `LEFT` JOIN per FR-008:
+
+| `clubMembership` arg | JOIN | Implicit `confirmed=true` |
+|----------------------|------|--------------------------|
+| omitted | (current behavior — implicit dollar-syntax filter on through-model) | YES (preserved) |
+| `{}` (empty) | `LEFT` (defensive) | NO |
+| any field set | `INNER` (`required: true`) | NO |
+
+## Implicit `confirmed = true` removal — behavioral spec
+
+The resolver currently injects `[ $ClubPlayerMembership.confirmed$ ]: true` into `where` whenever `active=true` (default). After this change:
+
+```ts
+const opting_in = clubMembership !== undefined && clubMembership !== null;
+if (active && !opting_in) {
+  // legacy path — preserve today's behavior
+  options.where = { ...options.where, [`$${ClubPlayerMembership.name}.confirmed$`]: true };
+}
+```
+
+When `opting_in` is true, the `confirmed` filter (if any) comes solely from `clubMembership.confirmed`. If that field is omitted, no `confirmed` filter is applied.
+
+## No state transitions
+
+Query-side feature. No write paths or lifecycle changes.

--- a/specs/005-club-players-nested-where/plan.md
+++ b/specs/005-club-players-nested-where/plan.md
@@ -1,0 +1,270 @@
+# Implementation Plan: Filter Club Players by Membership Fields
+
+**Branch**: `005-club-players-nested-where` | **Date**: 2026-05-01 (revised after BAD-132 v3) | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Add a typed `clubMembership: ClubMembershipFilterInput` argument to the `Club.players` resolve field. Fields are concrete typed (no `JSONObject` operator maps): `id: [ID!]`, `membershipType: [String!]` → `IN`; `startBefore: DateTime` → `start <=`; `endAfter: DateTime` → `end >=`; `confirmed: Boolean` → exact match. Translation goes through Sequelize `include` with `INNER` JOIN (`required: true`) when any field is set, `LEFT` JOIN when arg is `{}`. **Critical behavioral rule**: when the arg is supplied at all, the legacy implicit `confirmed = true` filter (currently injected by the `active` arg) is suppressed — this is the load-bearing change for BAD-120's enrollment flow which persists transfers/loans with `confirmed: false`. Existing callers that omit the arg get identical behavior to today.
+
+## Technical Context
+
+**Language/Version**: TypeScript (Node.js 20, Nx monorepo)
+**Primary Dependencies**: NestJS, Sequelize + sequelize-typescript, Apollo GraphQL
+**Storage**: PostgreSQL — `ClubPlayerMembership` table in `public` schema
+**Testing**: Jest via Nx (`nx test backend-graphql`)
+**Target Platform**: Node.js API server (port 5010)
+**Project Type**: NestJS Nx monorepo — `@badman/backend-graphql` only
+**Performance Goals**: One SQL query per resolver call (FR-009).
+**Constraints**: No DB schema changes. Backward-compatible: callers without `clubMembership` arg behave exactly as today (implicit `confirmed = true` preserved).
+**Scale/Scope**: One resolver field touched + one new input type + tests.
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Code-First GraphQL via Sequelize Models | PASS | New `@InputType` `ClubMembershipFilterInput` is a thin filter container; references the existing through-model. No duplicate entity. |
+| II. Translation Discipline | PASS | No i18n changes. |
+| III. Transactional Mutations | N/A | Query field. |
+| IV. Resolver Test Discipline | REQUIRES WORK | New tests added covering FR-001..FR-010. |
+| V. Legacy Frontend Boundary | PASS | No frontend changes. |
+
+No violations.
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/005-club-players-nested-where/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 findings (revised)
+├── data-model.md        ← Phase 1 input type + translation rules (revised)
+└── tasks.md             ← Phase 2 output (/speckit-tasks)
+```
+
+### Source Code
+
+```text
+libs/backend/graphql/src/resolvers/club/
+├── club-membership-filter.input.ts    ← NEW @InputType
+├── club.resolver.ts                   ← extend players() resolve field
+├── club.module.ts                     ← (likely auto-discovered, verify)
+└── club.resolver.spec.ts              ← NEW or extend with players() filter cases
+```
+
+## Phase 0: Research (complete)
+
+See [research.md](research.md). Key decisions:
+
+1. Typed input fields (no operator maps), pre-baked semantics per field name.
+2. Arg presence as opt-in signal — supplying `clubMembership` (even `{}`) drops the implicit `confirmed = true` filter.
+3. `INNER JOIN` when any filter field set; `LEFT JOIN` for empty `{}`.
+4. `id: []` short-circuits to empty result.
+5. `endAfter` excludes NULL `end` (open-ended memberships) — caller's responsibility.
+6. `active` virtual not exposed.
+
+## Phase 1: Design & Contracts
+
+See [data-model.md](data-model.md). No DB changes.
+
+### GraphQL contract delta
+
+```graphql
+input ClubMembershipFilterInput {
+  id:             [ID!]
+  membershipType: [String!]
+  startBefore:    DateTime
+  endAfter:       DateTime
+  confirmed:      Boolean
+}
+
+type Club {
+  players(
+    skip: Int,
+    take: Int,
+    where: JSONObject,
+    order: [SortOrderType!],
+    active: Boolean,
+    clubMembership: ClubMembershipFilterInput   # NEW
+  ): [PlayerWithClubMembershipType!]!
+}
+```
+
+### Behavioral table (from data-model.md)
+
+| `clubMembership` arg | `confirmed` field | Filter applied | JOIN |
+|----------------------|-------------------|----------------|------|
+| omitted | n/a | implicit `confirmed = true` (legacy preserved) | (current path) |
+| `{}` | omitted | no `confirmed` filter | LEFT |
+| any field set, `confirmed` omitted | omitted | no `confirmed` filter | INNER |
+| any field set, `confirmed: true` | `true` | `confirmed = true` | INNER |
+| any field set, `confirmed: false` | `false` | `confirmed = false` | INNER |
+
+### Implementation steps (ordered)
+
+#### Step 1 — Create `ClubMembershipFilterInput`
+
+**File**: `libs/backend/graphql/src/resolvers/club/club-membership-filter.input.ts` (NEW)
+
+Per data-model.md "New GraphQL input type". Five typed fields. Field-level descriptions explaining `startBefore`/`endAfter` semantics and the `endAfter` NULL-end exclusion.
+
+#### Step 2 — Extend `Club.players` resolver
+
+**File**: `libs/backend/graphql/src/resolvers/club/club.resolver.ts:92`
+
+Add the new arg:
+
+```ts
+@Args("clubMembership", { type: () => ClubMembershipFilterInput, nullable: true })
+clubMembership?: ClubMembershipFilterInput,
+```
+
+Build the through-model where + include:
+
+```ts
+const optingIn = clubMembership !== undefined && clubMembership !== null;
+
+if (optingIn) {
+  // Empty array on `id` means "match nothing" — short-circuit
+  if (clubMembership.id !== undefined && clubMembership.id.length === 0) {
+    return [];
+  }
+
+  const membershipWhere: Record<string, unknown> = {};
+  if (clubMembership.id?.length) {
+    membershipWhere.id = { [Op.in]: clubMembership.id };
+  }
+  if (clubMembership.membershipType?.length) {
+    membershipWhere.membershipType = { [Op.in]: clubMembership.membershipType };
+  }
+  if (clubMembership.startBefore !== undefined) {
+    membershipWhere.start = { [Op.lte]: clubMembership.startBefore };
+  }
+  if (clubMembership.endAfter !== undefined) {
+    membershipWhere.end = { [Op.gte]: clubMembership.endAfter };
+  }
+  if (clubMembership.confirmed !== undefined) {
+    membershipWhere.confirmed = clubMembership.confirmed;
+  }
+
+  const anyFieldSet = Object.keys(membershipWhere).length > 0;
+
+  options.include = [
+    ...(options.include ?? []),
+    {
+      model: ClubPlayerMembership,
+      as: "ClubPlayerMembership", // verified alias — see club.model.ts:124–126
+      required: anyFieldSet, // INNER when any field set; LEFT for `{}`
+      where: anyFieldSet ? membershipWhere : undefined,
+    },
+  ];
+}
+```
+
+Adjust the `active=true` branch to skip when opting in:
+
+```ts
+if (active && !optingIn) {
+  // Legacy path — preserve today's behavior for callers that don't pass the arg
+  options.where = {
+    ...options.where,
+    [`$${ClubPlayerMembership.name}.confirmed$`]: true,
+  };
+}
+```
+
+(The original `active`-branch had commented-out time-bounded filters; leave them commented exactly as today. They are not part of this fix.)
+
+#### Step 3 — Module registration
+
+**File**: `libs/backend/graphql/src/resolvers/club/club.module.ts`
+
+NestJS code-first auto-discovers `@InputType` classes via the resolver's import statement. The new file is referenced by `club.resolver.ts` — that's enough. Verify `nx build api` succeeds. If a type-not-registered error surfaces, follow the precedent for other input types in the codebase.
+
+#### Step 4 — Tests
+
+**File**: `libs/backend/graphql/src/resolvers/club/club.resolver.spec.ts`
+
+If the file exists from spec 004 (depends on merge state), append cases. Otherwise create following `team.resolver.spec.ts` pattern.
+
+Mock setup:
+
+```ts
+const fakeClub = {
+  getPlayers: jest.fn().mockResolvedValue([fakePlayer1, fakePlayer2]),
+} as unknown as Club;
+jest.spyOn(Club, "findByPk").mockResolvedValue(fakeClub);
+```
+
+Cases:
+
+1. **No `clubMembership` arg, `active=true`** → `getPlayers` called once; `where` includes `$ClubPlayerMembership.confirmed$ = true`; no `include` for through-model added.
+2. **`clubMembership: {}`** → `where` does NOT include `$confirmed$`; `include` present with `required: false`.
+3. **`clubMembership: { membershipType: ["LOAN"] }`** → `include` has `required: true` and `where.membershipType: { [Op.in]: ["LOAN"] }`.
+4. **`clubMembership: { startBefore: <date>, endAfter: <date> }`** → `include.where` has both `start: { [Op.lte] }` and `end: { [Op.gte] }`.
+5. **`clubMembership: { confirmed: false }`** → `include.where.confirmed === false`; legacy `$confirmed$=true` not injected.
+6. **`clubMembership: { membershipType: ["NORMAL"], confirmed: false, startBefore: <date>, endAfter: <date> }`** → `include.where` has `membershipType IN`, `confirmed: false`, `start: { [Op.lte] }`, `end: { [Op.gte] }`.
+7. **`clubMembership: { id: [] }`** → returns `[]` immediately; `getPlayers` not called.
+8. **`clubMembership: { id: ["a","b"] }` + `where: { firstName: { $eq: "Anna" } }`** → both filter sets present in the call.
+9. **Single-query assertion** — spy `Sequelize.prototype.query`, expect exactly 1 call for a multi-row result.
+
+#### Step 5 — Polish
+
+- `nx test backend-graphql` — must pass (existing + new cases)
+- `nx lint backend-graphql` — must pass
+- `nx build backend-graphql` and `nx build api` — must compile
+- Manual probe: with API running, call `players(clubMembership: {})` against a club known to have unconfirmed memberships (e.g. `4699bcdd-f6db-48ea-81aa-f79acdf47a7c` per BAD-132 references); verify count grows vs. `players()` without the arg.
+
+## Quickstart
+
+After this lands, BAD-120 frontend queries become:
+
+```graphql
+# Load LOAN memberships for the current enrollment season (incl. unconfirmed)
+query GetClubLoans($clubId: ID!, $startBefore: DateTime!, $endAfter: DateTime!) {
+  club(id: $clubId) {
+    id
+    players(clubMembership: {
+      membershipType: ["LOAN"]
+      startBefore: $startBefore
+      endAfter: $endAfter
+    }) {
+      id memberId firstName lastName fullName gender
+      clubMembership { id membershipType start end confirmed }
+    }
+  }
+}
+
+# Load unconfirmed NORMAL (transfer) memberships for the current enrollment season
+query GetClubTransfers($clubId: ID!, $startBefore: DateTime!, $endAfter: DateTime!) {
+  club(id: $clubId) {
+    id
+    players(clubMembership: {
+      membershipType: ["NORMAL"]
+      confirmed: false
+      startBefore: $startBefore
+      endAfter: $endAfter
+    }) {
+      id memberId firstName lastName fullName gender
+      clubMembership { id membershipType start end confirmed }
+    }
+  }
+}
+
+# Step-3 SearchClubPlayers — opts in to "include unconfirmed" via empty {}
+query SearchClubPlayers($clubId: ID!, $where: JSONObject) {
+  club(id: $clubId) {
+    id
+    players(where: $where, clubMembership: {}) {
+      id memberId firstName lastName fullName gender
+      clubMembership { id membershipType start end confirmed }
+    }
+  }
+}
+```
+
+Frontend `getSeasonPeriod(season)` from `utils/date.utils.ts:13` provides the `startBefore`/`endAfter` ISO values.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.

--- a/specs/005-club-players-nested-where/research.md
+++ b/specs/005-club-players-nested-where/research.md
@@ -1,0 +1,123 @@
+# Research: Filter Club Players by Membership Fields
+
+**Branch**: `005-club-players-nested-where` | **Date**: 2026-05-01 (revised after BAD-132 v3)
+
+## Finding 1: Current `Club.players` resolver shape
+
+`libs/backend/graphql/src/resolvers/club/club.resolver.ts:92–147`. Resolves `[PlayerWithClubMembershipType]`. Args today:
+- `@Args() listArgs: ListArgs` — paged where/order/skip/take. `where` is `JSONObject` after `queryFixer()`.
+- `@Args("active", { defaultValue: true }) active`. When `true`, injects `$ClubPlayerMembership.confirmed$ = true` into `where`.
+
+**Decision**: Add a third arg `clubMembership: ClubMembershipFilterInput` (optional). When supplied, suppress the `active`-derived `confirmed` injection; build a typed where on the through-model and attach via `include`.
+
+## Finding 2: Typed-input shape (BAD-132 v3)
+
+The original spec planned `JSONObject` operator maps per field. BAD-132 v2 superseded that with concrete typed fields. BAD-132 v3 adds an explicit transfer-loading use case (`membershipType: NORMAL, confirmed: false`) as the canonical frontend pattern for identifying "transfers added during this enrollment session":
+
+- `id: [ID!]` and `membershipType: [String!]` → SQL `IN`
+- `startBefore: DateTime` → `start <= startBefore`
+- `endAfter: DateTime` → `end >= endAfter`
+- `confirmed: Boolean` → exact match (load-bearing for US2: `confirmed: false` filters to transfer-only rows)
+
+**Decision**: Adopt verbatim. The `confirmed: false` + date-range combination is the primary transfer-loading pattern. The `id` field remains in the schema for future use but is no longer a primary user story.
+
+**Trade-off**: New operators (e.g. `between`, `not in`) require schema additions, not just new operator constants. Acceptable — the field set is small and stable.
+
+## Finding 3: Implicit `confirmed = true` removal — opt-in via arg presence
+
+This is the load-bearing rule for BAD-120. Today every `Club.players` call gets `confirmed: true` injected (when `active=true` which is the default). BAD-120 persists transfers/loans with `confirmed: false`; today's resolver hides them.
+
+**Decision**: Use **arg presence as the opt-in signal**. If `clubMembership` is supplied (even as `{}`), the implicit filter is dropped. If omitted, current behavior is preserved.
+
+**Why this design**: Backwards compat. Every existing caller (`SearchClubPlayers`, team-composition, etc.) is unchanged. Only callers that pass the new arg get the new behavior. Step-3 `SearchClubPlayers` will be updated in the frontend to pass `clubMembership: {}` to opt in to surfacing unconfirmed members.
+
+**Alternatives considered**:
+- A new `includeUnconfirmed: Boolean` flag — explicit but easier to forget. Two args (`active` + `includeUnconfirmed`) for related concerns is confusing.
+- Removing `active` entirely — breaking change to existing callers.
+- Always filter unconfirmed — would surface unconfirmed memberships in places that don't want them.
+
+## Finding 4: JOIN strategy — INNER vs LEFT
+
+BAD-132 v3 specifies:
+- Any `clubMembership` field set → `INNER JOIN` (`required: true`)
+- `clubMembership: {}` → `LEFT JOIN` (`required: false`) "defensive — if relationship is one-to-one and required, INNER is fine, but verify"
+
+**Decision**: Use `INNER` when any field is set, `LEFT` for empty `{}`. The `Club ↔ Player` association via `ClubPlayerMembership` is one-to-many (a player can belong to multiple clubs over time), so a player-without-membership row to this club shouldn't exist. The LEFT JOIN for `{}` is defensive but harmless.
+
+**Verification needed during implementation**: Confirm that `LEFT JOIN` doesn't produce duplicate `Player` rows when a player has multiple membership rows (it shouldn't, because we're going `Club → through → Player` not `Player → through`). The existing `distinctPlayers` filter at line 143–148 already guards against duplicates.
+
+## Finding 5: `include` shape with Sequelize BelongsToMany
+
+`Club.getPlayers(options)` accepts `options.include` to add nested where on the through-model. With `BelongsToMany`, the through-model is auto-included by Sequelize when its association alias is referenced. The pattern is:
+
+```ts
+options.include = [
+  ...(options.include ?? []),
+  {
+    model: ClubPlayerMembership,
+    as: 'ClubPlayerMembership',  // verified alias from dollar-syntax usage in the resolver
+    required: <bool>,
+    where: <built>,
+  },
+];
+```
+
+**Decision**: Build the `include` entry inside the resolver. The association alias `ClubPlayerMembership` is verified from the existing dollar-syntax key `$ClubPlayerMembership.confirmed$` in the resolver today.
+
+## Finding 6: `id: []` (empty array) handling
+
+Postgres `WHERE id IN ()` is a syntax error (some Sequelize versions short-circuit, some emit `IN (NULL)`). Empty array intent is ambiguous: "match nothing" vs "match everything".
+
+**Decision**: Treat `id: []` as "match nothing" → return empty list. Implementation: short-circuit before building the include if `clubMembership.id` is an empty array. Document in the input field description so frontend doesn't accidentally rely on it.
+
+## Finding 7: `endAfter` and NULL `end` (open-ended memberships)
+
+Memberships with `end IS NULL` are open-ended (still active). `end >= endAfter` excludes NULLs. BAD-132 v3 acknowledges this and explicitly does NOT add a synthetic operator for it.
+
+**Decision**: Document the exclusion in the field description. Frontend can either accept the exclusion or run a second query for open-ended rows. **No `$or` magic on the backend** — keep the input semantics unambiguous.
+
+## Finding 8: N+1 prevention
+
+Sequelize emits a single SELECT with one JOIN when `getPlayers(options)` is called with `include`. Existing impl already does this. Adding a `where` clause to the include doesn't change the query count.
+
+**Decision**: No additional work for FR-009. Add a test that asserts `Sequelize.prototype.query` is called exactly once for a multi-row result.
+
+## Finding 9: Test pattern
+
+Reference: `team.resolver.spec.ts` and `enrollmentSetting.resolver.spec.ts`. New `club.resolver.spec.ts` if absent (or extend if 004's tests merged first).
+
+**Cases for `players` field** (BAD-132 v3):
+
+1. No `clubMembership` arg → `getPlayers` called with the `active`-derived `$confirmed$ = true` (legacy path).
+2. `clubMembership: {}` → no `confirmed` filter; `include` has `required: false` (LEFT).
+3. `clubMembership: { membershipType: ["LOAN"] }` → `include` has `required: true` (INNER) and `where: { membershipType: { [Op.in]: ["LOAN"] } }`.
+4. `clubMembership: { startBefore: "2026-04-30", endAfter: "2025-09-01" }` → `where: { start: { [Op.lte]: ... }, end: { [Op.gte]: ... } }`.
+5. `clubMembership: { confirmed: false }` → `where: { confirmed: false }`; legacy `confirmed=true` not injected.
+6. `clubMembership: { membershipType: ["NORMAL"], confirmed: false, startBefore: <date>, endAfter: <date> }` → `where` has `membershipType IN`, `confirmed: false`, `start: { [Op.lte] }`, `end: { [Op.gte] }` (US2 transfer-loading pattern).
+7. `clubMembership: { id: [] }` → returns `[]` without calling `getPlayers` (short-circuit).
+8. `clubMembership: { id: ["a","b"] }` combined with player-level `where: { firstName: { $eq: "Anna" } }` → both filter sets present.
+9. Single-query assertion: spy on `Sequelize.prototype.query`, expect 1 call.
+
+## Finding 10: GraphQL schema delta summary
+
+```graphql
+input ClubMembershipFilterInput {
+  id:             [ID!]
+  membershipType: [String!]
+  startBefore:    DateTime
+  endAfter:       DateTime
+  confirmed:      Boolean
+}
+
+# Club.players signature:
+players(
+  skip: Int,
+  take: Int,
+  where: JSONObject,
+  order: [SortOrderType!],
+  active: Boolean,
+  clubMembership: ClubMembershipFilterInput   # NEW
+): [PlayerWithClubMembershipType!]!
+```
+
+**Decision**: New `@InputType` lives at `libs/backend/graphql/src/resolvers/club/club-membership-filter.input.ts`. Field-level descriptions per data-model.md.

--- a/specs/005-club-players-nested-where/spec.md
+++ b/specs/005-club-players-nested-where/spec.md
@@ -5,6 +5,13 @@
 **Status**: Draft
 **Linear**: [BAD-132](https://linear.app/dashdot/issue/BAD-132) — Priority: Urgent
 
+## Clarifications
+
+### Session 2026-04-30
+
+- Q: How should the `Club.players` resolver accept membership-field filters? → A: Typed input — add `clubMembership: ClubMembershipFilterInput` argument with explicit, named fields (cleaner SDL, no JSONObject magic keys). The dollar-syntax and new-top-level-query options were rejected.
+- Q: Should `active` (a virtual computed field) be filterable through the typed input? → A: No — exclude `active` from `ClubMembershipFilterInput`. Callers express the same intent via `start`/`end` operators, avoiding implicit "current time" coupling.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 — Frontend loads existing LOAN memberships for an enrollment season (Priority: P1)
@@ -64,19 +71,19 @@ A single request to filter players by membership fields produces a single SQL qu
 
 ### Functional Requirements
 
-- **FR-001**: `Club.players` MUST accept a where clause whose keys reference fields on the player's club membership (e.g. `membershipType`, `start`, `end`, `confirmed`, `active`).
-- **FR-002**: A `where` clause MUST support at minimum these operators on membership fields: equal, set membership (in), less-than-or-equal, greater-than-or-equal — matching the operator vocabulary already accepted on player-level fields.
-- **FR-003**: Membership-field filters MUST compose (logical AND) with existing player-level filters within the same `where` clause.
+- **FR-001**: `Club.players` MUST accept a typed `clubMembership` argument that filters returned players by fields on their club membership: `membershipType`, `start`, `end`, `confirmed`. The virtual `active` field is intentionally excluded — callers express the same intent via `start`/`end` operators.
+- **FR-002**: The `clubMembership` filter MUST support at minimum these operators on its fields: equal, set membership (in), less-than-or-equal, greater-than-or-equal — matching the operator vocabulary already accepted on player-level fields.
+- **FR-003**: The `clubMembership` filter MUST compose (logical AND) with the existing player-level `where` argument within the same query.
 - **FR-004**: Filters MUST be applied via a database join, not by post-fetch client-side filtering.
 - **FR-005**: A single resolver call MUST emit one SQL query regardless of result-row count (no N+1).
-- **FR-006**: Existing callers that pass only player-level filters MUST continue to receive identical results to today.
-- **FR-007**: The where-clause syntax accepted by the resolver MUST be documented (example query in the spec or contract document) so the frontend can adopt it without trial-and-error.
+- **FR-006**: Existing callers that pass only the player-level `where` (no `clubMembership` argument) MUST continue to receive identical results to today.
+- **FR-007**: The `clubMembership` input type MUST be exposed in the GraphQL schema with field-level descriptions so the frontend can author queries from introspection alone.
 
 ### Key Entities
 
 - **Club**: Existing entity. Owns the `players` collection that this feature filters.
 - **Player**: Existing entity. Returned by the filter; player-level fields remain filterable as today.
-- **ClubPlayerMembership**: Existing entity. Provides the fields newly available in the where clause: `membershipType`, `start`, `end`, `confirmed`, `active`.
+- **ClubPlayerMembership**: Existing entity. Provides the fields newly available in the typed filter input: `membershipType`, `start`, `end`, `confirmed`. The virtual `active` getter is not filterable through this input.
 
 ## Success Criteria *(mandatory)*
 
@@ -89,7 +96,7 @@ A single request to filter players by membership fields produces a single SQL qu
 
 ## Assumptions
 
-- The frontend will adopt whichever where-clause syntax the backend ships (dollar-key, dotted, or typed input), as long as it satisfies FR-001 through FR-007.
+- The frontend will adopt the typed `clubMembership` argument once it ships; until then, the workaround query path stays in place.
 - The fields exposed for filtering match what already exists on the membership entity; no new columns or virtual fields are introduced as part of this change.
 - Date-range overlap (start/end) is expressed by the caller using the same operators used elsewhere — no new "between" or "overlaps" operator is required for v1; FR-002 covers the operator set.
 - Authorization on the player list is unchanged: callers who can already see a club's players today continue to see them; this feature does not add or remove visibility.

--- a/specs/005-club-players-nested-where/spec.md
+++ b/specs/005-club-players-nested-where/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: Filter Club Players by Membership Fields
+
+**Feature Branch**: `005-club-players-nested-where`
+**Created**: 2026-04-30
+**Status**: Draft
+**Linear**: [BAD-132](https://linear.app/dashdot/issue/BAD-132) — Priority: Urgent
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Frontend loads existing LOAN memberships for an enrollment season (Priority: P1)
+
+The enrollment wizard, on entry to step 2, asks the backend for the players currently registered with a club whose membership is a LOAN that overlaps the enrollment season's date range. The wizard receives only those players (with their membership details), so it can hydrate the loans panel without a second round-trip and without any client-side filtering.
+
+**Why this priority**: BAD-120 FR-011 cannot ship without this. Today the same query path either errors out or requires a workaround that inverts the join direction and complicates the wizard's hydration logic.
+
+**Independent Test**: With a club that has known LOAN memberships overlapping a chosen season, request `Club.players` with a where clause filtering on membership type and overlapping start/end dates; assert the returned player list matches the expected memberships and only those.
+
+**Acceptance Scenarios**:
+
+1. **Given** a club with three LOAN memberships in 2025-2026 and one NORMAL membership, **When** the wizard requests the club's players filtered by `membershipType = LOAN` and date overlap with the 2025-2026 season window, **Then** exactly those three LOAN players are returned with their membership details.
+2. **Given** a club with no LOAN memberships in the requested season, **When** the same filter is applied, **Then** an empty list is returned (no error).
+3. **Given** the same query combined with a player-level filter (e.g. `firstName = "Anna"`), **When** the request runs, **Then** only players matching both the membership filter and the player-level filter are returned.
+
+---
+
+### User Story 2 — Existing flat filters keep working (Priority: P1)
+
+Existing callers that already filter `Club.players` by player-level fields (e.g. autocomplete lookups, team-composition dialogs) continue to work without any change to their queries.
+
+**Why this priority**: This change must not break production flows. The flat-filter shape is in active use across the codebase.
+
+**Independent Test**: Run the existing `SearchClubPlayers` autocomplete query (or equivalent) before and after the change; assert identical results for at least three sample queries.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing query that filters players by `firstName` only, **When** the request runs after the change, **Then** results are identical to the pre-change behavior.
+2. **Given** a query mixing flat player filters and the new membership filters, **When** the request runs, **Then** both filter groups apply (logical AND) without one overriding the other.
+
+---
+
+### User Story 3 — Predictable performance under load (Priority: P2)
+
+A single request to filter players by membership fields produces a single SQL query, regardless of how many players are returned.
+
+**Why this priority**: Without this guarantee, the new capability could mask an N+1 pattern that surfaces only on large clubs and is expensive to debug post-deploy.
+
+**Independent Test**: Capture the SQL queries emitted by the resolver for a 1-player and a 50-player result set; assert the query count is the same (one per request).
+
+**Acceptance Scenarios**:
+
+1. **Given** a request that returns 50 players, **When** the request runs, **Then** the resolver emits one SQL query (one JOIN), not 51.
+2. **Given** a request that returns zero players, **When** the request runs, **Then** the resolver still emits exactly one query.
+
+---
+
+### Edge Cases
+
+- A `where` clause references a membership field on a member that does not exist on the membership entity — the system MUST return a clear error rather than silently ignoring the unknown key.
+- A `where` clause uses an operator on a membership field that is not in the supported set (`$eq`, `$in`, `$lte`, `$gte`, plus any others already supported on flat fields) — system behavior MUST match how the same unsupported operator behaves on flat player fields (consistent error or no-op, but not a different shape).
+- The membership filter matches zero players — empty list returned (already covered above; reinforces no error path).
+- The membership filter matches all players in a club — full list returned with one query (no pagination collapse, no N+1).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `Club.players` MUST accept a where clause whose keys reference fields on the player's club membership (e.g. `membershipType`, `start`, `end`, `confirmed`, `active`).
+- **FR-002**: A `where` clause MUST support at minimum these operators on membership fields: equal, set membership (in), less-than-or-equal, greater-than-or-equal — matching the operator vocabulary already accepted on player-level fields.
+- **FR-003**: Membership-field filters MUST compose (logical AND) with existing player-level filters within the same `where` clause.
+- **FR-004**: Filters MUST be applied via a database join, not by post-fetch client-side filtering.
+- **FR-005**: A single resolver call MUST emit one SQL query regardless of result-row count (no N+1).
+- **FR-006**: Existing callers that pass only player-level filters MUST continue to receive identical results to today.
+- **FR-007**: The where-clause syntax accepted by the resolver MUST be documented (example query in the spec or contract document) so the frontend can adopt it without trial-and-error.
+
+### Key Entities
+
+- **Club**: Existing entity. Owns the `players` collection that this feature filters.
+- **Player**: Existing entity. Returned by the filter; player-level fields remain filterable as today.
+- **ClubPlayerMembership**: Existing entity. Provides the fields newly available in the where clause: `membershipType`, `start`, `end`, `confirmed`, `active`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: BAD-120 frontend loads existing LOAN memberships for an enrollment season in a single request, with zero client-side filtering — verified by an end-to-end test in the frontend repo.
+- **SC-002**: All three acceptance scenarios in User Story 1 pass against a real database with at least one club seeded with LOAN, NORMAL, and TRANSFER memberships across two seasons.
+- **SC-003**: Zero regressions across existing `Club.players` callers — verified by running the affected backend test suite plus the frontend autocomplete smoke test.
+- **SC-004**: Single SQL query emitted per resolver call regardless of result size — verified by query-log capture in test.
+
+## Assumptions
+
+- The frontend will adopt whichever where-clause syntax the backend ships (dollar-key, dotted, or typed input), as long as it satisfies FR-001 through FR-007.
+- The fields exposed for filtering match what already exists on the membership entity; no new columns or virtual fields are introduced as part of this change.
+- Date-range overlap (start/end) is expressed by the caller using the same operators used elsewhere — no new "between" or "overlaps" operator is required for v1; FR-002 covers the operator set.
+- Authorization on the player list is unchanged: callers who can already see a club's players today continue to see them; this feature does not add or remove visibility.
+
+## Dependencies
+
+- BAD-120: Frontend persistence work — this feature is a hard prerequisite for FR-011 (loan-loading on step 2 entry).
+- BAD-131: Sibling backend issue (`addPlayerToClub` return type). Independent — can ship in either order.

--- a/specs/005-club-players-nested-where/spec.md
+++ b/specs/005-club-players-nested-where/spec.md
@@ -2,50 +2,68 @@
 
 **Feature Branch**: `005-club-players-nested-where`
 **Created**: 2026-04-30
-**Status**: Draft
+**Status**: Draft (BAD-132 scope updated 2026-05-01 — see Clarifications)
 **Linear**: [BAD-132](https://linear.app/dashdot/issue/BAD-132) — Priority: Urgent
 
 ## Clarifications
 
 ### Session 2026-04-30
 
-- Q: How should the `Club.players` resolver accept membership-field filters? → A: Typed input — add `clubMembership: ClubMembershipFilterInput` argument with explicit, named fields (cleaner SDL, no JSONObject magic keys). The dollar-syntax and new-top-level-query options were rejected.
-- Q: Should `active` (a virtual computed field) be filterable through the typed input? → A: No — exclude `active` from `ClubMembershipFilterInput`. Callers express the same intent via `start`/`end` operators, avoiding implicit "current time" coupling.
+- Q: How should the `Club.players` resolver accept membership-field filters? → A: Typed input — add `clubMembership: ClubMembershipFilterInput` argument with explicit, named fields. The dollar-syntax and new-top-level-query options were rejected.
+- Q: Should `active` (a virtual computed field) be filterable through the typed input? → A: No — exclude `active` from `ClubMembershipFilterInput`.
+- Q: BAD-132 scope update (2026-04-30) — fields are pre-typed (no operator maps), implicit `confirmed = true` is removed when the arg is supplied → A: Adopt typed SDL with `id: [ID!]`, `membershipType: [String!]`, `startBefore: DateTime`, `endAfter: DateTime`, `confirmed: Boolean`. When `clubMembership` arg is supplied (even as `{}`), the implicit `confirmed = true` filter is NOT applied. When the arg is omitted, today's behavior is preserved.
+- Q: BAD-132 scope update (2026-05-01) — US2 changed from localStorage ID reconciliation to season-scoped transfer loading → A: US2 is now "load unconfirmed NORMAL (transfer) memberships for enrollment season" using `membershipType: ["NORMAL"], confirmed: false, startBefore, endAfter`. Step-3 SearchClubPlayers now explicitly passes `clubMembership: {}` to surface unconfirmed members.
 
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 — Frontend loads existing LOAN memberships for an enrollment season (Priority: P1)
 
-The enrollment wizard, on entry to step 2, asks the backend for the players currently registered with a club whose membership is a LOAN that overlaps the enrollment season's date range. The wizard receives only those players (with their membership details), so it can hydrate the loans panel without a second round-trip and without any client-side filtering.
+The enrollment wizard, on entry to step 2, asks the backend for the players whose membership is a LOAN that overlaps the enrollment season's date range, **including unconfirmed memberships**. The wizard receives only those players (with their membership details) and hydrates the loans panel without a second round-trip and without any client-side filtering.
 
-**Why this priority**: BAD-120 FR-011 cannot ship without this. Today the same query path either errors out or requires a workaround that inverts the join direction and complicates the wizard's hydration logic.
+**Why this priority**: BAD-120 FR-011 cannot ship without this. The frontend persists loans with `confirmed: false`; today's resolver silently filters them out.
 
-**Independent Test**: With a club that has known LOAN memberships overlapping a chosen season, request `Club.players` with a where clause filtering on membership type and overlapping start/end dates; assert the returned player list matches the expected memberships and only those.
+**Independent Test**: With a club that has known LOAN memberships (some confirmed, some not) overlapping a chosen season, request `Club.players(clubMembership: { membershipType: ["LOAN"], startBefore: <seasonEnd>, endAfter: <seasonStart> })`; assert the returned list contains all matching memberships regardless of `confirmed`.
 
 **Acceptance Scenarios**:
 
-1. **Given** a club with three LOAN memberships in 2025-2026 and one NORMAL membership, **When** the wizard requests the club's players filtered by `membershipType = LOAN` and date overlap with the 2025-2026 season window, **Then** exactly those three LOAN players are returned with their membership details.
+1. **Given** a club with three LOAN memberships in the 2025-2026 season (two confirmed, one unconfirmed), **When** the wizard requests `players(clubMembership: { membershipType: ["LOAN"], startBefore: "2026-04-30", endAfter: "2025-09-01" })`, **Then** all three LOAN players are returned.
 2. **Given** a club with no LOAN memberships in the requested season, **When** the same filter is applied, **Then** an empty list is returned (no error).
-3. **Given** the same query combined with a player-level filter (e.g. `firstName = "Anna"`), **When** the request runs, **Then** only players matching both the membership filter and the player-level filter are returned.
+3. **Given** the same query combined with a player-level `where: { firstName: { $eq: "Anna" } }`, **When** the request runs, **Then** only players matching both filters are returned.
 
 ---
 
-### User Story 2 — Existing flat filters keep working (Priority: P1)
+### User Story 2 — Frontend loads unconfirmed NORMAL (transfer) memberships for an enrollment season (Priority: P1)
 
-Existing callers that already filter `Club.players` by player-level fields (e.g. autocomplete lookups, team-composition dialogs) continue to work without any change to their queries.
+The enrollment wizard, on entry to step 2, asks the backend for players whose membership is a NORMAL type that is **unconfirmed** (i.e. a transfer added during this enrollment session) and overlaps the enrollment season's date range. The frontend uses `membershipType = NORMAL` + `confirmed = false` as the canonical "transfer added during this enrollment" indicator.
 
-**Why this priority**: This change must not break production flows. The flat-filter shape is in active use across the codebase.
+**Why this priority**: BAD-120 FR-007a / FR-011 cannot ship without this. Without filtering by `confirmed: false`, the frontend cannot distinguish transfers added in this session from long-standing confirmed members. Today's resolver silently strips all `confirmed: false` rows.
 
-**Independent Test**: Run the existing `SearchClubPlayers` autocomplete query (or equivalent) before and after the change; assert identical results for at least three sample queries.
+**Independent Test**: Request `Club.players(clubMembership: { membershipType: ["NORMAL"], confirmed: false, startBefore: <seasonEnd>, endAfter: <seasonStart> })`; assert only unconfirmed NORMAL memberships overlapping the season are returned.
 
 **Acceptance Scenarios**:
 
-1. **Given** an existing query that filters players by `firstName` only, **When** the request runs after the change, **Then** results are identical to the pre-change behavior.
-2. **Given** a query mixing flat player filters and the new membership filters, **When** the request runs, **Then** both filter groups apply (logical AND) without one overriding the other.
+1. **Given** a club with unconfirmed NORMAL memberships in the 2025-2026 season, **When** the wizard requests `players(clubMembership: { membershipType: ["NORMAL"], confirmed: false, startBefore: "2026-04-30", endAfter: "2025-09-01" })`, **Then** those unconfirmed NORMAL players are returned.
+2. **Given** no unconfirmed NORMAL memberships exist in the season, **When** the same query runs, **Then** an empty list is returned (no error).
+3. **Given** the same query, **When** the request runs, **Then** confirmed NORMAL members are NOT included in the result (the `confirmed: false` filter is exact match).
 
 ---
 
-### User Story 3 — Predictable performance under load (Priority: P2)
+### User Story 3 — Existing callers stay unchanged (Priority: P1)
+
+Callers that DO NOT pass the `clubMembership` argument (e.g. `SearchClubPlayers` autocomplete, team-composition dialog) continue to receive only confirmed memberships, exactly as today. The step-3 `SearchClubPlayers` query is updated to explicitly pass `clubMembership: {}` so it opts in to surfacing unconfirmed members in the team-composition dialog.
+
+**Why this priority**: This change must be opt-in. Production flows already in active use must not change behavior.
+
+**Independent Test**: Run the existing `SearchClubPlayers` query before and after the change; assert identical results.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing query `players(where: { firstName: { $eq: "Anna" } })` (no `clubMembership` arg), **When** the request runs after the change, **Then** results are identical to the pre-change behavior — unconfirmed memberships are still excluded.
+2. **Given** any query that supplies `clubMembership: {}` (empty object), **When** the request runs, **Then** unconfirmed memberships ARE included (the empty arg signals "I am opting in to the new behavior").
+
+---
+
+### User Story 4 — Predictable performance under load (Priority: P2)
 
 A single request to filter players by membership fields produces a single SQL query, regardless of how many players are returned.
 
@@ -55,53 +73,74 @@ A single request to filter players by membership fields produces a single SQL qu
 
 **Acceptance Scenarios**:
 
-1. **Given** a request that returns 50 players, **When** the request runs, **Then** the resolver emits one SQL query (one JOIN), not 51.
+1. **Given** a request that returns 50 players, **When** the request runs, **Then** the resolver emits one SQL query (one INNER JOIN), not 51.
 2. **Given** a request that returns zero players, **When** the request runs, **Then** the resolver still emits exactly one query.
 
 ---
 
 ### Edge Cases
 
-- A `where` clause references a membership field on a member that does not exist on the membership entity — the system MUST return a clear error rather than silently ignoring the unknown key.
-- A `where` clause uses an operator on a membership field that is not in the supported set (`$eq`, `$in`, `$lte`, `$gte`, plus any others already supported on flat fields) — system behavior MUST match how the same unsupported operator behaves on flat player fields (consistent error or no-op, but not a different shape).
-- The membership filter matches zero players — empty list returned (already covered above; reinforces no error path).
-- The membership filter matches all players in a club — full list returned with one query (no pagination collapse, no N+1).
+- `clubMembership` arg supplied as `{}` (empty object) — the resolver opts into the new behavior: implicit `confirmed = true` is dropped, JOIN is `LEFT` (defensive) so members without a `clubMembership` row also surface.
+- `clubMembership` arg supplied with `confirmed: false` — only unconfirmed memberships are returned. (Distinct from the `{}` case which includes both.)
+- `clubMembership.id: []` (empty array) — caller intent is ambiguous (zero IDs); the resolver treats this as a no-match (returns empty list), not as "no filter" (which would be the `id` field omitted entirely).
+- `startBefore` and `endAfter` together describe a date range overlap; either may be omitted to make the constraint one-sided.
+- `clubMembership.membershipType: ["LOAN", "NORMAL"]` (multiple values) — translates to `IN ("LOAN", "NORMAL")`.
+- `endAfter` excludes memberships where `end IS NULL` (open-ended memberships) — caller's responsibility to handle separately if needed.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
-- **FR-001**: `Club.players` MUST accept a typed `clubMembership` argument that filters returned players by fields on their club membership: `membershipType`, `start`, `end`, `confirmed`. The virtual `active` field is intentionally excluded — callers express the same intent via `start`/`end` operators.
-- **FR-002**: The `clubMembership` filter MUST support at minimum these operators on its fields: equal, set membership (in), less-than-or-equal, greater-than-or-equal — matching the operator vocabulary already accepted on player-level fields.
-- **FR-003**: The `clubMembership` filter MUST compose (logical AND) with the existing player-level `where` argument within the same query.
-- **FR-004**: Filters MUST be applied via a database join, not by post-fetch client-side filtering.
-- **FR-005**: A single resolver call MUST emit one SQL query regardless of result-row count (no N+1).
-- **FR-006**: Existing callers that pass only the player-level `where` (no `clubMembership` argument) MUST continue to receive identical results to today.
-- **FR-007**: The `clubMembership` input type MUST be exposed in the GraphQL schema with field-level descriptions so the frontend can author queries from introspection alone.
+#### Filter input shape
+
+- **FR-001**: `Club.players` MUST accept an optional typed argument `clubMembership: ClubMembershipFilterInput`. The argument MUST be additive — omitting it preserves today's behavior exactly.
+- **FR-002**: `ClubMembershipFilterInput` MUST expose exactly these fields:
+  - `id: [ID!]` — array of membership UUIDs; matches via SQL `IN`.
+  - `membershipType: [String!]` — array of membership types (`NORMAL`, `LOAN`); matches via SQL `IN`.
+  - `startBefore: DateTime` — translates to `ClubPlayerMembership.start <= startBefore`.
+  - `endAfter: DateTime` — translates to `ClubPlayerMembership.end >= endAfter`.
+  - `confirmed: Boolean` — exact match against `ClubPlayerMembership.confirmed`.
+- **FR-003**: The virtual `active` field MUST NOT appear in the input.
+
+#### Resolver behavior
+
+- **FR-004**: When `clubMembership` is OMITTED, the resolver MUST behave exactly as today (implicit `confirmed = true` filter still applied via the existing `active`-derived path).
+- **FR-005**: When `clubMembership` is SUPPLIED (even as `{}`), the resolver MUST NOT apply the implicit `confirmed = true` filter. Confirmed and unconfirmed memberships both surface unless the caller explicitly sets `confirmed: true`.
+- **FR-006**: When `clubMembership` is supplied with `confirmed: <bool>`, the resolver MUST apply that exact-match filter (overrides the default-suppression rule for that one field).
+- **FR-007**: The `clubMembership` filter MUST compose (logical AND) with the existing `where: JSONObject` argument on `Player`. Both filter groups apply within the same query.
+- **FR-008**: Filters MUST be applied via a database JOIN (`INNER JOIN` when any field on `clubMembership` is set, `LEFT JOIN` when arg is `{}`), not by post-fetch client-side filtering.
+- **FR-009**: A single resolver call MUST emit one SQL query regardless of result-row count (no N+1).
+
+#### Schema documentation
+
+- **FR-010**: `ClubMembershipFilterInput` MUST be exposed in the GraphQL schema with field-level descriptions explaining the operator semantics (`startBefore` → `<=`, `endAfter` → `>=`, etc.) so the frontend can author queries from introspection alone.
 
 ### Key Entities
 
-- **Club**: Existing entity. Owns the `players` collection that this feature filters.
-- **Player**: Existing entity. Returned by the filter; player-level fields remain filterable as today.
-- **ClubPlayerMembership**: Existing entity. Provides the fields newly available in the typed filter input: `membershipType`, `start`, `end`, `confirmed`. The virtual `active` getter is not filterable through this input.
+- **Club**: Existing entity. Owns the `players` collection.
+- **Player**: Existing entity. Returned by the filter; player-level filtering via the existing `where` arg unchanged.
+- **ClubPlayerMembership**: Existing entity. Provides the fields newly filterable via the typed input: `id`, `membershipType`, `start` (via `startBefore`), `end` (via `endAfter`), `confirmed`.
+- **ClubMembershipFilterInput**: NEW GraphQL input type defined by FR-002.
 
 ## Success Criteria *(mandatory)*
 
 ### Measurable Outcomes
 
-- **SC-001**: BAD-120 frontend loads existing LOAN memberships for an enrollment season in a single request, with zero client-side filtering — verified by an end-to-end test in the frontend repo.
-- **SC-002**: All three acceptance scenarios in User Story 1 pass against a real database with at least one club seeded with LOAN, NORMAL, and TRANSFER memberships across two seasons.
-- **SC-003**: Zero regressions across existing `Club.players` callers — verified by running the affected backend test suite plus the frontend autocomplete smoke test.
+- **SC-001**: BAD-120 frontend loads existing LOAN memberships (incl. unconfirmed) for an enrollment season in a single request, with zero client-side filtering — verified by end-to-end test in the frontend repo.
+- **SC-002**: BAD-120 frontend loads unconfirmed NORMAL (transfer) memberships for an enrollment season in a single request using `confirmed: false` — verified by end-to-end test in the frontend repo.
+- **SC-003**: Existing `SearchClubPlayers` autocomplete (and any other caller without `clubMembership` arg) returns identical results before and after the change — zero regressions on the implicit-confirmed-filter behavior.
 - **SC-004**: Single SQL query emitted per resolver call regardless of result size — verified by query-log capture in test.
+- **SC-005**: Probe verification — a club with known unconfirmed memberships (e.g. clubId `4699bcdd-f6db-48ea-81aa-f79acdf47a7c` per BAD-132 references) returns those unconfirmed rows when called with `clubMembership: {}` and continues to exclude them when called without the arg.
 
 ## Assumptions
 
-- The frontend will adopt the typed `clubMembership` argument once it ships; until then, the workaround query path stays in place.
-- The fields exposed for filtering match what already exists on the membership entity; no new columns or virtual fields are introduced as part of this change.
-- Date-range overlap (start/end) is expressed by the caller using the same operators used elsewhere — no new "between" or "overlaps" operator is required for v1; FR-002 covers the operator set.
+- The frontend lands its `.gql` mutation/query updates and codegen regen in the same coordinated PR window as the backend SDL change.
+- No `season: Int` field is added to `ClubPlayerMembership`; date-range queries use `startBefore`/`endAfter` derived from `getSeasonPeriod(season)` on the frontend side.
 - Authorization on the player list is unchanged: callers who can already see a club's players today continue to see them; this feature does not add or remove visibility.
+- Sequelize `BelongsToMany` association from `Club` → `Player` via `ClubPlayerMembership` is the existing path; no association rewiring needed.
+- `endAfter` excludes NULL `end` (open-ended memberships); the frontend accepts this exclusion or handles it with a second query.
 
 ## Dependencies
 
-- BAD-120: Frontend persistence work — this feature is a hard prerequisite for FR-011 (loan-loading on step 2 entry).
+- BAD-120: Frontend persistence work — this feature is a hard prerequisite for FR-007a, FR-011 (loan/transfer hydration on step 2/3 entry, including unconfirmed rows).
 - BAD-131: Sibling backend issue (`addPlayerToClub` return type). Independent — can ship in either order.

--- a/specs/005-club-players-nested-where/tasks.md
+++ b/specs/005-club-players-nested-where/tasks.md
@@ -1,0 +1,209 @@
+---
+
+description: "Tasks for Filter Club Players by Membership Fields (BAD-132)"
+---
+
+# Tasks: Filter Club Players by Membership Fields
+
+**Input**: Design documents from `/specs/005-club-players-nested-where/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md
+
+**Tests**: Required per Constitution Principle IV. Test tasks included.
+
+**Organization**: Resolver impl is one cohesive change (Foundational); user-story phases own their test cases.
+
+## Format: `[ID] [P?] [Story?] Description with file path`
+
+## Path Conventions
+
+NestJS Nx monorepo. Affected paths:
+- `libs/backend/graphql/src/resolvers/club/` — input type, resolver, tests
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Run baseline `nx test backend-graphql` and capture pass count, so any new failure introduced later is attributable
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build the new input type and the full resolver change in one cohesive unit. All user stories depend on this.
+
+**⚠️ CRITICAL**: T002 + T003 must complete before any test task in Phases 3–6 can run.
+
+- [ ] T002 Create `ClubMembershipFilterInput` `@InputType` in `libs/backend/graphql/src/resolvers/club/club-membership-filter.input.ts` with fields `id: [ID!]`, `membershipType: [String!]`, `startBefore: Date`, `endAfter: Date`, `confirmed: Boolean` per data-model.md "New GraphQL input type"; field-level descriptions explain the operator semantics (`startBefore` → `<=`, `endAfter` → `>=`, arrays → `IN`, `endAfter` excludes NULL `end`)
+
+- [ ] T003 Extend the `Club.players` resolver in `libs/backend/graphql/src/resolvers/club/club.resolver.ts:92-147` per plan.md Step 2:
+  - Add `@Args("clubMembership", { type: () => ClubMembershipFilterInput, nullable: true }) clubMembership?: ClubMembershipFilterInput` parameter
+  - Compute `const optingIn = clubMembership !== undefined && clubMembership !== null`
+  - Short-circuit `return []` when `clubMembership.id !== undefined && clubMembership.id.length === 0`
+  - Build `membershipWhere` from set fields (`id` → `Op.in`, `membershipType` → `Op.in`, `startBefore` → `start: { Op.lte }`, `endAfter` → `end: { Op.gte }`, `confirmed` → exact)
+  - Append `{ model: ClubPlayerMembership, as: "ClubPlayerMembership", required: anyFieldSet, where: anyFieldSet ? membershipWhere : undefined }` to `options.include`
+  - Wrap the existing `active`-derived `confirmed=true` injection: `if (active && !optingIn) { options.where = { ...options.where, [`$${ClubPlayerMembership.name}.confirmed$`]: true }; }`
+  - Add imports: `ClubMembershipFilterInput`, `Op` from `sequelize`
+
+**Checkpoint**: Resolver compiles. Schema introspection shows the new arg. All four user stories are now mechanically implemented; remaining tasks verify per-story behavior via tests.
+
+---
+
+## Phase 3: User Story 1 — LOAN memberships for an enrollment season (Priority: P1) 🎯 MVP
+
+**Goal**: Frontend loads LOAN memberships overlapping a season window, **including unconfirmed**.
+
+**Independent Test**: `players(clubMembership: { membershipType: ["LOAN"], startBefore, endAfter })` returns the expected rows including unconfirmed; query log shows one INNER JOIN.
+
+### Tests for User Story 1
+
+- [ ] T004 [P] [US1] Add test "LOAN + season window returns matching memberships including unconfirmed" in `libs/backend/graphql/src/resolvers/club/club.resolver.spec.ts` — spy `Club.findByPk` returning a fake club with `getPlayers` jest.fn(); call resolver with `clubMembership: { membershipType: ["LOAN"], startBefore: new Date("2026-04-30"), endAfter: new Date("2025-09-01") }`; assert `getPlayers` called with `include` containing one entry where `model === ClubPlayerMembership`, `required === true`, `where.membershipType: { [Op.in]: ["LOAN"] }`, `where.start: { [Op.lte]: ... }`, `where.end: { [Op.gte]: ... }`; assert no `$ClubPlayerMembership.confirmed$ = true` key in `options.where` (legacy filter suppressed)
+
+- [ ] T005 [P] [US1] Add test "empty result is not an error" — same input as T004 but `getPlayers` resolves `[]`; assert resolver returns `[]` without throwing
+
+- [ ] T006 [P] [US1] Add test "membership filter composes with player-level where (logical AND)" — call with both `where: { firstName: { $eq: "Anna" } }` (post-`queryFixer`) AND `clubMembership: { membershipType: ["LOAN"] }`; assert `options.where` contains the player-level filter AND `options.include[].where.membershipType` contains the LOAN filter
+
+**Checkpoint**: US1 acceptance scenarios verified.
+
+---
+
+## Phase 4: User Story 2 — Unconfirmed NORMAL (transfer) memberships for an enrollment season (Priority: P1)
+
+**Goal**: Frontend loads unconfirmed NORMAL memberships (transfers) for a season window using `confirmed: false` + date range.
+
+**Independent Test**: `players(clubMembership: { membershipType: ["NORMAL"], confirmed: false, startBefore, endAfter })` returns only unconfirmed NORMAL memberships overlapping the season.
+
+### Tests for User Story 2
+
+- [ ] T007 [P] [US2] Add test "NORMAL + confirmed:false + season window returns unconfirmed transfer memberships" in `libs/backend/graphql/src/resolvers/club/club.resolver.spec.ts` — call with `clubMembership: { membershipType: ["NORMAL"], confirmed: false, startBefore: new Date("2026-04-30"), endAfter: new Date("2025-09-01") }`; assert `options.include[].where.membershipType: { [Op.in]: ["NORMAL"] }`, `where.confirmed === false`, `where.start: { [Op.lte]: ... }`, `where.end: { [Op.gte]: ... }`, `required === true`; legacy `$confirmed$=true` not present in `options.where`
+
+- [ ] T008 [P] [US2] Add test "confirmed:false does not return confirmed members" — same call as T007; `getPlayers` resolves `[fakeConfirmedPlayer]`; assert resolver returns that list (no filtering on resolver side — SQL handles it); assert `options.include[].where.confirmed === false` (not undefined)
+
+- [ ] T009 [P] [US2] Add test "empty result when no transfers exist is not an error" — same input as T007, `getPlayers` resolves `[]`; assert resolver returns `[]` without throwing
+
+**Checkpoint**: US2 acceptance scenarios verified.
+
+---
+
+## Phase 5: User Story 3 — Existing callers stay unchanged (Priority: P1)
+
+**Goal**: Callers that DO NOT pass `clubMembership` continue to receive only confirmed memberships, exactly as today.
+
+**Independent Test**: `players(where: { firstName: { $eq: "Anna" } })` (no `clubMembership`) → identical behavior to before this PR.
+
+### Tests for User Story 3
+
+- [ ] T010 [P] [US3] Add test "omitted clubMembership preserves legacy confirmed=true filter" — call with `where: { firstName: { $eq: "Anna" } }` and NO `clubMembership` arg, `active=true` (default); assert `options.where[$ClubPlayerMembership.confirmed$] === true`; assert `options.include` does NOT contain a `ClubPlayerMembership` model entry from this fix (the legacy code path adds the dollar-syntax filter, not an explicit include)
+
+- [ ] T011 [P] [US3] Add test "clubMembership: {} opts in (LEFT JOIN, no implicit confirmed)" — call with `clubMembership: {}`; assert `options.include` contains a `ClubPlayerMembership` entry with `required: false`; assert `options.where` does NOT contain `$ClubPlayerMembership.confirmed$`
+
+- [ ] T012 [P] [US3] Add test "explicit confirmed: false returns only unconfirmed" — call with `clubMembership: { confirmed: false }`; assert `options.include[].where.confirmed === false` and `options.include[].required === true`
+
+- [ ] T013 [P] [US3] Add test "active=false with no clubMembership skips legacy injection" — call with `where: {}`, `active: false`, no `clubMembership`; assert no `$ClubPlayerMembership.confirmed$` key (regression guard for the legacy `active=false` branch)
+
+**Checkpoint**: US3 acceptance scenarios verified. SC-003 (zero regressions on omitted-arg callers) green.
+
+---
+
+## Phase 6: User Story 4 — Single SQL query per call (Priority: P2)
+
+**Goal**: One SQL query per resolver call regardless of result size.
+
+**Independent Test**: Spy on `Sequelize.prototype.query` (or the underlying find); assert exactly one call.
+
+### Tests for User Story 4
+
+- [ ] T014 [P] [US4] Add test "single-query: getPlayers called once" — call with `clubMembership: { membershipType: ["LOAN"] }` against a fake club whose `getPlayers` resolves a 50-row array; assert `fakeClub.getPlayers` called exactly once. (Note: this verifies the resolver-level call shape; full SQL-query-count assertion across the Sequelize layer is verified manually in T017 polish.)
+
+**Checkpoint**: US4 acceptance scenarios verified at the resolver level.
+
+---
+
+## Phase 7: Polish & Cross-Cutting
+
+- [ ] T015 Run `nx test backend-graphql` — all suites must pass (existing + new)
+
+- [ ] T016 Run `nx lint backend-graphql` — must pass (no new lint errors)
+
+- [ ] T017 Run `nx build backend-graphql` and `nx build api` — both must compile clean (catches missing input-type registration)
+
+- [ ] T018 [P] Manual smoke (SC-005 verification): with API running on :5010, against the probe target club `4699bcdd-f6db-48ea-81aa-f79acdf47a7c` per BAD-132 references, run two queries:
+  1. `Club.players` with no `clubMembership` arg — note the player count
+  2. `Club.players(clubMembership: {})` — assert count is ≥ first count + 4 (the four known unconfirmed NORMAL memberships)
+
+- [ ] T019 [P] Manual smoke (LOAN season filter): with API running, query `Club.players(clubMembership: { membershipType: ["LOAN"], startBefore: <2026-04-30 ISO>, endAfter: <2025-09-01 ISO> })` against a club with known LOAN memberships in 2025-26; verify only LOAN rows return and the SQL log shows one query with one INNER JOIN
+
+- [ ] T020 [P] Manual smoke (transfer filter): with API running, query `Club.players(clubMembership: { membershipType: ["NORMAL"], confirmed: false, startBefore: <2026-04-30 ISO>, endAfter: <2025-09-01 ISO> })` against the probe club; verify only unconfirmed NORMAL rows return (SC-002 verification)
+
+- [ ] T021 [P] Verify schema introspection: with API running, run `query { __type(name: "ClubMembershipFilterInput") { name fields { name type { name kind ofType { name } } } } }`; assert all five fields are present with the expected types
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: T001 — independent.
+- **Phase 2 (Foundational)**: T002 must complete before T003 (resolver imports the input type). After T003, all four user stories are mechanically implemented.
+- **Phases 3–6 (Test phases)**: All depend on Phase 2 complete. Test files in different test cases parallelize freely.
+- **Phase 7 (Polish)**: T015–T017 sequential; T018–T021 parallel after the API boots.
+
+### User Story Independence
+
+- **US1, US2, US3, US4**: All four are verified by tests against the same resolver. Test cases are independent and can be authored/run in any order. Implementation work for all four lives entirely in T002+T003 (Foundational).
+
+### Parallel Opportunities
+
+- T004–T006 ([P] [US1]) — three test cases, separate `it()` blocks, can land in any order.
+- T007–T009 ([P] [US2]) — same.
+- T010–T013 ([P] [US3]) — four test cases, parallel.
+- T014 ([P] [US4]) — single test.
+- T018–T021 ([P]) — four independent manual smoke checks.
+
+### Within Each User Story
+
+- Tests are pure unit tests; no ordering between them.
+- All assert against the `options` shape passed to `fakeClub.getPlayers` (`include`, `where`, `required`, `Op.in`/`Op.lte`/`Op.gte`). The Sequelize Symbol keys (`Op.in`, etc.) are imported in the test file.
+
+---
+
+## Parallel Example: US1 Tests
+
+```bash
+# After T003 lands, run these in parallel:
+Task: "Add test 'LOAN + season window returns matching memberships including unconfirmed' in club.resolver.spec.ts"
+Task: "Add test 'empty result is not an error' in club.resolver.spec.ts"
+Task: "Add test 'membership filter composes with player-level where' in club.resolver.spec.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. T001 baseline.
+2. T002 input type.
+3. T003 resolver extension.
+4. T004–T006 US1 tests pass.
+5. **STOP and VALIDATE**: BAD-120 frontend can call `Club.players(clubMembership: { membershipType: ["LOAN"], startBefore, endAfter })` and receive unconfirmed LOANs. Ship.
+
+### Incremental Delivery
+
+1. MVP (above) ships → BAD-120's loan-loading unblocked.
+2. T007–T009 (US2) → transfer-loading with `confirmed: false` + date range works.
+3. T010–T013 (US3) → regression coverage for autocomplete + other legacy callers locks the contract.
+4. T014 (US4) → perf assertion at resolver level.
+5. T015–T021 (Polish) → full test suite green + manual smoke + introspection check.
+
+### Solo Developer Sequence
+
+T001 → T002 → T003 → T004 → T005 → T006 → T007 → T008 → T009 → T010 → T011 → T012 → T013 → T014 → T015 → T016 → T017 → T018 → T019 → T020 → T021.
+
+---
+
+## Notes
+
+- All resolver tests use mocked `Club.findByPk` (returning a fake `Club` with a `getPlayers` jest.fn) — never hit the real DB. Constitution IV.
+- Assertions check the *shape* of `options` passed to `getPlayers` (`include`, `where`, `required`, `Op.in`/`Op.lte`/`Op.gte`). The Sequelize Symbol keys (`Op.in`, etc.) are imported in the test file.
+- Manual smokes in Polish (T018–T021) need the local API running and a club seeded with the right mix of confirmed/unconfirmed memberships. The probe club ID from BAD-132 references is a known-good target.
+- Frontend coordination (BAD-120 `.gql` updates + codegen regen) is OUT OF SCOPE for this branch; that's a sibling PR in the frontend repo.


### PR DESCRIPTION
## Summary

- Add `ClubMembershipFilterInput` @InputType with 5 typed fields: `id`, `membershipType`, `startBefore`, `endAfter`, `confirmed`
- Add `clubMembership?: ClubMembershipFilterInput` arg to `Club.players()` resolver
- When arg is supplied (even as `{}`), suppress legacy implicit `confirmed = true` filter — unconfirmed LOAN/NORMAL memberships now surface for BAD-120's enrollment wizard
- INNER JOIN when any field set; LEFT JOIN for empty `{}`
- Existing callers without the arg: zero behavior change

## Test plan

- [x] `nx test backend-graphql` — 53 tests pass (9 new covering all 4 user stories)
- [x] `nx lint backend-graphql` — 0 new errors
- [ ] Manual smoke T018: probe club `4699bcdd-f6db-48ea-81aa-f79acdf47a7c` — `players(clubMembership: {})` count > `players()` count by ≥4
- [ ] Manual smoke T019: LOAN season filter returns only LOAN rows, 1 INNER JOIN in SQL log
- [ ] Manual smoke T020: `membershipType: NORMAL, confirmed: false` returns only transfer rows
- [ ] Schema introspection T021: all 5 fields visible on `ClubMembershipFilterInput`

## Linear

Closes BAD-132 (child of BAD-120)

🤖 Generated with [Claude Code](https://claude.com/claude-code)