### PR TITLE
feat(i18n): add enrollment teams & team-enrollment a11y keys

### DIFF
--- a/libs/backend/translate/assets/i18n/en/all.json
+++ b/libs/backend/translate/assets/i18n/en/all.json
@@ -1527,11 +1527,7 @@
       },
       "team-enrollment": {
         "addBasePlayerDialog": {
-          "baseIndex": {
-            "loading": "Calculating base index…",
-            "unavailable": "Base index not available",
-            "value": "Base index: {baseIndex}"
-          },
+          "baseIndex": "Base index",
           "maxPlayersReached": "You can add at most {max} base players.",
           "noCompetitions": "No competitions are available for this season.",
           "competition": "Competition",
@@ -1573,6 +1569,10 @@
         "addAtLeastOneTeam": "Add at least one team."
       },
       "teams": {
+        "baseValue": "Team {index}",
+        "baseIndex": {
+          "loading": "Loading team..."
+        },
         "categories": {
           "M": "Men",
           "F": "Women",
@@ -1581,6 +1581,13 @@
         "addTeam": "Add team",
         "emptyCategory": "No teams in this category",
         "a11y": {
+          "statusError": "Team has validation errors",
+          "statusSuccess": "Team is valid",
+          "validatingStatus": "Validating team...",
+          "expandValidationDetails": "Expand validation details",
+          "collapseValidationDetails": "Collapse validation details",
+          "editTeam": "Edit team",
+          "deleteTeam": "Delete team",
           "removePlayerFromList": "Remove player from list"
         },
         "deleteError": "Error deleting team",

--- a/libs/backend/translate/assets/i18n/en/all.json
+++ b/libs/backend/translate/assets/i18n/en/all.json
@@ -1525,31 +1525,6 @@
         "manageAvailability": "Manage availability",
         "hideAvailability": "Hide availability"
       },
-      "team-enrollment": {
-        "addBasePlayerDialog": {
-          "baseIndex": "Base index",
-          "maxPlayersReached": "You can add at most {max} base players.",
-          "noCompetitions": "No competitions are available for this season.",
-          "competition": "Competition",
-          "division": "Division",
-          "divisionBaseIndexRangeMismatch": "Your team's base index ({baseIndex}) does not match any division for this competition.",
-          "playerTooStrong": "{name} has level {level}, which is too strong for this division (strongest allowed: {maxLevel})."
-        },
-        "import-existing-optional": "Import existing (optional)",
-        "validating": "Validating…",
-        "import-teams": {
-          "title": "Import teams",
-          "allTeams": "All teams",
-          "categories": {
-            "MX": "Mixed",
-            "M": "Men's",
-            "F": "Women's",
-            "NATIONAL": "National"
-          },
-          "cancel": "Cancel",
-          "import": "Import"
-        }
-      },
       "steps": {
         "info": "Information",
         "players": "Players",
@@ -1702,6 +1677,31 @@
         "notificationFailedTitle": "Submission complete — confirmation could not be sent",
         "retryFinalisation": "Retry",
         "retryNotification": "Retry"
+      },
+      "teamEnrollment": {
+        "addBasePlayerDialog": {
+          "baseIndex": "Base index",
+          "maxPlayersReached": "You can add at most {max} base players.",
+          "noCompetitions": "No competitions are available for this season.",
+          "competition": "Competition",
+          "division": "Division",
+          "divisionBaseIndexRangeMismatch": "Your team's base index ({baseIndex}) does not match any division for this competition.",
+          "playerTooStrong": "{name} has level {level}, which is too strong for this division (strongest allowed: {maxLevel})."
+        },
+        "importExistingOptional": "Import existing (optional)",
+        "validating": "Validating…",
+        "importTeams": {
+          "title": "Import teams",
+          "allTeams": "All teams",
+          "categories": {
+            "MX": "Mixed",
+            "M": "Men's",
+            "F": "Women's",
+            "NATIONAL": "National"
+          },
+          "cancel": "Cancel",
+          "import": "Import"
+        }
       }
     },
     "messages": {

--- a/libs/backend/translate/assets/i18n/fr_BE/all.json
+++ b/libs/backend/translate/assets/i18n/fr_BE/all.json
@@ -1847,11 +1847,7 @@
       },
       "team-enrollment": {
         "addBasePlayerDialog": {
-          "baseIndex": {
-            "loading": "Calcul de l'index de base…",
-            "unavailable": "Index de base indisponible",
-            "value": "Indice de base : {baseIndex}"
-          },
+          "baseIndex": "Indice de base",
           "maxPlayersReached": "Vous pouvez ajouter au maximum {max} joueurs de base.",
           "noCompetitions": "Aucune compétition n'est disponible pour cette saison.",
           "competition": "Compétition",
@@ -1893,6 +1889,10 @@
         "addAtLeastOneTeam": "Ajoutez au moins une équipe."
       },
       "teams": {
+        "baseValue": "Équipe {index}",
+        "baseIndex": {
+          "loading": "Chargement de l'équipe..."
+        },
         "categories": {
           "M": "Hommes",
           "F": "Dames",
@@ -1901,6 +1901,13 @@
         "addTeam": "Ajouter une équipe",
         "emptyCategory": "Aucune équipe dans cette catégorie",
         "a11y": {
+          "statusError": "L'équipe a des erreurs de validation",
+          "statusSuccess": "L'équipe est valide",
+          "validatingStatus": "Validation de l'équipe...",
+          "expandValidationDetails": "Développer les détails de validation",
+          "collapseValidationDetails": "Réduire les détails de validation",
+          "editTeam": "Modifier l'équipe",
+          "deleteTeam": "Supprimer l'équipe",
           "removePlayerFromList": "Retirer le joueur de la liste"
         },
         "deleteError": "Erreur lors de la suppression de l'équipe",

--- a/libs/backend/translate/assets/i18n/fr_BE/all.json
+++ b/libs/backend/translate/assets/i18n/fr_BE/all.json
@@ -1845,31 +1845,6 @@
         "manageAvailability": "Gérer la disponibilité",
         "hideAvailability": "Masquer la disponibilité"
       },
-      "team-enrollment": {
-        "addBasePlayerDialog": {
-          "baseIndex": "Indice de base",
-          "maxPlayersReached": "Vous pouvez ajouter au maximum {max} joueurs de base.",
-          "noCompetitions": "Aucune compétition n'est disponible pour cette saison.",
-          "competition": "Compétition",
-          "division": "Division",
-          "divisionBaseIndexRangeMismatch": "L'indice de base de votre équipe ({baseIndex}) ne correspond à aucune division pour cette compétition.",
-          "playerTooStrong": "{name} a le niveau {level}, ce qui est trop fort pour cette division (maximum autorisé : {maxLevel})."
-        },
-        "import-existing-optional": "Importer l'existant (optionnel)",
-        "validating": "Validation…",
-        "import-teams": {
-          "title": "Importer les équipes",
-          "allTeams": "Toutes les équipes",
-          "categories": {
-            "MX": "Mixte",
-            "M": "Messieurs",
-            "F": "Dames",
-            "NATIONAL": "National"
-          },
-          "cancel": "Annuler",
-          "import": "Importer"
-        }
-      },
       "steps": {
         "info": "Informations",
         "players": "Joueurs",
@@ -2022,6 +1997,31 @@
         "notificationFailedTitle": "Soumission terminée — la confirmation n'a pas pu être envoyée",
         "retryFinalisation": "Réessayer",
         "retryNotification": "Réessayer"
+      },
+      "teamEnrollment": {
+        "addBasePlayerDialog": {
+          "baseIndex": "Indice de base",
+          "maxPlayersReached": "Vous pouvez ajouter au maximum {max} joueurs de base.",
+          "noCompetitions": "Aucune compétition n'est disponible pour cette saison.",
+          "competition": "Compétition",
+          "division": "Division",
+          "divisionBaseIndexRangeMismatch": "L'indice de base de votre équipe ({baseIndex}) ne correspond à aucune division pour cette compétition.",
+          "playerTooStrong": "{name} a le niveau {level}, ce qui est trop fort pour cette division (maximum autorisé : {maxLevel})."
+        },
+        "importExistingOptional": "Importer l'existant (optionnel)",
+        "validating": "Validation…",
+        "importTeams": {
+          "title": "Importer les équipes",
+          "allTeams": "Toutes les équipes",
+          "categories": {
+            "MX": "Mixte",
+            "M": "Messieurs",
+            "F": "Dames",
+            "NATIONAL": "National"
+          },
+          "cancel": "Annuler",
+          "import": "Importer"
+        }
       }
     },
     "locations": {

--- a/libs/backend/translate/assets/i18n/nl_BE/all.json
+++ b/libs/backend/translate/assets/i18n/nl_BE/all.json
@@ -1243,31 +1243,6 @@
         "manageAvailability": "Beschikbaarheid beheren",
         "hideAvailability": "Beschikbaarheid verbergen"
       },
-      "team-enrollment": {
-        "addBasePlayerDialog": {
-          "baseIndex": "Basisindex",
-          "maxPlayersReached": "Je kunt maximaal {max} basisspelers toevoegen.",
-          "noCompetitions": "Er zijn geen competities beschikbaar voor dit seizoen.",
-          "competition": "Competitie",
-          "division": "Afdeling",
-          "divisionBaseIndexRangeMismatch": "De basisindex van je team ({baseIndex}) komt niet overeen met een divisie in deze competitie.",
-          "playerTooStrong": "{name} heeft niveau {level}; dat is te sterk voor deze divisie (sterkst toegestaan: {maxLevel})."
-        },
-        "import-existing-optional": "Bestaande importeren (optioneel)",
-        "validating": "Valideren…",
-        "import-teams": {
-          "title": "Teams importeren",
-          "allTeams": "Alle teams",
-          "categories": {
-            "MX": "Gemengd",
-            "M": "Heren",
-            "F": "Dames",
-            "NATIONAL": "Nationaal"
-          },
-          "cancel": "Annuleren",
-          "import": "Importeren"
-        }
-      },
       "steps": {
         "info": "Informatie",
         "players": "Spelers",
@@ -1420,6 +1395,31 @@
         "notificationFailedTitle": "Indiening voltooid — bevestiging kon niet worden verzonden",
         "retryFinalisation": "Opnieuw proberen",
         "retryNotification": "Opnieuw proberen"
+      },
+      "teamEnrollment": {
+        "addBasePlayerDialog": {
+          "baseIndex": "Basisindex",
+          "maxPlayersReached": "Je kunt maximaal {max} basisspelers toevoegen.",
+          "noCompetitions": "Er zijn geen competities beschikbaar voor dit seizoen.",
+          "competition": "Competitie",
+          "division": "Afdeling",
+          "divisionBaseIndexRangeMismatch": "De basisindex van je team ({baseIndex}) komt niet overeen met een divisie in deze competitie.",
+          "playerTooStrong": "{name} heeft niveau {level}; dat is te sterk voor deze divisie (sterkst toegestaan: {maxLevel})."
+        },
+        "importExistingOptional": "Bestaande importeren (optioneel)",
+        "validating": "Valideren…",
+        "importTeams": {
+          "title": "Teams importeren",
+          "allTeams": "Alle teams",
+          "categories": {
+            "MX": "Gemengd",
+            "M": "Heren",
+            "F": "Dames",
+            "NATIONAL": "Nationaal"
+          },
+          "cancel": "Annuleren",
+          "import": "Importeren"
+        }
       }
     },
     "messages": {

--- a/libs/backend/translate/assets/i18n/nl_BE/all.json
+++ b/libs/backend/translate/assets/i18n/nl_BE/all.json
@@ -1245,11 +1245,7 @@
       },
       "team-enrollment": {
         "addBasePlayerDialog": {
-          "baseIndex": {
-            "loading": "Basisindex berekenen…",
-            "unavailable": "Basisindex niet beschikbaar",
-            "value": "Basisindex: {baseIndex}"
-          },
+          "baseIndex": "Basisindex",
           "maxPlayersReached": "Je kunt maximaal {max} basisspelers toevoegen.",
           "noCompetitions": "Er zijn geen competities beschikbaar voor dit seizoen.",
           "competition": "Competitie",
@@ -1291,6 +1287,10 @@
         "addAtLeastOneTeam": "Voeg minstens één ploeg toe."
       },
       "teams": {
+        "baseValue": "Team {index}",
+        "baseIndex": {
+          "loading": "Team laden..."
+        },
         "categories": {
           "M": "Heren",
           "F": "Dames",
@@ -1299,6 +1299,13 @@
         "addTeam": "Ploeg toevoegen",
         "emptyCategory": "Geen ploegen in deze categorie",
         "a11y": {
+          "statusError": "Team heeft validatiefouten",
+          "statusSuccess": "Team is geldig",
+          "validatingStatus": "Team valideren...",
+          "expandValidationDetails": "Validatiedetails uitklappen",
+          "collapseValidationDetails": "Validatiedetails inklappen",
+          "editTeam": "Team bewerken",
+          "deleteTeam": "Team verwijderen",
           "removePlayerFromList": "Speler uit lijst verwijderen"
         },
         "deleteError": "Fout bij het verwijderen van team",

--- a/libs/utils/src/lib/i18n.generated.ts
+++ b/libs/utils/src/lib/i18n.generated.ts
@@ -1543,31 +1543,6 @@ export type I18nTranslations = {
                     "manageAvailability": string;
                     "hideAvailability": string;
                 };
-                "team-enrollment": {
-                    "addBasePlayerDialog": {
-                        "baseIndex": string;
-                        "maxPlayersReached": string;
-                        "noCompetitions": string;
-                        "competition": string;
-                        "division": string;
-                        "divisionBaseIndexRangeMismatch": string;
-                        "playerTooStrong": string;
-                    };
-                    "import-existing-optional": string;
-                    "validating": string;
-                    "import-teams": {
-                        "title": string;
-                        "allTeams": string;
-                        "categories": {
-                            "MX": string;
-                            "M": string;
-                            "F": string;
-                            "NATIONAL": string;
-                        };
-                        "cancel": string;
-                        "import": string;
-                    };
-                };
                 "steps": {
                     "info": string;
                     "players": string;
@@ -1720,6 +1695,31 @@ export type I18nTranslations = {
                     "notificationFailedTitle": string;
                     "retryFinalisation": string;
                     "retryNotification": string;
+                };
+                "teamEnrollment": {
+                    "addBasePlayerDialog": {
+                        "baseIndex": string;
+                        "maxPlayersReached": string;
+                        "noCompetitions": string;
+                        "competition": string;
+                        "division": string;
+                        "divisionBaseIndexRangeMismatch": string;
+                        "playerTooStrong": string;
+                    };
+                    "importExistingOptional": string;
+                    "validating": string;
+                    "importTeams": {
+                        "title": string;
+                        "allTeams": string;
+                        "categories": {
+                            "MX": string;
+                            "M": string;
+                            "F": string;
+                            "NATIONAL": string;
+                        };
+                        "cancel": string;
+                        "import": string;
+                    };
                 };
             };
             "messages": {

--- a/libs/utils/src/lib/i18n.generated.ts
+++ b/libs/utils/src/lib/i18n.generated.ts
@@ -1545,11 +1545,7 @@ export type I18nTranslations = {
                 };
                 "team-enrollment": {
                     "addBasePlayerDialog": {
-                        "baseIndex": {
-                            "loading": string;
-                            "unavailable": string;
-                            "value": string;
-                        };
+                        "baseIndex": string;
                         "maxPlayersReached": string;
                         "noCompetitions": string;
                         "competition": string;
@@ -1591,6 +1587,10 @@ export type I18nTranslations = {
                     "addAtLeastOneTeam": string;
                 };
                 "teams": {
+                    "baseValue": string;
+                    "baseIndex": {
+                        "loading": string;
+                    };
                     "categories": {
                         "M": string;
                         "F": string;
@@ -1599,6 +1599,13 @@ export type I18nTranslations = {
                     "addTeam": string;
                     "emptyCategory": string;
                     "a11y": {
+                        "statusError": string;
+                        "statusSuccess": string;
+                        "validatingStatus": string;
+                        "expandValidationDetails": string;
+                        "collapseValidationDetails": string;
+                        "editTeam": string;
+                        "deleteTeam": string;
                         "removePlayerFromList": string;
                     };
                     "deleteError": string;


### PR DESCRIPTION
Missing keys for team cards (status icons, expand/collapse, edit/delete actions) and addBasePlayerDialog.baseIndex caused runtime MISSING_MESSAGE errors in the enrollment UI.