### PR TITLE
fix(visual): make XmlTeam.Code optional on Match payloads

### DIFF
--- a/libs/backend/visual/src/utils/__tests__/visual-result.spec.ts
+++ b/libs/backend/visual/src/utils/__tests__/visual-result.spec.ts
@@ -188,6 +188,21 @@ describe("requiredCoercedString invariant", () => {
     }
   });
 
+  // Visual API sends Match-level Team1/Team2 objects without a Code field —
+  // Code is only set on top-level draw teams (Sentry #116466287 follow-up).
+  it("XmlMatchSchema: accepts Team1/Team2 object without Code", () => {
+    const result = XmlMatchSchema.safeParse({
+      Code: "M1",
+      Team1: { Player1: { MemberID: "P1" } },
+      Team2: { Player1: { MemberID: "P2" } },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.Team1?.Code).toBeUndefined();
+      expect(result.data.Team2?.Code).toBeUndefined();
+    }
+  });
+
   it("XmlTeamMatchSchema: coerces numeric Team1/Team2 to undefined", () => {
     const result = XmlTeamMatchSchema.safeParse({ Code: "TM1", Team1: 42, Team2: 99 });
     expect(result.success).toBe(true);

--- a/libs/backend/visual/src/utils/visual-result.ts
+++ b/libs/backend/visual/src/utils/visual-result.ts
@@ -238,7 +238,10 @@ export type XmlPlayers = z.infer<typeof XmlPlayersSchema>;
 
 export const XmlTeamSchema = z
   .object({
-    Code: requiredCoercedString,
+    // Code is missing on Match/TeamMatch sub-team payloads (Visual API only
+    // sends it for top-level draw teams). Keep it coercion-friendly when
+    // present, but don't reject the whole Match response when absent.
+    Code: z.union([z.string(), z.number()]).transform((v) => String(v)).optional(),
     Name: z.string().optional(),
     Player1: z.preprocess(dropPrimitive("Team.Player1"), XmlPlayerSchema.optional()),
     Player2: z.preprocess(dropPrimitive("Team.Player2"), XmlPlayerSchema.optional()),
@@ -258,7 +261,7 @@ export const XmlTeamSchema = z
 // wrapper types (Player1-4, Club, Players). The schema validates the
 // runtime shape; this interface keeps the static type stable.
 export interface XmlTeam {
-  Code: string;
+  Code?: string;
   Name?: string;
   Player1?: XmlPlayer;
   Player2?: XmlPlayer;


### PR DESCRIPTION
Match/TeamMatch sub-team payloads omit Code — Visual API only sets it on top-level draw teams. Previous fix (70d6fd277) only handled primitive Team1/Team2; now upstream sends an object with players but no Code, slipping past dropPrimitive and failing requiredCoercedString validation.

Refs Sentry #116466287