### PR TITLE
Backend: harden finishEventEntry — atomic txn, idempotency, resolver tests

### DIFF
--- a/.maqa/state.json
+++ b/.maqa/state.json
@@ -26,6 +26,33 @@
       "card_id": "BAD-132",
       "branch": "005-club-players-nested-where"
     },
+    "007-finish-event-entry-hardening": {
+      "status": "in_review_qa_approved",
+      "board": "linear",
+      "card_id": "BAD-137",
+      "linear_status": "Ready for review",
+      "branch": "007-finish-event-entry-hardening",
+      "tasks_total": 24,
+      "tasks_completed": "T001, T003-T020 (19/24)",
+      "deferred": "T002 (docker check), T021 (nx affected:test), T022 (manual quickstart walk), T023 (verify only), T024 (frontend PR — separate repo)",
+      "implementation_commits": ["e407d0553", "cf539101b"],
+      "tests_passed": 12,
+      "tests_total": 12,
+      "qa_status": "approved",
+      "qa_checks": {
+        "text": "PASS",
+        "links": "PASS",
+        "security": "PASS"
+      },
+      "constitution_check": {
+        "principle_i_codefirst_graphql": "PASS",
+        "principle_ii_i18n": "PASS (no diff)",
+        "principle_iii_transactional_mutations": "PASS",
+        "principle_iv_resolver_tests": "PASS",
+        "principle_v_legacy_frontend": "PASS (no diff)"
+      },
+      "next_step": "human review and merge to develop; open companion frontend PR per specs/007-finish-event-entry-hardening/frontend-changes.md (BAD-122 follow-up)"
+    },
     "006-unify-base-index-backend": {
       "status": "in_review_qa_approved",
       "board": "linear",

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/006-unify-base-index-backend"
+  "feature_directory": "specs/007-finish-event-entry-hardening"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,6 @@ Long-form internal docs live under [`docs/`](docs/). Skim the relevant ones befo
 
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-[specs/006-unify-base-index-backend/plan.md](specs/006-unify-base-index-backend/plan.md)
+[specs/007-finish-event-entry-hardening/plan.md](specs/007-finish-event-entry-hardening/plan.md)
 
 <!-- SPECKIT END -->

--- a/libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts
@@ -1,0 +1,400 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { GraphQLError } from "graphql";
+import { Sequelize } from "sequelize-typescript";
+import { Club, EventEntry, Logging, Player, Team } from "@badman/backend-database";
+import { EnrollmentValidationService } from "@badman/backend-enrollment";
+import { NotificationService } from "@badman/backend-notifications";
+import { EventEntryResolver } from "./entry.resolver";
+import { ErrorCode } from "../../utils/error-codes";
+
+// Type helper to cast mocked model objects
+const asUnknown = <T>(x: unknown): T => x as T;
+
+describe("EventEntryResolver.finishEventEntry", () => {
+  let resolver: EventEntryResolver;
+  let mockTransaction: {
+    commit: jest.Mock;
+    rollback: jest.Mock;
+    LOCK: { UPDATE: string };
+  };
+  let mockNotificationService: { notifyEnrollment: jest.Mock };
+  let mockEnrollmentService: { fetchAndValidate: jest.Mock };
+
+  const userWithPermission = (allowed: boolean) =>
+    ({
+      id: "user-uuid",
+      hasAnyPermission: jest.fn().mockResolvedValue(allowed),
+    }) as unknown as Player;
+
+  const stubClub = (overrides: Partial<{ contactCompetition: string }> = {}) => {
+    const save = jest.fn().mockResolvedValue(undefined);
+    return asUnknown<Club & { _save: jest.Mock }>({
+      id: "club-uuid",
+      name: "Test Club",
+      contactCompetition: overrides.contactCompetition ?? "existing@example.com",
+      save,
+      _save: save,
+    });
+  };
+
+  const stubEntry = (sendOn: Date | null = null, teamId = "team-uuid") => {
+    const save = jest.fn().mockResolvedValue(undefined);
+    return asUnknown<EventEntry & { _save: jest.Mock }>({
+      teamId,
+      sendOn,
+      save,
+      _save: save,
+    });
+  };
+
+  const stubTeam = (
+    entry: (EventEntry & { _save: jest.Mock }) | null = stubEntry(),
+    id = "team-uuid"
+  ) =>
+    asUnknown<Team>({
+      id,
+      clubId: "club-uuid",
+      season: 2026,
+      entry,
+    });
+
+  beforeEach(async () => {
+    mockTransaction = {
+      commit: jest.fn().mockResolvedValue(undefined),
+      rollback: jest.fn().mockResolvedValue(undefined),
+      LOCK: { UPDATE: "UPDATE" },
+    };
+    mockNotificationService = { notifyEnrollment: jest.fn().mockResolvedValue(undefined) };
+    mockEnrollmentService = { fetchAndValidate: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EventEntryResolver,
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+        },
+        {
+          provide: NotificationService,
+          useValue: mockNotificationService,
+        },
+        {
+          provide: EnrollmentValidationService,
+          useValue: mockEnrollmentService,
+        },
+      ],
+    }).compile();
+    resolver = module.get<EventEntryResolver>(EventEntryResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  // Case #1: unauthorized user
+  it("throws UnauthorizedException when user lacks permission", async () => {
+    const user = userWithPermission(false);
+    jest.spyOn(Club, "findByPk").mockResolvedValue(stubClub());
+
+    await expect(
+      resolver.finishEventEntry(user, "club-uuid", 2026, "new@example.com")
+    ).rejects.toThrow(UnauthorizedException);
+
+    // No model writes
+    expect(mockTransaction.commit).not.toHaveBeenCalled();
+    expect(mockTransaction.rollback).not.toHaveBeenCalled();
+    expect(mockNotificationService.notifyEnrollment).not.toHaveBeenCalled();
+  });
+
+  // Case #2: unknown clubId
+  it("throws NotFoundException when club does not exist", async () => {
+    const user = userWithPermission(true);
+    jest.spyOn(Club, "findByPk").mockResolvedValue(null);
+
+    await expect(
+      resolver.finishEventEntry(user, "missing-club", 2026, "new@example.com")
+    ).rejects.toThrow(NotFoundException);
+
+    // No transaction started
+    expect(mockTransaction.commit).not.toHaveBeenCalled();
+    expect(mockTransaction.rollback).not.toHaveBeenCalled();
+    expect(mockNotificationService.notifyEnrollment).not.toHaveBeenCalled();
+  });
+
+  // Case #3: zero teams
+  it("throws GraphQLError with NO_TEAMS_TO_FINALISE and rolls back when no teams for season", async () => {
+    const user = userWithPermission(true);
+    jest.spyOn(Club, "findByPk").mockResolvedValue(stubClub());
+    jest.spyOn(Team, "findAll").mockResolvedValue([]);
+
+    try {
+      await resolver.finishEventEntry(user, "club-uuid", 2026, "new@example.com");
+      fail("expected throw");
+    } catch (err) {
+      const e = err as GraphQLError;
+      expect(e.extensions?.["code"]).toBe(ErrorCode.NO_TEAMS_TO_FINALISE);
+      expect(e.extensions?.["clubId"]).toBe("club-uuid");
+      expect(e.extensions?.["season"]).toBe(2026);
+    }
+
+    expect(mockTransaction.rollback).toHaveBeenCalled();
+    expect(mockTransaction.commit).not.toHaveBeenCalled();
+    expect(mockNotificationService.notifyEnrollment).not.toHaveBeenCalled();
+  });
+
+  // Case #4: fresh happy path
+  it("sets sendOn on all entries, creates log, commits, notifies on fresh finalisation", async () => {
+    const user = userWithPermission(true);
+    const club = stubClub({ contactCompetition: "old@example.com" });
+    const entry1 = stubEntry(null, "team-1");
+    const entry2 = stubEntry(null, "team-2");
+    const entry3 = stubEntry(null, "team-3");
+    const teams = [
+      stubTeam(entry1, "team-1"),
+      stubTeam(entry2, "team-2"),
+      stubTeam(entry3, "team-3"),
+    ];
+
+    jest.spyOn(Club, "findByPk").mockResolvedValue(club);
+    jest.spyOn(Team, "findAll").mockResolvedValue(teams);
+    jest
+      .spyOn(EventEntry, "findAll")
+      .mockResolvedValue([entry1, entry2, entry3] as unknown as EventEntry[]);
+    const loggingCreate = jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
+
+    const result = await resolver.finishEventEntry(user, "club-uuid", 2026, "new@example.com");
+
+    expect(result).toEqual({
+      success: true,
+      alreadyFinalised: false,
+      notificationDispatched: true,
+    });
+    expect(entry1._save).toHaveBeenCalledWith(
+      expect.objectContaining({ transaction: mockTransaction })
+    );
+    expect(entry2._save).toHaveBeenCalledWith(
+      expect.objectContaining({ transaction: mockTransaction })
+    );
+    expect(entry3._save).toHaveBeenCalledWith(
+      expect.objectContaining({ transaction: mockTransaction })
+    );
+    expect(loggingCreate).toHaveBeenCalledTimes(1);
+    expect(mockTransaction.commit).toHaveBeenCalledTimes(1);
+    expect(mockTransaction.rollback).not.toHaveBeenCalled();
+    expect(mockNotificationService.notifyEnrollment).toHaveBeenCalledTimes(1);
+    expect(mockNotificationService.notifyEnrollment).toHaveBeenCalledWith(
+      user.id,
+      "club-uuid",
+      2026,
+      "new@example.com"
+    );
+  });
+
+  // Case #5: rollback on Logging.create throw
+  it("rolls back and re-throws when Logging.create throws", async () => {
+    const user = userWithPermission(true);
+    const club = stubClub();
+    const entry1 = stubEntry(null, "team-uuid");
+    const teams = [stubTeam(entry1, "team-uuid")];
+
+    jest.spyOn(Club, "findByPk").mockResolvedValue(club);
+    jest.spyOn(Team, "findAll").mockResolvedValue(teams);
+    jest.spyOn(EventEntry, "findAll").mockResolvedValue([entry1] as unknown as EventEntry[]);
+    jest.spyOn(Logging, "create").mockRejectedValue(new Error("DB write failed"));
+
+    await expect(
+      resolver.finishEventEntry(user, "club-uuid", 2026, "new@example.com")
+    ).rejects.toThrow("DB write failed");
+
+    expect(mockTransaction.rollback).toHaveBeenCalled();
+    expect(mockTransaction.commit).not.toHaveBeenCalled();
+    expect(mockNotificationService.notifyEnrollment).not.toHaveBeenCalled();
+  });
+
+  // Case #6: already-finalised same email
+  it("returns alreadyFinalised: true with no writes when all entries already have sendOn and email matches", async () => {
+    const user = userWithPermission(true);
+    const club = stubClub({ contactCompetition: "same@example.com" });
+    const entry1 = stubEntry(new Date("2026-01-01"), "team-1");
+    const entry2 = stubEntry(new Date("2026-01-01"), "team-2");
+    const teams = [stubTeam(entry1, "team-1"), stubTeam(entry2, "team-2")];
+
+    jest.spyOn(Club, "findByPk").mockResolvedValue(club);
+    jest.spyOn(Team, "findAll").mockResolvedValue(teams);
+    jest
+      .spyOn(EventEntry, "findAll")
+      .mockResolvedValue([entry1, entry2] as unknown as EventEntry[]);
+    const loggingCreate = jest.spyOn(Logging, "create");
+
+    const result = await resolver.finishEventEntry(user, "club-uuid", 2026, "same@example.com");
+
+    expect(result).toEqual({
+      success: true,
+      alreadyFinalised: true,
+      notificationDispatched: false,
+    });
+    expect(club._save).not.toHaveBeenCalled();
+    expect(entry1._save).not.toHaveBeenCalled();
+    expect(entry2._save).not.toHaveBeenCalled();
+    expect(loggingCreate).not.toHaveBeenCalled();
+    expect(mockNotificationService.notifyEnrollment).not.toHaveBeenCalled();
+    expect(mockTransaction.commit).toHaveBeenCalledTimes(1);
+  });
+
+  // Case #7: already-finalised + email differs
+  it("updates club.contactCompetition only when already-finalised but email differs", async () => {
+    const user = userWithPermission(true);
+    const club = stubClub({ contactCompetition: "old@example.com" });
+    const entry1 = stubEntry(new Date("2026-01-01"), "team-1");
+    const entry2 = stubEntry(new Date("2026-01-01"), "team-2");
+    const teams = [stubTeam(entry1, "team-1"), stubTeam(entry2, "team-2")];
+
+    jest.spyOn(Club, "findByPk").mockResolvedValue(club);
+    jest.spyOn(Team, "findAll").mockResolvedValue(teams);
+    jest
+      .spyOn(EventEntry, "findAll")
+      .mockResolvedValue([entry1, entry2] as unknown as EventEntry[]);
+    const loggingCreate = jest.spyOn(Logging, "create");
+
+    const result = await resolver.finishEventEntry(user, "club-uuid", 2026, "new@example.com");
+
+    expect(result).toEqual({
+      success: true,
+      alreadyFinalised: true,
+      notificationDispatched: false,
+    });
+    expect(club._save).toHaveBeenCalledWith(
+      expect.objectContaining({ transaction: mockTransaction })
+    );
+    expect(entry1._save).not.toHaveBeenCalled();
+    expect(entry2._save).not.toHaveBeenCalled();
+    expect(loggingCreate).not.toHaveBeenCalled();
+    expect(mockNotificationService.notifyEnrollment).not.toHaveBeenCalled();
+    expect(mockTransaction.commit).toHaveBeenCalledTimes(1);
+  });
+
+  // Case #8: partial state (some entries null)
+  it("updates only null entries and notifies once on partial state", async () => {
+    const user = userWithPermission(true);
+    const club = stubClub();
+    const entryAlreadySet = stubEntry(new Date("2026-01-01"), "team-set");
+    const entryNull = stubEntry(null, "team-null");
+    const teamWithSet = stubTeam(entryAlreadySet, "team-set");
+    const teamWithNull = stubTeam(entryNull, "team-null");
+
+    jest.spyOn(Club, "findByPk").mockResolvedValue(club);
+    jest.spyOn(Team, "findAll").mockResolvedValue([teamWithSet, teamWithNull]);
+    // Locked read returns both entries — one has sendOn set, one doesn't → NOT alreadyFinalised
+    jest
+      .spyOn(EventEntry, "findAll")
+      .mockResolvedValue([entryAlreadySet, entryNull] as unknown as EventEntry[]);
+    const loggingCreate = jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
+
+    const result = await resolver.finishEventEntry(user, "club-uuid", 2026, "test@example.com");
+
+    expect(result).toEqual({
+      success: true,
+      alreadyFinalised: false,
+      notificationDispatched: true,
+    });
+    // Only the null entry was saved
+    expect(entryAlreadySet._save).not.toHaveBeenCalled();
+    expect(entryNull._save).toHaveBeenCalledTimes(1);
+    expect(loggingCreate).toHaveBeenCalledTimes(1);
+    expect(mockNotificationService.notifyEnrollment).toHaveBeenCalledTimes(1);
+    expect(mockTransaction.commit).toHaveBeenCalledTimes(1);
+  });
+
+  // Case #9: team without entry row skipped without error
+  it("skips teams without entry row without throwing", async () => {
+    const user = userWithPermission(true);
+    const club = stubClub();
+    const teamNoEntry = stubTeam(null, "team-no-entry");
+    const entryWithData = stubEntry(null, "team-with-entry");
+    const teamWithEntry = stubTeam(entryWithData, "team-with-entry");
+
+    jest.spyOn(Club, "findByPk").mockResolvedValue(club);
+    jest.spyOn(Team, "findAll").mockResolvedValue([teamNoEntry, teamWithEntry]);
+    jest.spyOn(EventEntry, "findAll").mockResolvedValue([entryWithData] as unknown as EventEntry[]);
+    jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
+
+    const result = await resolver.finishEventEntry(user, "club-uuid", 2026, "test@example.com");
+
+    expect(result.success).toBe(true);
+    expect(result.alreadyFinalised).toBe(false);
+    expect(mockTransaction.commit).toHaveBeenCalledTimes(1);
+  });
+
+  // Case #10: notification fails post-commit
+  it("commits DB writes but returns notificationDispatched: false when notification rejects", async () => {
+    const user = userWithPermission(true);
+    const club = stubClub();
+    const entry1 = stubEntry(null, "team-uuid");
+    const teams = [stubTeam(entry1, "team-uuid")];
+
+    jest.spyOn(Club, "findByPk").mockResolvedValue(club);
+    jest.spyOn(Team, "findAll").mockResolvedValue(teams);
+    jest.spyOn(EventEntry, "findAll").mockResolvedValue([entry1] as unknown as EventEntry[]);
+    jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
+    mockNotificationService.notifyEnrollment.mockRejectedValue(new Error("SMTP failure"));
+
+    const result = await resolver.finishEventEntry(user, "club-uuid", 2026, "test@example.com");
+
+    // DB writes committed
+    expect(mockTransaction.commit).toHaveBeenCalledTimes(1);
+    expect(mockTransaction.rollback).not.toHaveBeenCalled();
+    // Resolver did NOT throw
+    expect(result).toEqual({
+      success: true,
+      alreadyFinalised: false,
+      notificationDispatched: false,
+    });
+  });
+
+  // Case #11: row-lock query uses LOCK.UPDATE
+  it("passes lock: transaction.LOCK.UPDATE to EventEntry.findAll", async () => {
+    const user = userWithPermission(true);
+    const club = stubClub();
+    const entry1 = stubEntry(null, "team-uuid");
+    const teams = [stubTeam(entry1, "team-uuid")];
+
+    jest.spyOn(Club, "findByPk").mockResolvedValue(club);
+    jest.spyOn(Team, "findAll").mockResolvedValue(teams);
+    const eventEntryFindAll = jest
+      .spyOn(EventEntry, "findAll")
+      .mockResolvedValue([entry1] as unknown as EventEntry[]);
+    jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
+
+    await resolver.finishEventEntry(user, "club-uuid", 2026, "test@example.com");
+
+    expect(eventEntryFindAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lock: mockTransaction.LOCK.UPDATE,
+        transaction: mockTransaction,
+      })
+    );
+  });
+
+  // Case #12: edit-any:club permission grants access
+  it("allows caller with edit-any:club permission", async () => {
+    const user = asUnknown<Player>({
+      id: "admin-uuid",
+      hasAnyPermission: jest
+        .fn()
+        .mockImplementation(async (perms: string[]) => perms.includes("edit-any:club")),
+    });
+    const club = stubClub();
+    const entry1 = stubEntry(null, "team-uuid");
+    const teams = [stubTeam(entry1, "team-uuid")];
+
+    jest.spyOn(Club, "findByPk").mockResolvedValue(club);
+    jest.spyOn(Team, "findAll").mockResolvedValue(teams);
+    jest.spyOn(EventEntry, "findAll").mockResolvedValue([entry1] as unknown as EventEntry[]);
+    jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
+
+    const result = await resolver.finishEventEntry(user, "club-uuid", 2026, "test@example.com");
+
+    expect(result.success).toBe(true);
+    expect(result.alreadyFinalised).toBe(false);
+    expect(mockTransaction.commit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/backend/graphql/src/resolvers/event/entry.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/entry.resolver.ts
@@ -16,15 +16,22 @@ import {
 import { EnrollmentValidationService, TeamEnrollmentOutput } from "@badman/backend-enrollment";
 import { NotificationService } from "@badman/backend-notifications";
 import { LoggingAction, TeamMembershipType } from "@badman/utils";
-import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { Logger, NotFoundException, UnauthorizedException } from "@nestjs/common";
 import { Args, ID, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
+import { GraphQLError } from "graphql";
+import { Sequelize } from "sequelize-typescript";
 import { ListArgs } from "../../utils";
+import { ErrorCode } from "../../utils/error-codes";
+import { FinishEventEntryResult } from "./finish-event-entry-result.object";
 
 @Resolver(() => EventEntry)
 export class EventEntryResolver {
+  private readonly logger = new Logger(EventEntryResolver.name);
+
   constructor(
     private notificationService: NotificationService,
-    private enrollmentService: EnrollmentValidationService
+    private enrollmentService: EnrollmentValidationService,
+    private _sequelize: Sequelize
   ) {}
 
   @Query(() => EventEntry)
@@ -117,13 +124,13 @@ export class EventEntryResolver {
     return validation.teams?.find((t) => t.id === team.id) ?? null;
   }
 
-  @Mutation(() => Boolean)
+  @Mutation(() => FinishEventEntryResult)
   async finishEventEntry(
     @User() user: Player,
     @Args("clubId", { type: () => ID }) clubId: string,
     @Args("season", { type: () => Int }) season: number,
     @Args("email", { type: () => String }) email: string
-  ) {
+  ): Promise<FinishEventEntryResult> {
     if (!(await user.hasAnyPermission([clubId + "_edit:club", "edit-any:club"]))) {
       throw new UnauthorizedException(`You do not have permission to enroll a club`);
     }
@@ -133,42 +140,104 @@ export class EventEntryResolver {
       throw new NotFoundException(clubId);
     }
 
-    // update the contact email of the club if it is different
-    if (club.contactCompetition !== email) {
-      club.contactCompetition = email;
-      await club.save();
-    }
+    const transaction = await this._sequelize.transaction();
 
-    await this.notificationService.notifyEnrollment(user.id, clubId, season, email);
+    try {
+      // Fetch teams for the club and season
+      const teams = await Team.findAll({
+        where: {
+          clubId: clubId,
+          season: season,
+        },
+        include: [{ model: EventEntry }],
+        transaction,
+      });
 
-    const teamsOfClub = await Team.findAll({
-      where: {
-        clubId: clubId,
-        season: season,
-      },
-      include: [{ model: EventEntry }],
-    });
-
-    for (const team of teamsOfClub) {
-      if (!team.entry) {
-        continue;
+      // Reject if no teams exist for this club and season
+      if (teams.length === 0) {
+        throw new GraphQLError("No teams to finalise for this club and season", {
+          extensions: { code: ErrorCode.NO_TEAMS_TO_FINALISE, clubId, season },
+        });
       }
 
-      team.entry.sendOn = new Date();
-      await team.entry.save();
+      // Collect team IDs that have entries for row locking
+      const teamIds = teams.filter((t) => t.entry).map((t) => t.id);
+
+      // Acquire row-level locks on EventEntry rows for this club+season
+      const entries = await EventEntry.findAll({
+        where: { teamId: teamIds },
+        lock: transaction.LOCK.UPDATE,
+        transaction,
+      });
+
+      // Idempotency check: all entries already have sendOn set
+      const alreadyFinalised =
+        entries.length > 0 && entries.every((e) => e.sendOn !== null && e.sendOn !== undefined);
+
+      if (alreadyFinalised) {
+        // Only permitted side-effect on no-op path: update contact email if different
+        if (club.contactCompetition !== email) {
+          club.contactCompetition = email;
+          await club.save({ transaction });
+        }
+
+        await transaction.commit();
+        return { success: true, alreadyFinalised: true, notificationDispatched: false };
+      }
+
+      // Fresh finalisation path
+      // Update the contact email of the club if it is different
+      if (club.contactCompetition !== email) {
+        club.contactCompetition = email;
+        await club.save({ transaction });
+      }
+
+      // Update sendOn for all null entries only (partial-state safety)
+      for (const team of teams) {
+        if (!team.entry) {
+          continue;
+        }
+
+        if (team.entry.sendOn === null || team.entry.sendOn === undefined) {
+          team.entry.sendOn = new Date();
+          await team.entry.save({ transaction });
+        }
+      }
+
+      // Write audit log row
+      await Logging.create(
+        {
+          action: LoggingAction.EnrollmentSubmitted,
+          playerId: user.id,
+          meta: {
+            clubId,
+            season,
+            email,
+          },
+        },
+        { transaction }
+      );
+
+      await transaction.commit();
+
+      // Post-commit: dispatch notification (must NOT be inside transaction)
+      let notificationDispatched = false;
+      try {
+        await this.notificationService.notifyEnrollment(user.id, clubId, season, email);
+        notificationDispatched = true;
+      } catch (notifyError) {
+        this.logger.error(
+          `Failed to dispatch enrollment notification for club ${clubId} season ${season}`,
+          notifyError
+        );
+        notificationDispatched = false;
+      }
+
+      return { success: true, alreadyFinalised: false, notificationDispatched };
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
     }
-
-    await Logging.create({
-      action: LoggingAction.EnrollmentSubmitted,
-      playerId: user.id,
-      meta: {
-        clubId,
-        season,
-        email,
-      },
-    });
-
-    return true;
   }
   // @Mutation(returns => EventEntry)
   // async addEventEntry(

--- a/libs/backend/graphql/src/resolvers/event/finish-event-entry-result.object.ts
+++ b/libs/backend/graphql/src/resolvers/event/finish-event-entry-result.object.ts
@@ -1,0 +1,25 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+
+@ObjectType({
+  description:
+    "Result of a single finishEventEntry mutation. Distinguishes three terminal outcomes: fresh finalisation succeeded ({success: true, alreadyFinalised: false, notificationDispatched: true}), fresh finalisation succeeded but notification failed ({success: true, alreadyFinalised: false, notificationDispatched: false}), already-finalised no-op ({success: true, alreadyFinalised: true, notificationDispatched: false}).",
+})
+export class FinishEventEntryResult {
+  @Field(() => Boolean, {
+    description:
+      "Overall outcome. True whenever the resolver returns a value (i.e. did not throw). Reserved for forward-compat soft failures.",
+  })
+  declare success: boolean;
+
+  @Field(() => Boolean, {
+    description:
+      "True when every EventEntry for (clubId, season) already had sendOn set and the call was a no-op apart from an optional Club.contactCompetition update.",
+  })
+  declare alreadyFinalised: boolean;
+
+  @Field(() => Boolean, {
+    description:
+      "True when the post-commit notificationService.notifyEnrollment call succeeded. False when it threw, or when alreadyFinalised is true (no notification is attempted on the no-op path).",
+  })
+  declare notificationDispatched: boolean;
+}

--- a/libs/backend/graphql/src/utils/error-codes.ts
+++ b/libs/backend/graphql/src/utils/error-codes.ts
@@ -33,7 +33,10 @@ export const ErrorCode = {
 
   // Index calculation (libs/backend/graphql/src/resolvers/event/competition/calculate-index/calculate-index.resolver.ts)
   RANKING_SYSTEM_NOT_FOUND: "RANKING_SYSTEM_NOT_FOUND",
-  
+
+  // Event entry finalisation (libs/backend/graphql/src/resolvers/event/entry.resolver.ts)
+  NO_TEAMS_TO_FINALISE: "NO_TEAMS_TO_FINALISE",
+
 } as const;
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/specs/007-finish-event-entry-hardening/checklists/requirements.md
+++ b/specs/007-finish-event-entry-hardening/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: finishEventEntry Hardening
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec deliberately names backend tech (Sequelize transactions, NestJS, jest spies) in FR-001/FR-007 because the audience here is backend developers and the spec is scoped to a backend-only library. Project convention (CLAUDE.md) treats these as the lingua franca for backend specs rather than "implementation details to hide".
+- One open architectural question deferred to `/speckit.plan`: whether to add a `SELECT … FOR UPDATE` row-lock on `Team.entry` rows for the club+season inside the transaction. Documented under Assumptions.
+- Schema return-type compatibility decision (Boolean vs. additive object) is also deferred to planning per FR-008.

--- a/specs/007-finish-event-entry-hardening/contracts/finish-event-entry.graphql
+++ b/specs/007-finish-event-entry-hardening/contracts/finish-event-entry.graphql
@@ -1,0 +1,60 @@
+# GraphQL contract: finishEventEntry
+#
+# This file documents the post-change shape of the mutation. It is NOT a
+# hand-written SDL artefact — Apollo code-first generates the schema from the
+# resolver + @ObjectType. The contract here is the source of truth for the
+# sibling frontend repo's codegen expectations.
+
+"""
+Result of a single finishEventEntry mutation. Distinguishes three terminal
+outcomes:
+  - fresh finalisation succeeded:        {success: true,  alreadyFinalised: false, notificationDispatched: true}
+  - fresh finalisation, notify failed:   {success: true,  alreadyFinalised: false, notificationDispatched: false}
+  - already-finalised no-op:             {success: true,  alreadyFinalised: true,  notificationDispatched: false}
+"""
+type FinishEventEntryResult {
+  """
+  Overall outcome. True whenever the resolver returns a value (i.e. did not
+  throw). Reserved for forward-compat soft failures.
+  """
+  success: Boolean!
+
+  """
+  True when every EventEntry for (clubId, season) already had sendOn set and
+  the call was a no-op apart from an optional Club.contactCompetition update.
+  """
+  alreadyFinalised: Boolean!
+
+  """
+  True when the post-commit notificationService.notifyEnrollment call
+  succeeded. False when it threw, or when alreadyFinalised is true (no
+  notification is attempted on the no-op path).
+  """
+  notificationDispatched: Boolean!
+}
+
+extend type Mutation {
+  """
+  Finalise a club's enrollment for a given season. Atomic over:
+    - Club.contactCompetition update (if email arg differs)
+    - EventEntry.sendOn set on every team entry for (clubId, season)
+    - Logging row with action EnrollmentSubmitted
+
+  Idempotent: re-submission for an already-finalised (clubId, season) returns
+  alreadyFinalised: true and performs no writes other than (optionally)
+  updating Club.contactCompetition.
+
+  Authorisation: caller must hold "{clubId}_edit:club" or "edit-any:club".
+
+  Errors (GraphQLError.extensions.code):
+    PERMISSION_DENIED          — caller lacks required permission
+    CLUB_NOT_FOUND             — clubId is unknown
+    NO_TEAMS_TO_FINALISE       — extensions: { clubId, season }
+    INTERNAL_ERROR             — any other server error (transaction rolled back)
+  """
+  finishEventEntry(
+    clubId: ID!
+    season: Int!
+    email: String!
+  ): FinishEventEntryResult!
+}

--- a/specs/007-finish-event-entry-hardening/data-model.md
+++ b/specs/007-finish-event-entry-hardening/data-model.md
@@ -1,0 +1,94 @@
+# Phase 1 Data Model: finishEventEntry Hardening
+
+## New transient types
+
+### `FinishEventEntryResult` (`@ObjectType`, non-persistent)
+
+GraphQL return payload for the `finishEventEntry` mutation. Lives at [`libs/backend/graphql/src/resolvers/event/finish-event-entry-result.object.ts`](../../libs/backend/graphql/src/resolvers/event/finish-event-entry-result.object.ts).
+
+| Field | GraphQL type | TS type | Description |
+|-------|-------------|---------|-------------|
+| `success` | `Boolean!` | `boolean` | Overall outcome. `true` whenever the resolver returns a value (i.e. did not throw). Provided for symmetry with other mutation result types and for forward-compat. |
+| `alreadyFinalised` | `Boolean!` | `boolean` | `true` when every existing `EventEntry` for `(clubId, season)` already had `sendOn !== null` and the call was an idempotent no-op (apart from optional `Club.contactCompetition` update). `false` for fresh finalisation. |
+| `notificationDispatched` | `Boolean!` | `boolean` | `true` when the post-commit `notificationService.notifyEnrollment` call returned without throwing. `false` when it threw, OR when on the `alreadyFinalised: true` path (no notification is attempted). |
+
+**Invariants**:
+- `alreadyFinalised === true` implies `notificationDispatched === false`.
+- `success === false` is currently never returned; resolver throws instead. Field reserved for future "soft failure" outcomes.
+
+## Persistent entities (referenced, not modified structurally)
+
+### `Club` (`@badman/backend-database`)
+
+- Field touched: `contactCompetition: string`
+- Mutation behaviour: updated to the supplied `email` argument when (a) on the fresh path and the value differs, or (b) on the `alreadyFinalised: true` path and the value differs.
+
+### `Team` (`@badman/backend-database`)
+
+- Read-only here. Filtered by `(clubId, season)`. Used to enumerate the set of `EventEntry` rows.
+
+### `EventEntry` (`@badman/backend-database`, schema `event`)
+
+- Field touched: `sendOn: Date | null`
+- Lock: rows for the resolved `(clubId, season)` set are locked with `LOCK.UPDATE` inside the transaction before the idempotency precheck.
+- Mutation behaviour: every entry with `sendOn === null` has it set to `new Date()` on the fresh path. Untouched on the `alreadyFinalised: true` path.
+
+### `Logging` (`@badman/backend-database`, schema `system`)
+
+- One row created on the fresh path with `action = LoggingAction.EnrollmentSubmitted`, `playerId = user.id`, `meta = { clubId, season, email }`.
+- Zero rows on the `alreadyFinalised: true` path.
+- Zero rows on any error path (covered by transaction rollback).
+
+## Error contract additions
+
+### `ErrorCode.NO_TEAMS_TO_FINALISE`
+
+Added to [`libs/backend/graphql/src/utils/error-codes.ts`](../../libs/backend/graphql/src/utils/error-codes.ts) under a new `// Event entry finalisation` group.
+
+`GraphQLError.extensions` payload:
+
+```ts
+{
+  code: "NO_TEAMS_TO_FINALISE",
+  clubId: string,   // the requested club
+  season: number    // the requested season
+}
+```
+
+## State transitions
+
+```text
+                        +----------------------+
+                        | client invokes       |
+                        | finishEventEntry()   |
+                        +----------+-----------+
+                                   |
+                          (auth check fails) ----> UnauthorizedException
+                                   |
+                          (club not found) -----> NotFoundException
+                                   |
+                       BEGIN TRANSACTION
+                                   |
+              +--------------------+--------------------+
+              | lock+read EventEntries for (clubId,season)|
+              | read Teams for (clubId,season)             |
+              +--------------------+--------------------+
+                                   |
+                          (zero teams) ----> throw NO_TEAMS_TO_FINALISE
+                                   |               (rollback)
+                       compute alreadyFinalised
+                          /                  \
+                         /                    \
+                 alreadyFinalised        not yet finalised
+                 = true                  = fresh path
+                   |                          |
+        if email differs:           update club.contactCompetition (if differs)
+          update club.contactCompetition      set sendOn on null entries
+                   |                          create Logging row
+                   |                          |
+                COMMIT                     COMMIT
+                   |                          |
+        return {success, true, false}    notify (post-commit, try/catch)
+                                              |
+                                  return {success, false, dispatched?}
+```

--- a/specs/007-finish-event-entry-hardening/frontend-changes.md
+++ b/specs/007-finish-event-entry-hardening/frontend-changes.md
@@ -1,0 +1,169 @@
+# Frontend Migration Notes — finishEventEntry Hardening
+
+This document enumerates every frontend-visible change shipped by the backend feature
+[007-finish-event-entry-hardening](spec.md). It is the hand-off checklist for the
+sibling frontend repo (`badman-frontend`, Next.js) and, where still applicable, for
+the legacy Angular SPA inside this monorepo.
+
+**Compatibility level**: BREAKING. Coordinated release required — backend PR cannot
+merge to `develop` until the frontend PR(s) consuming the new shape are open and
+green.
+
+---
+
+## 1. Mutation return type changes from `Boolean!` to `FinishEventEntryResult!`
+
+**Before**:
+
+```graphql
+mutation FinishEvent($clubId: ID!, $email: String!, $season: Int!) {
+  finishEventEntry(clubId: $clubId, email: $email, season: $season)
+}
+```
+
+The mutation field returned `Boolean!`. Generated TS type:
+`Mutation['finishEventEntry']: boolean`.
+
+**After**:
+
+```graphql
+mutation FinishEvent($clubId: ID!, $email: String!, $season: Int!) {
+  finishEventEntry(clubId: $clubId, email: $email, season: $season) {
+    success
+    alreadyFinalised
+    notificationDispatched
+  }
+}
+```
+
+Generated TS type: `Mutation['finishEventEntry']: { success: boolean; alreadyFinalised: boolean; notificationDispatched: boolean }`.
+
+**Frontend action**:
+- Update the `.graphql` document to select the three subfields.
+- Re-run codegen (`yarn codegen` in `badman-frontend`; `nx run badman:codegen` in the legacy SPA if still wired).
+- Replace any `if (data.finishEventEntry)` boolean check with field access.
+
+---
+
+## 2. New terminal outcomes the UI must handle
+
+| Backend result | Meaning | Suggested UX |
+|----------------|---------|--------------|
+| `{ success: true, alreadyFinalised: false, notificationDispatched: true }` | Fresh finalisation, confirmation email/push sent. | Show "Submission complete — confirmation sent to {email}". |
+| `{ success: true, alreadyFinalised: false, notificationDispatched: false }` | DB committed but notification dispatch failed. | Show "Submission complete — confirmation email could not be sent. Retry?" Offer a button that re-calls `finishEventEntry` (the backend will hit the idempotent path on retry — see #3). |
+| `{ success: true, alreadyFinalised: true, notificationDispatched: false }` | Already submitted. | Show "Already submitted" terminal state. Disable the submit CTA. |
+
+**Frontend action**: replace any single boolean branch with the three-way split above.
+The legacy Angular wizard's "submitted!" toast logic must be widened.
+
+---
+
+## 3. Backend is now idempotent on re-submit
+
+Re-calling `finishEventEntry` for an already-finalised `(clubId, season)` is now safe:
+no duplicate email, no duplicate audit row, no `sendOn` overwrite. The frontend's
+"already submitted" guard (BAD-122) becomes a UX nicety rather than a correctness
+requirement.
+
+**Frontend action**:
+- The retry button suggested in #2 can call the mutation directly without a
+  pre-flight check.
+- The wizard-load guard (`hadEntries` flag from BAD-122) should now treat
+  `alreadyFinalised: true` returned from a submit attempt as authoritative — if it
+  comes back true, the wizard is already done, regardless of what the load-time
+  guard said.
+
+---
+
+## 4. New email-update side-effect on the no-op path
+
+When the user re-submits with a `email` arg that differs from the stored
+`Club.contactCompetition`, the backend updates the club's contact email **even on
+the `alreadyFinalised: true` path**. No notification is sent and no audit row is
+written. The new email persists.
+
+**Frontend action**: nothing required, but be aware that:
+- Cached `Club.contactCompetition` in Apollo cache may go stale after a re-submit
+  attempt. Add `Club` to the mutation's `refetchQueries` / `update` callback if
+  the wizard or club-settings page reads `contactCompetition` afterwards.
+- If the product team prefers the email NOT change on the no-op path, raise it now
+  — current spec deliberately allows this (clarification recorded in
+  [spec.md](spec.md#clarifications)).
+
+---
+
+## 5. New error code: `NO_TEAMS_TO_FINALISE`
+
+Submitting a `(clubId, season)` that has zero `Team` rows now throws a
+`GraphQLError` with `extensions.code === "NO_TEAMS_TO_FINALISE"` and
+`extensions: { clubId, season }`.
+
+**Frontend action**:
+- Add `NO_TEAMS_TO_FINALISE` to the existing extensions-code-to-translation-key
+  map (in `badman-frontend`: alongside `extensionsCodeMapForCreateEnrollment` in
+  `useTranslateValidationError`).
+- Add a translation key in all three locales via the `translation-manager` agent
+  (do NOT hand-edit `all.json`). Suggested key path:
+  `all.v1.enrollment.error.noTeamsToFinalise`.
+- Wizard logic that gates the submit CTA on team count should already prevent
+  this case from reaching the backend; treat it as a defensive backend guard only.
+
+---
+
+## 6. Notification failure no longer rolls back the database
+
+Previously, a notification-service failure would surface as a thrown
+`GraphQLError` (and confusingly leave half-written `sendOn` timestamps from the
+pre-failure loop iterations). Now, DB writes commit first; the notification
+attempt happens after commit; failure surfaces as `notificationDispatched: false`,
+not as a thrown error.
+
+**Frontend action**: remove any code path that treats a thrown
+`finishEventEntry` error as "the submission probably half-succeeded — refresh
+to find out". The new contract makes this unambiguous.
+
+---
+
+## 7. Permission and not-found errors unchanged
+
+- Lacking `{clubId}_edit:club` / `edit-any:club` still produces a thrown error.
+  The backend error class is `UnauthorizedException` (NestJS) but the GraphQL
+  error code is `PERMISSION_DENIED` (existing constant). No frontend change.
+- Unknown `clubId` still produces a thrown error mapping to `CLUB_NOT_FOUND`.
+  No frontend change.
+
+---
+
+## 8. Schema diff (TL;DR)
+
+```diff
+-extend type Mutation {
+-  finishEventEntry(clubId: ID!, email: String!, season: Int!): Boolean!
+-}
++type FinishEventEntryResult {
++  success: Boolean!
++  alreadyFinalised: Boolean!
++  notificationDispatched: Boolean!
++}
++
++extend type Mutation {
++  finishEventEntry(clubId: ID!, email: String!, season: Int!): FinishEventEntryResult!
++}
+```
+
+New error code added to clients' classified-error catalog: `NO_TEAMS_TO_FINALISE`.
+
+---
+
+## 9. Coordinated rollout
+
+1. Backend PR opens against `develop` with this spec, plan, and implementation.
+2. Frontend PR(s) open in `badman-frontend` (and, if still actively serving the
+   wizard, `apps/badman/`) with the document update + codegen + UX branching from
+   sections 1–5 above.
+3. Both PRs reference each other in their description.
+4. Merge order: backend merges first to `develop` (the schema change does not
+   affect a deployed environment until both repos rebuild). Frontend merges
+   immediately after.
+5. Sanity-check: hit each of the three terminal outcomes (quickstart §3.a–c)
+   from a deployed preview before marking BAD-122 done.

--- a/specs/007-finish-event-entry-hardening/plan.md
+++ b/specs/007-finish-event-entry-hardening/plan.md
@@ -1,0 +1,106 @@
+# Implementation Plan: finishEventEntry Hardening
+
+**Branch**: `007-finish-event-entry-hardening` | **Date**: 2026-05-02 | **Spec**: [spec.md](spec.md)
+**Input**: [spec.md](spec.md)
+
+## Summary
+
+Wrap `EventEntryResolver.finishEventEntry` writes in a single Sequelize transaction; add an idempotency precheck so re-submission never sends a duplicate notification or writes a duplicate audit-log row; replace the `Boolean!` return with a `FinishEventEntryResult!` object exposing `success` / `alreadyFinalised` / `notificationDispatched`; reject zero-team finalisation with `GraphQLError` code `NO_TEAMS_TO_FINALISE`; dispatch the notification AFTER commit so its failure cannot roll back the database; ship a co-located `entry.resolver.spec.ts` matching the project's resolver test convention.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x on Node 20 (Nx monorepo)
+**Primary Dependencies**: NestJS, Apollo (`@nestjs/graphql`, code-first), Sequelize + `sequelize-typescript`, `nestjs-i18n`, Bull (Redis); `@badman/backend-database`, `@badman/backend-graphql`, `@badman/backend-notifications`, `@badman/backend-authorization`
+**Storage**: PostgreSQL via Sequelize. Tables touched: `Clubs.contactCompetition`, `event.EventEntries.sendOn`, `system.Loggings`. No schema migration.
+**Testing**: Jest. Co-located `entry.resolver.spec.ts`; `Test.createTestingModule` + mocked `Sequelize`, `jest.spyOn` on model statics, mocked `NotificationService`. Run via `nx test backend-graphql`.
+**Target Platform**: Linux server, NestJS on Fastify, port 5010.
+**Project Type**: Backend mutation hardening inside an existing Nx monorepo. No new app or lib.
+**Performance Goals**: Resolver completes within current latency envelope. Spec suite under 5 s locally.
+**Constraints**: Notification dispatch MUST occur after commit — must not extend transaction lifetime over a network call. Schema return-type change is breaking; coordinated with sibling frontend repo's release.
+**Scale/Scope**: Single resolver method; one new `@ObjectType` (`FinishEventEntryResult`); one new `ErrorCode` constant; one new spec file.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Compliance |
+|-----------|-----------|
+| **I. Code-First GraphQL via Sequelize Models** | PASS. `FinishEventEntryResult` is a non-persistent `@ObjectType` for a mutation result — same pattern as `TeamResult` / `EnrollmentResult`. No new persistent entity, no SDL, no DTO duplication. |
+| **II. Translation Discipline** | N/A. No `all.json` strings touched. Error code strings are machine-readable identifiers, not user copy. |
+| **III. Transactional Mutations** | PASS — this feature exists to bring the resolver into compliance. Writes wrapped in a single Sequelize transaction; auth checked before any write; commit/rollback boundaries explicit. The idempotency clause of Principle III formally applies to *create* mutations with natural uniqueness keys; we apply the same shape here (`alreadyFinalised: boolean`) by analogy because finalisation has a natural uniqueness key `(clubId, season)`. Documented in research.md. |
+| **IV. Resolver Test Discipline** | PASS — adds the missing co-located spec to `entry.resolver.ts`. Matches the reference pattern in `enrollmentSetting.resolver.spec.ts`. |
+| **V. Legacy Frontend Boundary** | PASS. No changes under `apps/badman/` or `libs/frontend/`. Schema break forces a generated-types regen for the legacy SPA only — a tooling artefact regen, not feature work. |
+
+No violations. **Complexity Tracking** section omitted.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-finish-event-entry-hardening/
+├── plan.md                     # this file
+├── spec.md
+├── spec.original.md            # pre-compression backup
+├── research.md                 # Phase 0
+├── data-model.md               # Phase 1
+├── quickstart.md               # Phase 1
+├── contracts/
+│   └── finish-event-entry.graphql
+├── checklists/
+│   └── requirements.md
+└── tasks.md                    # produced later by /speckit-tasks
+```
+
+### Source Code (repository root)
+
+Only existing locations are touched:
+
+```text
+libs/backend/graphql/src/
+├── resolvers/event/
+│   ├── entry.resolver.ts                       # MODIFY
+│   ├── entry.resolver.spec.ts                  # CREATE
+│   └── finish-event-entry-result.object.ts     # CREATE
+└── utils/
+    └── error-codes.ts                          # MODIFY: add NO_TEAMS_TO_FINALISE
+```
+
+No changes outside `libs/backend/graphql/`. No DB migration. No worker code. No translation files.
+
+**Structure Decision**: Single-project, in-place modification of `libs/backend/graphql`. The mutation, its contract, its test, and its result object all live next to one another so a reviewer reads the change as one cohesive unit. The new error code joins the existing shared registry.
+
+## Phase 0 — Research
+
+See [research.md](research.md). All NEEDS CLARIFICATION items resolved:
+
+1. **Concurrency / row-locking**: deferred from spec to plan — resolved with `SELECT ... FOR UPDATE` on the affected `EventEntry` rows inside the transaction.
+2. **Notification post-commit ordering**: resolved — notification awaited after `transaction.commit()` returns; failure caught and surfaced as `notificationDispatched: false`, never rolls back DB.
+3. **Idempotency precheck location**: resolved — performed inside the transaction immediately after the row-lock acquire, before any writes.
+4. **Audit-log content on idempotent path**: resolved — no `Logging` row written when `alreadyFinalised: true`. Email-only update on the no-op path is silent at the DB layer.
+
+## Phase 1 — Design & Contracts
+
+### Data model
+
+See [data-model.md](data-model.md). No new persistent entities. One new transient `@ObjectType` (`FinishEventEntryResult`).
+
+### Contracts
+
+See [contracts/finish-event-entry.graphql](contracts/finish-event-entry.graphql). Captures the new mutation signature, return type fields, and the per-code `extensions` payload for `NO_TEAMS_TO_FINALISE`, `PERMISSION_DENIED`, `CLUB_NOT_FOUND`. Sibling frontend repo will codegen against this.
+
+### Quickstart
+
+See [quickstart.md](quickstart.md). Developer-facing checklist for verifying the change locally.
+
+### Frontend migration notes
+
+See [frontend-changes.md](frontend-changes.md) — exhaustive checklist of frontend-visible changes (return-type swap, three terminal outcomes, idempotency, email side-effect on no-op path, new error code, notification-failure semantics, schema diff, coordinated rollout). Hand this to the frontend repo as the implementation brief for BAD-122 follow-up.
+
+### Agent context update
+
+`CLAUDE.md` plan-reference block updated to point at this plan file. (Symlink → `AGENTS.md`.)
+
+## Re-evaluated Constitution Check (post-design)
+
+Same five principles, same outcome — all PASS. Design did not introduce new abstractions, new persistence, or translation work.

--- a/specs/007-finish-event-entry-hardening/quickstart.md
+++ b/specs/007-finish-event-entry-hardening/quickstart.md
@@ -1,0 +1,73 @@
+# Quickstart: finishEventEntry Hardening
+
+Local verification checklist for the backend change. Assumes `npm run docker:up` already running.
+
+## 1. Build the affected lib
+
+```bash
+nx build backend-graphql
+```
+
+## 2. Run the new resolver spec
+
+```bash
+npx jest --config libs/backend/graphql/jest.config.ts \
+  libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts
+```
+
+Expected: all 12 cases (R7 in `research.md`) pass; suite under 5 s.
+
+## 3. Serve the API and exercise the GraphQL playground
+
+```bash
+nx serve api
+```
+
+Open `http://localhost:5010/graphql`. Run the three terminal-outcome cases against a seeded club + season.
+
+### 3.a Fresh finalisation (happy path)
+
+```graphql
+mutation FreshFinalise {
+  finishEventEntry(clubId: "<clubId>", season: 2026, email: "comp@club.test") {
+    success
+    alreadyFinalised
+    notificationDispatched
+  }
+}
+```
+
+Expected: `{ success: true, alreadyFinalised: false, notificationDispatched: true }`. Inspect:
+- `system.Loggings` has one new row with `action = 'EnrollmentSubmitted'` and matching `meta`.
+- Every `event.EventEntries.sendOn` for the club's teams in 2026 is non-null.
+- `Clubs.contactCompetition` reflects the supplied email.
+
+### 3.b Idempotent re-submit
+
+Run the mutation a second time with identical args.
+
+Expected: `{ success: true, alreadyFinalised: true, notificationDispatched: false }`. Inspect:
+- No new `Loggings` row.
+- No `sendOn` timestamps changed (compare timestamps).
+- No mail dispatched (check the mail service log / fake transport).
+
+### 3.c Zero-team rejection
+
+Pick a club+season pair with no `Team` rows.
+
+Expected: `errors[0].extensions.code === "NO_TEAMS_TO_FINALISE"` with `clubId` and `season` echoed in `extensions`. No DB writes.
+
+## 4. Lint + format
+
+```bash
+nx lint backend-graphql
+prettier --check libs/backend/graphql/src/resolvers/event/
+```
+
+## 5. Affected tests
+
+```bash
+nx affected:test
+```
+
+Should be green. If not, the change touched something outside the documented surface — investigate before pushing.

--- a/specs/007-finish-event-entry-hardening/research.md
+++ b/specs/007-finish-event-entry-hardening/research.md
@@ -1,0 +1,91 @@
+# Phase 0 Research: finishEventEntry Hardening
+
+## R1 — Concurrency / row locking
+
+**Decision**: Inside the new transaction, acquire `SELECT ... FOR UPDATE` on the relevant `EventEntry` rows for the `(clubId, season)` set BEFORE running the idempotency precheck. In Sequelize: `EventEntry.findAll({ where: { ... }, transaction, lock: transaction.LOCK.UPDATE })`.
+
+**Rationale**: Two browser tabs (or a retry-on-network-blip) can race the mutation. Without a row lock, both transactions read `sendOn === null` for the same entries, both proceed to write, and both dispatch a notification. The lock serialises competing submitters of the same `(clubId, season)`: the second transaction blocks until the first commits, then reads `sendOn !== null` and returns `alreadyFinalised: true`. PostgreSQL's default isolation (READ COMMITTED) is sufficient when combined with the row lock.
+
+**Alternatives considered**:
+- *Optimistic concurrency via a `version` column on `EventEntry`*: requires a schema migration, doesn't exist today, and adds complexity disproportionate to a single mutation.
+- *Application-level mutex via Redis*: introduces a new failure mode (Redis down) for a problem the database can solve directly.
+- *No locking, rely on isolation level*: fails — READ COMMITTED allows the race. Switching to SERIALIZABLE for one resolver is invasive and would need retry-on-serialization-failure plumbing across the resolver.
+
+The `Team` rows are read with `include: [{ model: EventEntry }]`. The lock is applied via `EventEntry`'s rows since those carry `sendOn`, the field actually being raced on. Locking `Team` rows is unnecessary.
+
+## R2 — Notification dispatch ordering
+
+**Decision**: Run `notificationService.notifyEnrollment(...)` AFTER `await transaction.commit()` returns. Wrap the call in its own `try/catch`. On failure: log the error, set `notificationDispatched = false` on the result, return normally. On success: `notificationDispatched = true`. The result's `success: true` reflects the persistence outcome; `notificationDispatched` is the side-effect signal.
+
+**Rationale**: Notifications go over SMTP and push gateways. Holding a transaction open across a network call is a known antipattern — it stalls connection pool capacity and turns transient mail-server slowness into database contention. Per FR-002, notification failure must NOT roll back the database; the entries are persisted, the federation can already see `sendOn`, so retrying the notification independently is the correct affordance.
+
+**Alternatives considered**:
+- *Notify inside the transaction (status quo)*: violates FR-002, holds connections, conflates two different failure surfaces.
+- *Enqueue notification on a Bull queue, return immediately*: cleanest long-term, but adds a queue to a previously synchronous flow and changes user-visible behaviour (no synchronous "we sent the email" signal). Out of scope; can be revisited as a follow-up.
+
+## R3 — Idempotency precheck location
+
+**Decision**: Inside the transaction, after the row-lock acquire, before any writes:
+
+```text
+1. transaction.start
+2. lock+read EventEntry rows for (clubId, season)
+3. compute alreadyFinalised = entries.length > 0 && entries.every(e => e.sendOn !== null)
+4. lookup Team rows for (clubId, season); if zero → throw NO_TEAMS_TO_FINALISE (rolls back txn)
+5. if alreadyFinalised:
+     5a. if club.contactCompetition !== email → update club.contactCompetition (single write)
+     5b. commit
+     5c. return { success: true, alreadyFinalised: true, notificationDispatched: false }
+6. else fresh path: update club email if differs, set sendOn on null entries, write Logging
+7. commit
+8. post-commit: dispatch notification, set notificationDispatched accordingly
+9. return { success: true, alreadyFinalised: false, notificationDispatched }
+```
+
+**Rationale**: Putting the precheck inside the transaction (rather than as a pre-flight read outside) keeps the lock + decision atomic. The post-commit notification only runs on the fresh path; on the no-op path nothing is dispatched, matching FR-003.
+
+**Alternatives considered**:
+- *Pre-flight read outside the transaction, then re-check inside*: doubles the query count for no behavioural gain.
+- *Database-level unique constraint on `EventEntry.sendOn`*: nonsensical — `sendOn` is a timestamp, not a uniqueness attribute. The natural uniqueness key for finalisation lives at the *set* level (`(clubId, season)`), which a row-level constraint cannot express.
+
+## R4 — Audit-log behaviour on idempotent path
+
+**Decision**: When `alreadyFinalised: true`, write zero `Logging` rows. The contact-email side-effect on the no-op path is not audit-logged. Original finalisation already has its `EnrollmentSubmitted` row with the email at the time of submission; subsequent contact-email updates flow through the regular `Club.contactCompetition` audit story (or lack thereof — out of scope here).
+
+**Rationale**: An audit row labelled `EnrollmentSubmitted` written when no submission happened would corrupt downstream queries that count submissions per season. The email update is a low-stakes data fix; if richer auditing is desired later, it belongs in a `updateClub` mutation, not as a side-channel of finalisation.
+
+## R5 — `NO_TEAMS_TO_FINALISE` error-code semantics
+
+**Decision**: Add `NO_TEAMS_TO_FINALISE: "NO_TEAMS_TO_FINALISE"` to the registry at [`libs/backend/graphql/src/utils/error-codes.ts`](../../libs/backend/graphql/src/utils/error-codes.ts) under a new `// Event entry finalisation` group. `extensions` payload: `{ code: "NO_TEAMS_TO_FINALISE", clubId: string, season: number }`. Thrown via `new GraphQLError("No teams to finalise for this club and season", { extensions })`.
+
+**Rationale**: Matches the existing convention used by `createEnrollment` / `createTeam`. Frontend can map the code to a localised message using `extensionsCodeMap` style (per BAD-122 frontend) without parsing English message text.
+
+## R6 — Result object placement & naming
+
+**Decision**: Create [`libs/backend/graphql/src/resolvers/event/finish-event-entry-result.object.ts`](../../libs/backend/graphql/src/resolvers/event/finish-event-entry-result.object.ts) defining `FinishEventEntryResult` as a non-persistent `@ObjectType`. Keeps it next to the resolver (precedent: `team-result.object.ts` lives next to `team.resolver.ts`).
+
+**Rationale**: Discoverability for reviewers; consistent with two existing reference implementations cited by Constitution Principle III.
+
+## R7 — Spec coverage matrix
+
+The new `entry.resolver.spec.ts` covers, at minimum, this matrix (each row = one `it(...)` test):
+
+| # | Scenario | Models stubbed | Expected |
+|---|----------|----------------|----------|
+| 1 | unauthorized user (no perms) | `Player.hasAnyPermission` returns false | `UnauthorizedException`; no model writes |
+| 2 | unknown clubId | `Club.findByPk` → null | `NotFoundException`; no other reads |
+| 3 | zero teams for season | `Team.findAll` → `[]` | throws `GraphQLError` with `extensions.code === NO_TEAMS_TO_FINALISE`; transaction rolled back |
+| 4 | fresh finalisation happy path | 3 teams, all entries `sendOn === null` | all `entry.save` called; one `Logging.create`; `transaction.commit`; notification dispatched once; result `{ success: true, alreadyFinalised: false, notificationDispatched: true }` |
+| 5 | rollback on `Logging.create` throw | as #4 but `Logging.create` throws | `transaction.rollback`; no notification call; resolver re-throws |
+| 6 | already-finalised no-op (same email) | every entry `sendOn !== null`; `club.contactCompetition === email` | no writes; no notification; result `{ success: true, alreadyFinalised: true, notificationDispatched: false }` |
+| 7 | already-finalised + email differs | every entry `sendOn !== null`; `club.contactCompetition !== email` | only `club.save` called inside txn; no `Logging`, no `entry.save`; no notification; result `alreadyFinalised: true` |
+| 8 | partial state (some entries null) | mix of `sendOn` set and null | only the null entries updated; one `Logging`; one notification; `alreadyFinalised: false` |
+| 9 | team without entry row | `team.entry === null` | skipped in the loop; no error |
+| 10 | notification fails post-commit | as #4 but `notifyEnrollment` rejects | DB writes committed; result `{ success: true, alreadyFinalised: false, notificationDispatched: false }`; resolver does NOT throw |
+| 11 | row-lock query uses `LOCK.UPDATE` | inspect `findAll` call args | second arg includes `lock: transaction.LOCK.UPDATE` and the same `transaction` object |
+| 12 | edit-any:club permission grants access | `hasAnyPermission` returns true on second arg | proceeds as #4 |
+
+## R8 — Open follow-ups (not in this feature)
+
+- Consider moving notification dispatch to a Bull queue for fire-and-forget delivery and built-in retry. Tracked as a tech-debt note candidate, not added here.
+- Consider auditing `Club.contactCompetition` updates centrally (a generic audit on `Club` mutations). Out of scope.

--- a/specs/007-finish-event-entry-hardening/spec.md
+++ b/specs/007-finish-event-entry-hardening/spec.md
@@ -1,0 +1,117 @@
+# Feature Specification: finishEventEntry Hardening
+
+**Feature Branch**: `007-finish-event-entry-hardening`
+**Created**: 2026-05-02
+**Status**: Draft
+**Input**: User description: "Backend hardening of finishEventEntry: wrap multi-write mutation in transaction, add idempotency guard so re-submission does not re-notify or re-log, add resolver spec test."
+
+## Clarifications
+
+### Session 2026-05-02
+
+- Q: Mutation return shape — Boolean (FR-008) vs rich object (FR-004) — which? → A: Replace Boolean with `FinishEventEntryResult` object (`success`, `alreadyFinalised`, `notificationDispatched`). Breaking schema change; both first-party callers updated same release.
+- Q: Behaviour when club has zero teams for season? → A: Reject with classified `GraphQLError` code `NO_TEAMS_TO_FINALISE`. No DB writes, no notification, no audit row.
+- Q: Already-finalised re-submit with different email arg — what happens? → A: Update `club.contactCompetition` to new email (single write inside transaction); still return `alreadyFinalised: true`, no notification, no audit row. Contact email only permitted side-effect on no-op path.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Atomic submission finalisation (Priority: P1)
+
+Club admin submits season enrollment. Backend finalises by updating club contact email, marking every team's `EventEntry.sendOn` timestamp, sending confirmation notification (push + email), writing audit log row. If any write fails mid-flight, DB must stay consistent — all writes succeed or none.
+
+**Why this priority**: Today finalisation = sequence of independent writes. Partial failure (e.g. notification throws after `sendOn` set on three of five entries) leaves federation seeing inconsistent submission, audit log missing. Only blocker preventing frontend (BAD-122) from treating finalisation as reliable terminal step.
+
+**Independent Test**: Inject forced failure on last write; verify earlier writes rolled back so next legitimate attempt sees original pre-submission state.
+
+**Acceptance Scenarios**:
+
+1. **Given** club with five team entries, all `sendOn = null`, **When** finalisation succeeds end-to-end, **Then** all five entries have `sendOn` set, audit log row exists, contact email updated, notification dispatched exactly once.
+2. **Given** finalisation begins and audit-log write fails, **When** mutation returns, **Then** no entry has `sendOn` set, contact email unchanged, next retry behaves as if failed attempt never happened.
+3. **Given** finalisation begins and notification dispatch fails, **When** mutation returns, **Then** DB state unchanged from before call.
+
+---
+
+### User Story 2 - Idempotent re-submission (Priority: P1)
+
+Club admin triggers submission second time (double-click, retry after network blip, reload wizard before frontend "already submitted" guard renders). Backend must recognise club+season already finalised — no second confirmation email, no second audit-log entry, no overwrite of original `sendOn` timestamps.
+
+**Why this priority**: Frontend guard (BAD-122) best-effort, races with reload. Without backend guard, duplicate emails go to club contacts, audit log ambiguous. Idempotency also required by project's create-mutation convention (Constitution Principle III, applied here for finalisation symmetry).
+
+**Independent Test**: Call mutation twice with identical args; assert DB state identical after call 1 and call 2, notification service invoked only once.
+
+**Acceptance Scenarios**:
+
+1. **Given** every team entry for `(clubId, season)` already has `sendOn` set, **When** mutation called again, **Then** no notification sent, no log row written, no `sendOn` modified, response indicates already finalised.
+2. **Given** some entries have `sendOn = null` and others do not (partial state from legacy half-finished submission), **When** mutation called, **Then** only null entries updated, single notification + audit-log row produced, result reflects fresh finalisation.
+3. **Given** contact email arg differs from stored `club.contactCompetition` AND submission already finalised, **When** mutation called, **Then** `club.contactCompetition` IS updated to new value (single write inside transaction), no notification, no audit-log row, no `sendOn` touched, response carries `alreadyFinalised: true`.
+
+---
+
+### User Story 3 - Resolver test coverage (Priority: P2)
+
+Backend dev changes any part of finalisation flow. Co-located resolver spec asserts mutation contract: auth gating, not-found handling, atomic success, transaction rollback on any internal failure, idempotency. CI fails fast if any contract broken.
+
+**Why this priority**: Project testing convention (CLAUDE.md) requires `*.resolver.spec.ts` co-located with every resolver. `entry.resolver.ts` has none. Necessary infrastructure — not value-adding alone, but blocks regressions in P1/P2 stories above.
+
+**Independent Test**: `nx test backend-graphql` passes with new spec exercising every acceptance scenario from Stories 1 and 2 using mocked Sequelize models and mocked notification service.
+
+**Acceptance Scenarios**:
+
+1. **Given** spec suite runs, **When** dev removes transaction wrapper, **Then** at least one rollback test fails.
+2. **Given** spec suite runs, **When** dev removes idempotency guard, **Then** at least one duplicate-submission test fails.
+
+---
+
+### Edge Cases
+
+- Club exists but zero teams for requested season: rejected with classified `GraphQLError` code `NO_TEAMS_TO_FINALISE`. No DB writes, no notification, no audit row. (See FR-009.)
+- Caller has `edit-any:club` but not per-club permission: must succeed (matches current `hasAnyPermission` semantics).
+- Team for club+season exists with `entry = null` (no `EventEntry` row yet): must skip, not throw. Matches today's `if (!team.entry) continue` branch.
+- Notification service slow / times out: must NOT hold DB transaction open for network call duration. Notification dispatched after commit, failure surfaced as partial-success signal not rollback.
+- Concurrent calls from two browser tabs: only one produces notification + log row. Other observes idempotent no-op outcome.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Mutation MUST execute all DB writes (club email update, every `EventEntry.sendOn` update, audit-log row insertion) inside single Sequelize transaction. On any thrown error within transaction scope, every write MUST roll back.
+- **FR-002**: Notification dispatch MUST occur AFTER transaction commits, not before. Dispatch failure MUST NOT roll back DB writes; response MUST signal partial success so caller can offer retry of notification step alone.
+- **FR-003**: When every `EventEntry` for `(clubId, season)` already has non-null `sendOn`, mutation MUST: dispatch no notification, write no audit-log row, leave every `EventEntry.sendOn` unchanged, return `alreadyFinalised: true`. ONLY permitted DB write on no-op path is updating `club.contactCompetition` when supplied email differs from stored value; that single write MUST occur inside same transaction as read that determined already-finalised state.
+- **FR-004**: Mutation MUST return `FinishEventEntryResult` object type carrying minimum: `success: Boolean!` (overall outcome), `alreadyFinalised: Boolean!` (true when call was no-op because `(clubId, season)` already finalised), `notificationDispatched: Boolean!` (true when post-commit notification call returned without error). Three flags together distinguish three outcomes: fresh finalisation succeeded, fresh finalisation succeeded but notification dispatch failed, already-finalised no-op.
+- **FR-005**: Mutation MUST preserve current auth: callers must hold either `{clubId}_edit:club` or `edit-any:club`. Unauthorised callers MUST receive permission error, no side effects.
+- **FR-006**: Mutation MUST preserve current not-found behaviour: unknown `clubId` MUST produce not-found error, no side effects.
+- **FR-007**: Co-located `entry.resolver.spec.ts` MUST exist, MUST cover minimum: authorised vs unauthorised callers, unknown club, fresh finalisation happy path, transaction rollback on injected mid-flight failure, idempotent re-submission no-op, partial state where some entries already have `sendOn` set, notification-failure partial-success path. Spec MUST follow project resolver test convention (mocked `Sequelize.transaction`, `jest.spyOn` on model statics, fake `Player` with `hasAnyPermission` jest.fn()).
+- **FR-008**: GraphQL schema `finishEventEntry` return type changes from `Boolean!` to `FinishEventEntryResult!` in single breaking release. Both first-party callers (legacy Angular wizard, new Next.js wizard) MUST update same release window. No deprecation alias retained.
+- **FR-009**: When club has zero `Team` rows for requested season (regardless of whether any teams have `EventEntry`), mutation MUST throw `GraphQLError` with `extensions.code = NO_TEAMS_TO_FINALISE`. Error code MUST be added to shared registry at [`libs/backend/graphql/src/utils/error-codes.ts`](libs/backend/graphql/src/utils/error-codes.ts). No DB writes, no notification, no audit-log row on this path.
+
+### Key Entities
+
+- **FinishEventEntryResult**: Mutation return payload. Carries `success`, `alreadyFinalised`, `notificationDispatched`. Sole signal to callers about which of three terminal outcomes occurred.
+- **EventEntry**: Per-team enrollment row. Carries `sendOn` timestamp federation reads to detect submission. Set of all `EventEntry` rows for `(clubId, season)` = source of truth for "is club's season already submitted".
+- **Club**: Owns `contactCompetition` (federation-facing email). Updated by mutation when supplied email differs.
+- **Logging**: Audit-log row written with action `EnrollmentSubmitted`, acting player, metadata `{ clubId, season, email }`. Exactly one row per fresh finalisation.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Zero observed cases of partial finalisation state in prod logs over 4-week window post-deploy (no orphaned `sendOn` timestamps without matching audit-log row, vice versa).
+- **SC-002**: Double-click or refresh-during-submit by end user produces exactly one confirmation email per `(clubId, season)`, verifiable in outbound mail logs.
+- **SC-003**: 100% of acceptance scenarios in Stories 1 and 2 covered by automated tests in `entry.resolver.spec.ts`, suite runs under 5 seconds locally.
+- **SC-004**: Dev can change any single line in finalisation flow and CI tells them within one test run whether contract still holds (no manual DB setup required).
+
+## Assumptions
+
+- Existing `notificationService.notifyEnrollment` impl acceptable as-is, treated as external side-effect invoked post-commit. Any retry mechanism for notification itself out of scope, lives behind partial-success response shape.
+- "Already finalised" defined strictly as: every `Team.entry` for `(clubId, season)` exists and has `sendOn !== null`. Teams with no entry row ignored for this check (consistent with current loop guard).
+- Breaking change to mutation return type acceptable because both consumers first-party, ship from this monorepo / sibling repo. Coordinated release: backend PR merges with frontend PRs that consume new shape. No external API contract exposed publicly.
+- Frontend BAD-122 work lands separately, out of scope for this spec; spec only ensures backend contract sound enough to rely on.
+- Concurrency bounded by Sequelize default isolation level; transaction plus `sendOn !== null` precheck inside transaction sufficient to serialise concurrent submitters of same `(clubId, season)`. Row-level lock on `Team.entry` rows for club+season MAY be added during planning if assumption challenged.
+
+## Dependencies
+
+- Backend models: `Club`, `Team`, `EventEntry`, `Logging`, `Player` (all in `@badman/backend-database`).
+- Services: `NotificationService` (`@badman/backend-notifications`).
+- Auth: `PermGuard` + `@User()` decorator (`@badman/backend-authorization`).
+- No DB migration required — schema unchanged.
+- No frontend coordination required for backend rollout itself; consumers (legacy Angular wizard, new Next.js wizard via BAD-122) call same mutation.

--- a/specs/007-finish-event-entry-hardening/tasks.md
+++ b/specs/007-finish-event-entry-hardening/tasks.md
@@ -1,0 +1,192 @@
+---
+
+description: "Tasks for finishEventEntry Hardening"
+---
+
+# Tasks: finishEventEntry Hardening
+
+**Input**: Design documents in `/specs/007-finish-event-entry-hardening/`
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/finish-event-entry.graphql](contracts/finish-event-entry.graphql)
+
+**Tests**: Included. FR-007 in [spec.md](spec.md) explicitly requires a co-located resolver spec; Constitution Principle IV mandates the resolver test pattern. Tests are part of the deliverable, not optional.
+
+**Organization**: Tasks grouped by user story. Stories US1 (atomic transaction) and US2 (idempotent re-submission) modify the same resolver method, so they MUST be implemented sequentially against `entry.resolver.ts`. US3 (resolver tests) co-evolves and is checkpointed last.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Different file or trivially-isolated change; no dependency on incomplete tasks.
+- **[Story]**: US1 / US2 / US3 — maps to user stories in [spec.md](spec.md).
+- File paths are absolute from repo root.
+
+## Path Conventions
+
+Single-project, in-place modification of [`libs/backend/graphql/`](../../libs/backend/graphql/). No new app or lib. No DB migration.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Prepare the working tree. Branch already exists.
+
+- [ ] T001 Verify branch `007-finish-event-entry-hardening` is checked out and clean: `git status` returns no surprises; `git rev-parse --abbrev-ref HEAD` returns the branch name
+- [ ] T002 [P] Confirm Docker stack is up for local verification (`npm run docker:up`) so quickstart §3 can run later
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared types and registry entries that BOTH US1 and US2 need before resolver edits.
+
+**⚠️ CRITICAL**: No story implementation may begin until this phase is complete.
+
+- [ ] T003 Add `NO_TEAMS_TO_FINALISE: "NO_TEAMS_TO_FINALISE"` to the registry in `libs/backend/graphql/src/utils/error-codes.ts` under a new `// Event entry finalisation` group; keep alphabetical-within-group ordering as the file establishes
+- [ ] T004 [P] Create the `FinishEventEntryResult` `@ObjectType` in `libs/backend/graphql/src/resolvers/event/finish-event-entry-result.object.ts` with three `Boolean!` fields (`success`, `alreadyFinalised`, `notificationDispatched`) and the field descriptions from [contracts/finish-event-entry.graphql](contracts/finish-event-entry.graphql); follow the structure of `libs/backend/graphql/src/resolvers/team/team-result.object.ts`
+- [ ] T005 Export `FinishEventEntryResult` from the appropriate barrel/index so it is reachable by `entry.resolver.ts` (verify there is no separate index file in `resolvers/event/`; if there is, add the export — otherwise direct import is fine and this task is a no-op)
+
+**Checkpoint**: Result type exists, error code exists. Stories can now begin.
+
+---
+
+## Phase 3: User Story 1 — Atomic submission finalisation (Priority: P1) 🎯 MVP
+
+**Goal**: Wrap every database write inside a single Sequelize transaction. Roll back on any thrown error. Move notification dispatch to after `commit`. Reject zero-team finalisation with `NO_TEAMS_TO_FINALISE`. Switch the mutation return to `FinishEventEntryResult`.
+
+**Independent Test**: Run the resolver against a real or mocked DB; force the `Logging.create` call to throw mid-flight; verify `transaction.rollback` runs and no `EventEntry.sendOn` is set. Verified end-to-end via [quickstart.md](quickstart.md) §3.a and [research.md](research.md) R7 cases #3, #4, #5.
+
+### Implementation for User Story 1
+
+- [ ] T006 [US1] Inject `Sequelize` into `EventEntryResolver` constructor in `libs/backend/graphql/src/resolvers/event/entry.resolver.ts` (private field `_sequelize`). Pattern: copy from `libs/backend/graphql/src/resolvers/enrollmentSetting/enrollmentSetting.resolver.ts`
+- [ ] T007 [US1] Change `finishEventEntry` return type from `Boolean` to `FinishEventEntryResult` (decorator `@Mutation(() => FinishEventEntryResult)`, TS return `Promise<FinishEventEntryResult>`) in `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
+- [ ] T008 [US1] Open a transaction via `await this._sequelize.transaction()` at the start of the mutation body (after auth + `Club.findByPk` checks); pass `{ transaction }` to every Sequelize call inside; `commit()` on success, `rollback()` in a `catch` re-throw block, in `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
+- [ ] T009 [US1] Inside the transaction: replace the existing `Team.findAll(...)` with one that includes `EventEntry` AND uses `lock: transaction.LOCK.UPDATE` on the included entries (or a separate `EventEntry.findAll({ where: { teamId: { [Op.in]: teamIds } }, lock, transaction })` after fetching teams), in `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`. Reference: [research.md](research.md) R1
+- [ ] T010 [US1] Add zero-team rejection: if `teams.length === 0`, throw `new GraphQLError("No teams to finalise for this club and season", { extensions: { code: ErrorCode.NO_TEAMS_TO_FINALISE, clubId, season } })`. Imports: `GraphQLError` from `graphql`; `ErrorCode` from `../../utils/error-codes`. Place this throw inside the transaction so the rollback runs. File: `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
+- [ ] T011 [US1] Move the notification dispatch (`this.notificationService.notifyEnrollment(...)`) to AFTER `await transaction.commit()`; wrap it in `try/catch`; on success set `notificationDispatched = true`, on failure log via NestJS `Logger` and set `notificationDispatched = false`. Do NOT re-throw. File: `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`. Reference: [research.md](research.md) R2
+- [ ] T012 [US1] Construct and return `{ success: true, alreadyFinalised: false, notificationDispatched }` on the fresh path in `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
+
+**Checkpoint**: Mutation is now atomic on the fresh path; zero-teams rejected; new return type wired. US1 passes its independent tests in isolation.
+
+---
+
+## Phase 4: User Story 2 — Idempotent re-submission (Priority: P1)
+
+**Goal**: When every `EventEntry` for `(clubId, season)` already has `sendOn !== null`, perform no notification, no audit row, no `sendOn` writes. The only permitted DB write on this path is updating `Club.contactCompetition` if the supplied email differs.
+
+**Independent Test**: Call the mutation twice with identical args; assert second call returns `alreadyFinalised: true`, no second `Logging` row, no second notification, original `sendOn` timestamps unchanged. Reference: [research.md](research.md) R7 cases #6, #7, #8.
+
+### Implementation for User Story 2
+
+- [ ] T013 [US2] Inside the transaction (after T009's locked read of entries, before any writes), compute `alreadyFinalised = entries.length > 0 && entries.every(e => e.sendOn !== null)` in `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
+- [ ] T014 [US2] Branch on `alreadyFinalised`: on the no-op path, conditionally `await club.save({ transaction })` ONLY if `club.contactCompetition !== email` (after assigning the new value); skip every other write (no entry saves, no `Logging.create`); commit; return `{ success: true, alreadyFinalised: true, notificationDispatched: false }` WITHOUT calling the notification service. File: `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
+- [ ] T015 [US2] On the fresh path, ensure the existing `if (!team.entry) continue` skip survives the rewrite — teams with no entry row must not throw and must not block the loop. File: `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
+- [ ] T016 [US2] On the fresh path, only update `Team.entry.sendOn` for entries where `sendOn === null` (partial-state safety; matches FR-003 and acceptance scenario US2.2). File: `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
+
+**Checkpoint**: Re-submission is idempotent. US1 + US2 both functional. The resolver matches the contract in [contracts/finish-event-entry.graphql](contracts/finish-event-entry.graphql).
+
+---
+
+## Phase 5: User Story 3 — Resolver test coverage (Priority: P2)
+
+**Goal**: Co-located `entry.resolver.spec.ts` exercising every R7 scenario; CI fails fast if any contract regresses.
+
+**Independent Test**: `npx jest --config libs/backend/graphql/jest.config.ts libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts` reports all 12 cases passing in under 5 s.
+
+### Tests for User Story 3 (TDD-style — write FIRST, watch fail, then re-run after US1/US2)
+
+> **NOTE**: T017 scaffolds the test file. Subsequent T018–T019 add cases that fail against the pre-hardening resolver and pass after US1+US2 are implemented. Authors may write tests upfront and only implement to green.
+
+- [ ] T017 [P] [US3] Create `libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts` with the test-module scaffold from `libs/backend/graphql/src/resolvers/enrollmentSetting/enrollmentSetting.resolver.spec.ts`: `Test.createTestingModule`, fake `Sequelize` whose `transaction()` returns `{ commit, rollback, LOCK: { UPDATE: 'UPDATE' } }` jest.fn() stubs, mocked `NotificationService`, mocked `EnrollmentValidationService`, fake `Player` factory with `hasAnyPermission` jest.fn(), `afterEach(jest.restoreAllMocks)`
+- [ ] T018 [US3] Add the 12 `it(...)` cases enumerated in [research.md](research.md) R7 to `libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts`. Each test uses `jest.spyOn` on `Club.findByPk`, `Team.findAll`, `EventEntry.findAll` (or whichever is used), `Logging.create`, plus mocked instance methods on returned objects. No real DB. Reference scenarios:
+  - #1 unauthorized → `UnauthorizedException`
+  - #2 unknown clubId → `NotFoundException`
+  - #3 zero teams → `GraphQLError` with `extensions.code === ErrorCode.NO_TEAMS_TO_FINALISE`; `transaction.rollback` called
+  - #4 fresh happy path → all expected writes; `commit`; notify; result `{ true, false, true }`
+  - #5 rollback on `Logging.create` throw → `rollback` called; no notify; resolver re-throws
+  - #6 already-finalised same email → no writes; result `{ true, true, false }`
+  - #7 already-finalised differing email → only `club.save` inside txn; no entry/log writes; result `alreadyFinalised: true`
+  - #8 partial state → only null entries updated; one log; one notify
+  - #9 team with `entry === null` skipped without error
+  - #10 notification rejects post-commit → DB committed; no throw; `notificationDispatched: false`
+  - #11 row-lock query inspected — `findAll` second arg includes `lock: 'UPDATE'` and the same `transaction`
+  - #12 `edit-any:club` permission grants access
+- [ ] T019 [US3] Run `npx jest --config libs/backend/graphql/jest.config.ts libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts` and confirm green. If a test fails because of a real bug exposed by US1/US2, fix the resolver — do NOT relax the test
+
+**Checkpoint**: All three stories functional. Spec covers every contract clause.
+
+---
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T020 [P] Run `nx lint backend-graphql` and `prettier --check libs/backend/graphql/src/resolvers/event/` ; fix anything reported
+- [ ] T021 [P] Run `nx affected:test` from the monorepo root; investigate any unrelated breakage
+- [ ] T022 Walk [quickstart.md](quickstart.md) §3.a, §3.b, §3.c against a local `nx serve api` and confirm each terminal outcome matches expectations
+- [ ] T023 Confirm `AGENTS.md` SPECKIT block points at `specs/007-finish-event-entry-hardening/plan.md` (already updated in `/speckit-plan`; verify only)
+- [ ] T024 Hand [frontend-changes.md](frontend-changes.md) to the sibling `badman-frontend` repo (open companion PR there); link both PRs in their descriptions per [frontend-changes.md](frontend-changes.md) §9
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Setup (Phase 1) → no dependencies
+- Foundational (Phase 2) → depends on Setup; BLOCKS all stories
+- US1 (Phase 3) → depends on Foundational
+- US2 (Phase 4) → depends on US1 because both edit `entry.resolver.ts`; cannot truly parallelise
+- US3 (Phase 5) → can START in parallel with US1/US2 (T017 scaffold), but T019 (final green run) depends on US1+US2 done
+- Polish (Phase 6) → depends on US1+US2+US3 done
+
+### Within Each User Story
+
+- Tests first if author chooses TDD (recommended: write T017 + skeletal T018 cases before T006).
+- Within US1: T006 → T007 → T008 → T009 → T010 → T011 → T012 (linear; same file).
+- Within US2: T013 → T014 → T015/T016 (T015/T016 are sanity preservations, can be done together).
+
+### Parallel Opportunities
+
+- T002 || T001 (T002 just verifies Docker; independent)
+- T003 || T004 (different files)
+- T017 (scaffold spec file) can start as soon as T004 lands — runs in parallel with T006–T012
+- T020 || T021 (lint vs. affected tests; different processes, both read-only of source)
+
+---
+
+## Parallel Example: Foundational + US3 scaffold
+
+```bash
+# Foundational, in parallel:
+Task: "T003 — add NO_TEAMS_TO_FINALISE to libs/backend/graphql/src/utils/error-codes.ts"
+Task: "T004 — create libs/backend/graphql/src/resolvers/event/finish-event-entry-result.object.ts"
+
+# Then US3 scaffold concurrently with US1 implementation:
+Task: "T017 — scaffold libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts"
+Task: "T006 — inject Sequelize into EventEntryResolver"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1)
+
+1. Phase 1 → Phase 2 → Phase 3 (US1 only) → run quickstart §3.a + §3.c.
+2. STOP. Demo: atomic transaction + zero-teams rejection + new return type. Value delivered: no more partial-write incidents.
+
+### Incremental Delivery
+
+1. Add US2 → run quickstart §3.b. Demo: idempotent re-submit.
+2. Add US3 → CI gate flips green; future regressions caught.
+3. Polish → coordinate with frontend PR per [frontend-changes.md](frontend-changes.md) §9.
+
+### Parallel Team Strategy
+
+One developer is sufficient — feature is small. If two: A handles US1+US2 (single resolver, sequential), B handles US3 (test file). Sync at T019.
+
+---
+
+## Notes
+
+- Every task touching `entry.resolver.ts` is sequential because they edit the same file. Do not mark them `[P]`.
+- `[P]` reserved for genuinely-isolated work: separate files (T004, T017), separate processes (T020, T021).
+- Commit after each phase checkpoint at minimum; per-task commits are encouraged inside US1 (the resolver edits are non-trivial).
+- Do NOT introduce `useTransaction` helpers, decorators, or any abstraction beyond what `enrollmentSetting.resolver.ts` already demonstrates. Match the project's existing pattern.
+- No translation work in this feature — `translation-manager` is NOT invoked.


### PR DESCRIPTION
## Summary

Hardens `finishEventEntry` (single resolver mutation in `libs/backend/graphql`) so it is **atomic**, **idempotent**, and **covered by tests**. Unblocks the BAD-122 frontend follow-up by giving the wizard a reliable terminal step.

Linear: [BAD-137](https://linear.app/dashdot/issue/BAD-137) — related to [BAD-122](https://linear.app/dashdot/issue/BAD-122).
Spec: [`specs/007-finish-event-entry-hardening/`](specs/007-finish-event-entry-hardening/spec.md).

### Changes

- All writes (`Club.contactCompetition`, `EventEntry.sendOn`, `Logging`) wrapped in a single Sequelize transaction with row-level locking on `EventEntry` for `(clubId, season)`. Eliminates partial-write incidents.
- Idempotent on `(clubId, season)`: re-submission returns `alreadyFinalised: true` with no duplicate notification, no duplicate audit row, no `sendOn` overwrite. Email update is the only permitted side-effect on the no-op path.
- Notification dispatch moved **after** `transaction.commit()`. SMTP/push failures no longer roll back the DB — surfaced as `notificationDispatched: false` instead.
- New classified error code `NO_TEAMS_TO_FINALISE` rejects empty-season finalisation.
- **Breaking schema change**: return type `Boolean!` → `FinishEventEntryResult { success, alreadyFinalised, notificationDispatched }`. See [`frontend-changes.md`](specs/007-finish-event-entry-hardening/frontend-changes.md) for the frontend hand-off.
- Co-located [`entry.resolver.spec.ts`](libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts) — 12 cases covering every contract clause (Constitution Principle IV).

### Files

- `libs/backend/graphql/src/resolvers/event/entry.resolver.ts` (modified)
- `libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts` (new, 400 LOC)
- `libs/backend/graphql/src/resolvers/event/finish-event-entry-result.object.ts` (new)
- `libs/backend/graphql/src/utils/error-codes.ts` (added `NO_TEAMS_TO_FINALISE`)

## Test plan

- [x] Unit: 12/12 jest cases pass in ~10s
- [x] Prettier clean for the touched directory
- [x] Lint: zero new errors (13 pre-existing `@nx/dependency-checks` errors unchanged)
- [x] QA static review: text / links / security PASS
- [x] Constitution check: 5/5 principles PASS
- [ ] Manual quickstart walk against `nx serve api` covering all three terminal outcomes ([`quickstart.md`](specs/007-finish-event-entry-hardening/quickstart.md) §3.a–c)
- [ ] Companion frontend PR opened in `badman-frontend` consuming the new shape; merge order is backend first

## Coordinated rollout

1. **This PR** merges first to the enrollment-module integration branch.
2. Frontend PR in `badman-frontend` consumes `FinishEventEntryResult` per [`frontend-changes.md`](specs/007-finish-event-entry-hardening/frontend-changes.md).
3. Both PRs reference each other.
4. Sanity-check the three terminal outcomes against a deployed preview before closing BAD-122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)