### PR TITLE
fix(entry-resolver): mark subEventCompetition and enrollmentValidatio…

### DIFF
--- a/libs/backend/graphql/src/resolvers/event/entry.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/entry.resolver.ts
@@ -59,7 +59,7 @@ export class EventEntryResolver {
     return eventEntry.getPlayers();
   }
 
-  @ResolveField(() => SubEventCompetition)
+  @ResolveField(() => SubEventCompetition, { nullable: true })
   async subEventCompetition(@Parent() eventEntry: EventEntry): Promise<SubEventCompetition> {
     return eventEntry.getSubEventCompetition();
   }
@@ -83,6 +83,7 @@ export class EventEntryResolver {
   }
 
   @ResolveField(() => TeamEnrollmentOutput, {
+    nullable: true,
     description: `Validate the enrollment\n\r**note**: the levels are the ones from may!`,
   })
   async enrollmentValidation(


### PR DESCRIPTION
…n resolve fields nullable

Prevents GraphQL schema errors when entries are not linked to a competition sub-event or when enrollment validation is absent.