### PR TITLE
feat(i18n): add v1.enrollment keys for BAD-122 finalisation UI

### DIFF
--- a/libs/backend/translate/assets/i18n/en/all.json
+++ b/libs/backend/translate/assets/i18n/en/all.json
@@ -1649,7 +1649,26 @@
         "successEdit": "Team has been updated"
       },
       "addPlayer": "Add player",
-      "players": "Players"
+      "players": "Players",
+      "alreadySubmitted": {
+        "title": "Already submitted",
+        "body": "This club's enrollment for the current season has already been submitted. To make changes, contact the federation."
+      },
+      "submit": {
+        "alreadyFinalised": "This enrollment was already submitted earlier.",
+        "finalisationFailed": "Your teams were saved, but we couldn't finalise the submission. Press Retry to try again.",
+        "finalised": "Enrollment submitted successfully.",
+        "notificationFailedBody": "Your enrollment was saved, but we couldn't send the confirmation email or push notification. Press Retry to try sending it again.",
+        "notificationFailedTitle": "Submission complete — confirmation could not be sent",
+        "retryFinalisation": "Retry",
+        "retryNotification": "Retry"
+      },
+      "errors": {
+        "clubNotFoundForFinalise": "Club not found.",
+        "finalisationFailed": "Submission failed. Please try again.",
+        "noTeamsToFinalise": "Add at least one team before submitting.",
+        "notAuthorisedToFinalise": "You don't have permission to finalise this club's enrollment."
+      }
     },
     "messages": {
       "buttons": {

--- a/libs/backend/translate/assets/i18n/fr_BE/all.json
+++ b/libs/backend/translate/assets/i18n/fr_BE/all.json
@@ -1957,7 +1957,26 @@
         "successEdit": "L'équipe a été mise à jour"
       },
       "addPlayer": "Ajouter un joueur",
-      "players": "Joueurs"
+      "players": "Joueurs",
+      "alreadySubmitted": {
+        "title": "Déjà soumis",
+        "body": "L'inscription de ce club pour la saison en cours a déjà été soumise. Pour apporter des modifications, veuillez contacter la fédération."
+      },
+      "submit": {
+        "alreadyFinalised": "Cette inscription a déjà été soumise précédemment.",
+        "finalisationFailed": "Vos équipes ont été enregistrées, mais nous n'avons pas pu finaliser la soumission. Cliquez sur Réessayer pour réessayer.",
+        "finalised": "Inscription soumise avec succès.",
+        "notificationFailedBody": "Votre inscription a été enregistrée, mais nous n'avons pas pu envoyer l'e-mail de confirmation ou la notification push. Cliquez sur Réessayer pour la renvoyer.",
+        "notificationFailedTitle": "Soumission terminée — la confirmation n'a pas pu être envoyée",
+        "retryFinalisation": "Réessayer",
+        "retryNotification": "Réessayer"
+      },
+      "errors": {
+        "clubNotFoundForFinalise": "Club non trouvé.",
+        "finalisationFailed": "La soumission a échoué. Veuillez réessayer.",
+        "noTeamsToFinalise": "Ajoutez au moins une équipe avant de soumettre.",
+        "notAuthorisedToFinalise": "Vous n'avez pas la permission de finaliser l'inscription de ce club."
+      }
     },
     "locations": {
       "exceptions": "Exceptions"

--- a/libs/backend/translate/assets/i18n/nl_BE/all.json
+++ b/libs/backend/translate/assets/i18n/nl_BE/all.json
@@ -1367,7 +1367,26 @@
         "successEdit": "Team is bijgewerkt"
       },
       "addPlayer": "Voeg speler toe",
-      "players": "Spelers"
+      "players": "Spelers",
+      "alreadySubmitted": {
+        "title": "Reeds ingediend",
+        "body": "De inschrijving van deze club voor het huidige seizoen is al ingediend. Neem contact op met de federatie om wijzigingen aan te brengen."
+      },
+      "submit": {
+        "alreadyFinalised": "Deze inschrijving is eerder al ingediend.",
+        "finalisationFailed": "Je teams zijn opgeslagen, maar we konden de indiening niet voltooien. Klik op Opnieuw proberen om het opnieuw te proberen.",
+        "finalised": "Inschrijving succesvol ingediend.",
+        "notificationFailedBody": "Je inschrijving is opgeslagen, maar we konden de bevestigingsemail of pushmelding niet versturen. Klik op Opnieuw proberen om het opnieuw te versturen.",
+        "notificationFailedTitle": "Indiening voltooid — bevestiging kon niet worden verzonden",
+        "retryFinalisation": "Opnieuw proberen",
+        "retryNotification": "Opnieuw proberen"
+      },
+      "errors": {
+        "clubNotFoundForFinalise": "Club niet gevonden.",
+        "finalisationFailed": "Indiening mislukt. Probeer het opnieuw.",
+        "noTeamsToFinalise": "Voeg minstens één team toe voor het indienen.",
+        "notAuthorisedToFinalise": "U bent niet bevoegd om de inschrijving van deze club af te ronden."
+      }
     },
     "messages": {
       "buttons": {

--- a/libs/utils/src/lib/i18n.generated.ts
+++ b/libs/utils/src/lib/i18n.generated.ts
@@ -1640,7 +1640,10 @@ export type I18nTranslations = {
                     "minBasePlayers": string;
                 };
                 "errors": {
-                    "rejectedPendingPlayerBlocksSubmit": string;
+                    "clubNotFoundForFinalise": string;
+                    "finalisationFailed": string;
+                    "noTeamsToFinalise": string;
+                    "notAuthorisedToFinalise": string;
                 };
                 "form": {
                     "type": string;
@@ -1668,6 +1671,19 @@ export type I18nTranslations = {
                 };
                 "addPlayer": string;
                 "players": string;
+                "alreadySubmitted": {
+                    "title": string;
+                    "body": string;
+                };
+                "submit": {
+                    "alreadyFinalised": string;
+                    "finalisationFailed": string;
+                    "finalised": string;
+                    "notificationFailedBody": string;
+                    "notificationFailedTitle": string;
+                    "retryFinalisation": string;
+                    "retryNotification": string;
+                };
             };
             "messages": {
                 "buttons": {


### PR DESCRIPTION
13 keys across en/nl_BE/fr_BE under all.v1.enrollment:
- alreadySubmitted.{title,body}
- submit.{finalisationFailed,retryFinalisation,finalised,notificationFailedTitle,notificationFailedBody,retryNotification,alreadyFinalised}
- errors.{notAuthorisedToFinalise,noTeamsToFinalise,clubNotFoundForFinalise,finalisationFailed}

Authored via translation-manager agent. i18n.generated.ts regenerated by nestjs-i18n on API boot per CLAUDE.md.

Backs the BAD-122 frontend wizard's submit/finalisation paths against the hardened finishEventEntry mutation (BAD-137).