### PR TITLE
feat(i18n): add enrollment & entryTeamDrawer keys

### DIFF
--- a/libs/backend/translate/assets/i18n/en/all.json
+++ b/libs/backend/translate/assets/i18n/en/all.json
@@ -1527,7 +1527,11 @@
       },
       "team-enrollment": {
         "addBasePlayerDialog": {
-          "baseIndex": "Base index: {baseIndex}",
+          "baseIndex": {
+            "loading": "Calculating base index…",
+            "unavailable": "Base index not available",
+            "value": "Base index: {baseIndex}"
+          },
           "maxPlayersReached": "You can add at most {max} base players.",
           "noCompetitions": "No competitions are available for this season.",
           "competition": "Competition",
@@ -1552,7 +1556,11 @@
       },
       "steps": {
         "info": "Information",
-        "players": "Players"
+        "players": "Players",
+        "generalInformation": "General information",
+        "transfersLoans": "Transfers & loans",
+        "teams": "Teams",
+        "confirm": "Confirm"
       },
       "nav": {
         "previous": "Previous",
@@ -1565,6 +1573,16 @@
         "addAtLeastOneTeam": "Add at least one team."
       },
       "teams": {
+        "categories": {
+          "M": "Men",
+          "F": "Women",
+          "MX": "Mixed"
+        },
+        "addTeam": "Add team",
+        "emptyCategory": "No teams in this category",
+        "a11y": {
+          "removePlayerFromList": "Remove player from list"
+        },
         "deleteError": "Error deleting team",
         "loadError": "Error loading teams",
         "retry": "Try again"
@@ -1578,7 +1596,10 @@
         }
       },
       "clubSelection": {
-        "noAdminClubs": "You are not an admin of any clubs"
+        "noAdminClubs": "You are not an admin of any clubs",
+        "heading": "Select your club",
+        "clubLabel": "Club",
+        "emailLabel": "Contact email"
       },
       "locationSelection": {
         "title": "Locations",
@@ -1595,7 +1616,16 @@
       "transfersLoans": {
         "addError": "Error adding transfer/loan",
         "deleteError": "Error deleting transfer/loan",
-        "loadError": "Error loading transfers/loans"
+        "loadError": "Error loading transfers/loans",
+        "addTransfersTitle": "Transfers",
+        "addTransferButton": "Add transfer",
+        "emptyTransfers": "No transfers added yet",
+        "addLoansTitle": "Loans",
+        "addLoanButton": "Add loan",
+        "emptyLoans": "No loans added yet",
+        "a11y": {
+          "cancelPendingSelection": "Cancel pending player selection"
+        }
       },
       "pendingTransferBadge": "transfer",
       "pendingLoanBadge": "loan",
@@ -1622,7 +1652,10 @@
         "minBasePlayers": "Select at least {min} base players."
       },
       "errors": {
-        "rejectedPendingPlayerBlocksSubmit": "Enrollment cannot be submitted. One or more teams contain base players that are no longer valid."
+        "clubNotFoundForFinalise": "Club not found.",
+        "finalisationFailed": "Submission failed. Please try again.",
+        "noTeamsToFinalise": "Add at least one team before submitting.",
+        "notAuthorisedToFinalise": "You don't have permission to finalise this club's enrollment."
       },
       "form": {
         "type": "Type",
@@ -1662,12 +1695,6 @@
         "notificationFailedTitle": "Submission complete — confirmation could not be sent",
         "retryFinalisation": "Retry",
         "retryNotification": "Retry"
-      },
-      "errors": {
-        "clubNotFoundForFinalise": "Club not found.",
-        "finalisationFailed": "Submission failed. Please try again.",
-        "noTeamsToFinalise": "Add at least one team before submitting.",
-        "notAuthorisedToFinalise": "You don't have permission to finalise this club's enrollment."
       }
     },
     "messages": {
@@ -3057,6 +3084,18 @@
           "subtitute-team-index": "s",
           "title": "Warnings"
         }
+      },
+      "errors": {
+        "title": "Errors",
+        "permissionDenied": "You don't have permission to perform this action.",
+        "clubNotFound": "Club not found.",
+        "playerNotFound": "Player not found.",
+        "rankingNotFound": "Player has no ranking — required for index calculation.",
+        "teamNotFound": "Team not found.",
+        "subEventNotFound": "Sub-event not found.",
+        "seasonMismatch": "The team's season does not match the sub-event's competition season.",
+        "internal": "Unexpected server error. Please try again.",
+        "unknown": "Something went wrong."
       }
     },
     "notFoundPage": {

--- a/libs/backend/translate/assets/i18n/fr_BE/all.json
+++ b/libs/backend/translate/assets/i18n/fr_BE/all.json
@@ -1772,6 +1772,18 @@
           "subtitute-team-index": "s",
           "title": "Avertissements"
         }
+      },
+      "errors": {
+        "title": "Erreurs",
+        "permissionDenied": "Vous n'avez pas la permission d'effectuer cette action.",
+        "clubNotFound": "Club non trouvé.",
+        "playerNotFound": "Joueur non trouvé.",
+        "rankingNotFound": "Le joueur n'a pas de classement - requis pour le calcul de l'indice.",
+        "teamNotFound": "Équipe non trouvée.",
+        "subEventNotFound": "Sous-événement non trouvé.",
+        "seasonMismatch": "La saison de l'équipe ne correspond pas à la saison de compétition.",
+        "internal": "Erreur serveur inattendue. Veuillez réessayer.",
+        "unknown": "Une erreur est survenue."
       }
     },
     "shell": {
@@ -1835,7 +1847,11 @@
       },
       "team-enrollment": {
         "addBasePlayerDialog": {
-          "baseIndex": "Indice de base : {baseIndex}",
+          "baseIndex": {
+            "loading": "Calcul de l'index de base…",
+            "unavailable": "Index de base indisponible",
+            "value": "Indice de base : {baseIndex}"
+          },
           "maxPlayersReached": "Vous pouvez ajouter au maximum {max} joueurs de base.",
           "noCompetitions": "Aucune compétition n'est disponible pour cette saison.",
           "competition": "Compétition",
@@ -1860,7 +1876,11 @@
       },
       "steps": {
         "info": "Informations",
-        "players": "Joueurs"
+        "players": "Joueurs",
+        "generalInformation": "Informations générales",
+        "transfersLoans": "Transferts & prêts",
+        "teams": "Équipes",
+        "confirm": "Confirmer"
       },
       "nav": {
         "previous": "Précédent",
@@ -1873,6 +1893,16 @@
         "addAtLeastOneTeam": "Ajoutez au moins une équipe."
       },
       "teams": {
+        "categories": {
+          "M": "Hommes",
+          "F": "Dames",
+          "MX": "Mixte"
+        },
+        "addTeam": "Ajouter une équipe",
+        "emptyCategory": "Aucune équipe dans cette catégorie",
+        "a11y": {
+          "removePlayerFromList": "Retirer le joueur de la liste"
+        },
         "deleteError": "Erreur lors de la suppression de l'équipe",
         "loadError": "Erreur lors du chargement des équipes",
         "retry": "Réessayer"
@@ -1886,7 +1916,10 @@
         }
       },
       "clubSelection": {
-        "noAdminClubs": "Vous n'êtes administrateur d'aucun club"
+        "noAdminClubs": "Vous n'êtes administrateur d'aucun club",
+        "heading": "Sélectionnez votre club",
+        "clubLabel": "Club",
+        "emailLabel": "E-mail de contact"
       },
       "locationSelection": {
         "title": "Lieux",
@@ -1903,7 +1936,16 @@
       "transfersLoans": {
         "addError": "Erreur lors de l'ajout du transfert/prêt",
         "deleteError": "Erreur lors de la suppression du transfert/prêt",
-        "loadError": "Erreur lors du chargement des transferts/prêts"
+        "loadError": "Erreur lors du chargement des transferts/prêts",
+        "addTransfersTitle": "Transferts",
+        "addTransferButton": "Ajouter un transfert",
+        "emptyTransfers": "Aucun transfert ajouté",
+        "addLoansTitle": "Prêts",
+        "addLoanButton": "Ajouter un prêt",
+        "emptyLoans": "Aucun prêt ajouté",
+        "a11y": {
+          "cancelPendingSelection": "Annuler la sélection de joueur en attente"
+        }
       },
       "pendingTransferBadge": "transfert",
       "pendingLoanBadge": "prêt",
@@ -1930,7 +1972,10 @@
         "minBasePlayers": "Sélectionnez au moins {min} joueurs de base."
       },
       "errors": {
-        "rejectedPendingPlayerBlocksSubmit": "L'inscription ne peut pas être soumise. Un ou plusieurs équipes contiennent des joueurs de base qui ne sont plus valides."
+        "clubNotFoundForFinalise": "Club non trouvé.",
+        "finalisationFailed": "La soumission a échoué. Veuillez réessayer.",
+        "noTeamsToFinalise": "Ajoutez au moins une équipe avant de soumettre.",
+        "notAuthorisedToFinalise": "Vous n'avez pas la permission de finaliser l'inscription de ce club."
       },
       "form": {
         "type": "Type",
@@ -1970,12 +2015,6 @@
         "notificationFailedTitle": "Soumission terminée — la confirmation n'a pas pu être envoyée",
         "retryFinalisation": "Réessayer",
         "retryNotification": "Réessayer"
-      },
-      "errors": {
-        "clubNotFoundForFinalise": "Club non trouvé.",
-        "finalisationFailed": "La soumission a échoué. Veuillez réessayer.",
-        "noTeamsToFinalise": "Ajoutez au moins une équipe avant de soumettre.",
-        "notAuthorisedToFinalise": "Vous n'avez pas la permission de finaliser l'inscription de ce club."
       }
     },
     "locations": {

--- a/libs/backend/translate/assets/i18n/nl_BE/all.json
+++ b/libs/backend/translate/assets/i18n/nl_BE/all.json
@@ -1245,7 +1245,11 @@
       },
       "team-enrollment": {
         "addBasePlayerDialog": {
-          "baseIndex": "Basisindex: {baseIndex}",
+          "baseIndex": {
+            "loading": "Basisindex berekenen…",
+            "unavailable": "Basisindex niet beschikbaar",
+            "value": "Basisindex: {baseIndex}"
+          },
           "maxPlayersReached": "Je kunt maximaal {max} basisspelers toevoegen.",
           "noCompetitions": "Er zijn geen competities beschikbaar voor dit seizoen.",
           "competition": "Competitie",
@@ -1270,7 +1274,11 @@
       },
       "steps": {
         "info": "Informatie",
-        "players": "Spelers"
+        "players": "Spelers",
+        "generalInformation": "Algemene informatie",
+        "transfersLoans": "Transfers & uitleningen",
+        "teams": "Ploegen",
+        "confirm": "Bevestigen"
       },
       "nav": {
         "previous": "Vorige",
@@ -1283,9 +1291,19 @@
         "addAtLeastOneTeam": "Voeg minstens één ploeg toe."
       },
       "teams": {
-        "deleteError": "Fout bij het verwijderen van het team",
+        "categories": {
+          "M": "Heren",
+          "F": "Dames",
+          "MX": "Gemengd"
+        },
+        "addTeam": "Ploeg toevoegen",
+        "emptyCategory": "Geen ploegen in deze categorie",
+        "a11y": {
+          "removePlayerFromList": "Speler uit lijst verwijderen"
+        },
+        "deleteError": "Fout bij het verwijderen van team",
         "loadError": "Fout bij het laden van teams",
-        "retry": "Opnieuw proberen"
+        "retry": "Probeer opnieuw"
       },
       "dialog": {
         "deleteTeam": {
@@ -1296,7 +1314,10 @@
         }
       },
       "clubSelection": {
-        "noAdminClubs": "Je bent geen admin van clubs"
+        "noAdminClubs": "Je bent geen admin van clubs",
+        "heading": "Selecteer je club",
+        "clubLabel": "Club",
+        "emailLabel": "Contact e-mail"
       },
       "locationSelection": {
         "title": "Locaties",
@@ -1313,7 +1334,16 @@
       "transfersLoans": {
         "addError": "Fout bij het toevoegen van transfer/uitlening",
         "deleteError": "Fout bij het verwijderen van transfer/uitlening",
-        "loadError": "Fout bij het laden van transfers/uitleningen"
+        "loadError": "Fout bij het laden van transfers/uitleningen",
+        "addTransfersTitle": "Transfers",
+        "addTransferButton": "Transfer toevoegen",
+        "emptyTransfers": "Nog geen transfers toegevoegd",
+        "addLoansTitle": "Uitleningen",
+        "addLoanButton": "Uitlening toevoegen",
+        "emptyLoans": "Nog geen uitleningen toegevoegd",
+        "a11y": {
+          "cancelPendingSelection": "Hangende spelerselectie annuleren"
+        }
       },
       "pendingTransferBadge": "transfer",
       "pendingLoanBadge": "uitleen",
@@ -1340,7 +1370,10 @@
         "minBasePlayers": "Je moet minstens {min} basisspelers selecteren."
       },
       "errors": {
-        "rejectedPendingPlayerBlocksSubmit": "Inschrijving kan niet ingediend worden. Eén of meerdere teams bevatten basisspelers die niet meer geldig zijn."
+        "clubNotFoundForFinalise": "Club niet gevonden.",
+        "finalisationFailed": "Indiening mislukt. Probeer het opnieuw.",
+        "noTeamsToFinalise": "Voeg minstens één team toe voor het indienen.",
+        "notAuthorisedToFinalise": "U bent niet bevoegd om de inschrijving van deze club af te ronden."
       },
       "form": {
         "type": "Type",
@@ -1380,12 +1413,6 @@
         "notificationFailedTitle": "Indiening voltooid — bevestiging kon niet worden verzonden",
         "retryFinalisation": "Opnieuw proberen",
         "retryNotification": "Opnieuw proberen"
-      },
-      "errors": {
-        "clubNotFoundForFinalise": "Club niet gevonden.",
-        "finalisationFailed": "Indiening mislukt. Probeer het opnieuw.",
-        "noTeamsToFinalise": "Voeg minstens één team toe voor het indienen.",
-        "notAuthorisedToFinalise": "U bent niet bevoegd om de inschrijving van deze club af te ronden."
       }
     },
     "messages": {
@@ -2775,6 +2802,18 @@
           "subtitute-team-index": "s",
           "title": "Waarschuwingen"
         }
+      },
+      "errors": {
+        "title": "Fouten",
+        "permissionDenied": "Je hebt geen toestemming om deze actie uit te voeren.",
+        "clubNotFound": "Club niet gevonden.",
+        "playerNotFound": "Speler niet gevonden.",
+        "rankingNotFound": "Speler heeft geen ranking - vereist voor indexberekening.",
+        "teamNotFound": "Team niet gevonden.",
+        "subEventNotFound": "Onderverdeling niet gevonden.",
+        "seasonMismatch": "Het seizoen van het team komt niet overeen met het competitieseizoen.",
+        "internal": "Onverwachte serverfout. Probeer het opnieuw.",
+        "unknown": "Er is iets misgegaan."
       }
     },
     "notFoundPage": {

--- a/libs/utils/src/lib/i18n.generated.ts
+++ b/libs/utils/src/lib/i18n.generated.ts
@@ -1545,7 +1545,11 @@ export type I18nTranslations = {
                 };
                 "team-enrollment": {
                     "addBasePlayerDialog": {
-                        "baseIndex": string;
+                        "baseIndex": {
+                            "loading": string;
+                            "unavailable": string;
+                            "value": string;
+                        };
                         "maxPlayersReached": string;
                         "noCompetitions": string;
                         "competition": string;
@@ -1571,6 +1575,10 @@ export type I18nTranslations = {
                 "steps": {
                     "info": string;
                     "players": string;
+                    "generalInformation": string;
+                    "transfersLoans": string;
+                    "teams": string;
+                    "confirm": string;
                 };
                 "nav": {
                     "previous": string;
@@ -1583,6 +1591,16 @@ export type I18nTranslations = {
                     "addAtLeastOneTeam": string;
                 };
                 "teams": {
+                    "categories": {
+                        "M": string;
+                        "F": string;
+                        "MX": string;
+                    };
+                    "addTeam": string;
+                    "emptyCategory": string;
+                    "a11y": {
+                        "removePlayerFromList": string;
+                    };
                     "deleteError": string;
                     "loadError": string;
                     "retry": string;
@@ -1597,6 +1615,9 @@ export type I18nTranslations = {
                 };
                 "clubSelection": {
                     "noAdminClubs": string;
+                    "heading": string;
+                    "clubLabel": string;
+                    "emailLabel": string;
                 };
                 "locationSelection": {
                     "title": string;
@@ -1614,6 +1635,15 @@ export type I18nTranslations = {
                     "addError": string;
                     "deleteError": string;
                     "loadError": string;
+                    "addTransfersTitle": string;
+                    "addTransferButton": string;
+                    "emptyTransfers": string;
+                    "addLoansTitle": string;
+                    "addLoanButton": string;
+                    "emptyLoans": string;
+                    "a11y": {
+                        "cancelPendingSelection": string;
+                    };
                 };
                 "pendingTransferBadge": string;
                 "pendingLoanBadge": string;
@@ -3072,6 +3102,18 @@ export type I18nTranslations = {
                         "subtitute-team-index": string;
                         "title": string;
                     };
+                };
+                "errors": {
+                    "title": string;
+                    "permissionDenied": string;
+                    "clubNotFound": string;
+                    "playerNotFound": string;
+                    "rankingNotFound": string;
+                    "teamNotFound": string;
+                    "subEventNotFound": string;
+                    "seasonMismatch": string;
+                    "internal": string;
+                    "unknown": string;
                 };
             };
             "notFoundPage": {


### PR DESCRIPTION
- enrollment: wizard steps, clubSelection, transfersLoans, teams (categories M/F/MX), team error toasts
- entryTeamDrawer: GraphQL error-code messages (permissionDenied, clubNotFound, playerNotFound, rankingNotFound, teamNotFound, subEventNotFound, seasonMismatch, internal, unknown)
- baseIndex string → { value, loading, unavailable } to cover async base-index states in addBasePlayerDialog