### PR TITLE
feat(enrollment): add submitEnrollment atomic mutation

### DIFF
--- a/libs/backend/graphql/src/resolvers/club/club-membership.service.spec.ts
+++ b/libs/backend/graphql/src/resolvers/club/club-membership.service.spec.ts
@@ -1,0 +1,129 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ClubPlayerMembership } from "@badman/backend-database";
+import { ClubMembershipType } from "@badman/utils";
+import { ClubMembershipService } from "./club-membership.service";
+
+describe("ClubMembershipService.upsertMembership", () => {
+  let service: ClubMembershipService;
+
+  const fakeTransaction = {} as never;
+
+  const fakeMembership = (overrides: Partial<ClubPlayerMembership> = {}) =>
+    ({
+      id: "membership-uuid",
+      clubId: "club-uuid",
+      playerId: "player-uuid",
+      start: new Date("2025-09-01"),
+      end: null,
+      membershipType: ClubMembershipType.NORMAL,
+      ...overrides,
+    }) as unknown as ClubPlayerMembership;
+
+  const baseArgs = (overrides = {}) => ({
+    clubId: "club-uuid",
+    playerId: "player-uuid",
+    start: new Date("2025-09-01"),
+    end: undefined as Date | undefined,
+    membershipType: ClubMembershipType.NORMAL,
+    confirmed: false,
+    transaction: fakeTransaction,
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ClubMembershipService],
+    }).compile();
+    service = module.get<ClubMembershipService>(ClubMembershipService);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it("creates a new membership and returns alreadyExisted: false", async () => {
+    const membership = fakeMembership();
+    jest.spyOn(ClubPlayerMembership, "findOrCreate").mockResolvedValue([membership, true] as never);
+
+    const result = await service.upsertMembership(baseArgs());
+
+    expect(result.alreadyExisted).toBe(false);
+    expect(result.id).toBe("membership-uuid");
+    expect(result.clubId).toBe("club-uuid");
+    expect(result.playerId).toBe("player-uuid");
+    expect(result.membershipType).toBe(ClubMembershipType.NORMAL);
+  });
+
+  it("returns alreadyExisted: true when membership already exists", async () => {
+    const existing = fakeMembership({ id: "existing-uuid" });
+    jest.spyOn(ClubPlayerMembership, "findOrCreate").mockResolvedValue([existing, false] as never);
+
+    const result = await service.upsertMembership(baseArgs());
+
+    expect(result.alreadyExisted).toBe(true);
+    expect(result.id).toBe("existing-uuid");
+  });
+
+  it("passes LOAN membershipType through unchanged", async () => {
+    const membership = fakeMembership({ membershipType: ClubMembershipType.LOAN });
+    jest.spyOn(ClubPlayerMembership, "findOrCreate").mockResolvedValue([membership, true] as never);
+
+    const result = await service.upsertMembership(baseArgs({ membershipType: ClubMembershipType.LOAN }));
+
+    expect(result.membershipType).toBe(ClubMembershipType.LOAN);
+  });
+
+  it("passes confirmed: true to findOrCreate defaults when caller specifies it", async () => {
+    const membership = fakeMembership();
+    const findOrCreate = jest
+      .spyOn(ClubPlayerMembership, "findOrCreate")
+      .mockResolvedValue([membership, true] as never);
+
+    await service.upsertMembership(baseArgs({ confirmed: true }));
+
+    expect(findOrCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaults: expect.objectContaining({ confirmed: true }),
+      })
+    );
+  });
+
+  it("passes confirmed: false to findOrCreate defaults when caller specifies it", async () => {
+    const membership = fakeMembership();
+    const findOrCreate = jest
+      .spyOn(ClubPlayerMembership, "findOrCreate")
+      .mockResolvedValue([membership, true] as never);
+
+    await service.upsertMembership(baseArgs({ confirmed: false }));
+
+    expect(findOrCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaults: expect.objectContaining({ confirmed: false }),
+      })
+    );
+  });
+
+  it("uses (clubId, playerId, start) as findOrCreate key", async () => {
+    const membership = fakeMembership();
+    const findOrCreate = jest
+      .spyOn(ClubPlayerMembership, "findOrCreate")
+      .mockResolvedValue([membership, true] as never);
+
+    const start = new Date("2025-09-01");
+    await service.upsertMembership(baseArgs({ start }));
+
+    expect(findOrCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { clubId: "club-uuid", playerId: "player-uuid", start },
+        transaction: fakeTransaction,
+      })
+    );
+  });
+
+  it("end is null in result when membership.end is undefined", async () => {
+    const membership = fakeMembership({ end: undefined });
+    jest.spyOn(ClubPlayerMembership, "findOrCreate").mockResolvedValue([membership, true] as never);
+
+    const result = await service.upsertMembership(baseArgs());
+
+    expect(result.end).toBeNull();
+  });
+});

--- a/libs/backend/graphql/src/resolvers/club/club-membership.service.spec.ts
+++ b/libs/backend/graphql/src/resolvers/club/club-membership.service.spec.ts
@@ -66,7 +66,9 @@ describe("ClubMembershipService.upsertMembership", () => {
     const membership = fakeMembership({ membershipType: ClubMembershipType.LOAN });
     jest.spyOn(ClubPlayerMembership, "findOrCreate").mockResolvedValue([membership, true] as never);
 
-    const result = await service.upsertMembership(baseArgs({ membershipType: ClubMembershipType.LOAN }));
+    const result = await service.upsertMembership(
+      baseArgs({ membershipType: ClubMembershipType.LOAN })
+    );
 
     expect(result.membershipType).toBe(ClubMembershipType.LOAN);
   });

--- a/libs/backend/graphql/src/resolvers/club/club-membership.service.ts
+++ b/libs/backend/graphql/src/resolvers/club/club-membership.service.ts
@@ -38,7 +38,9 @@ export class ClubMembershipService {
       defaults: { start, end, membershipType, confirmed },
       transaction,
     };
-    const [membership, created] = await (ClubPlayerMembership as unknown as ModelStatic<ClubPlayerMembership>).findOrCreate(options);
+    const [membership, created] = await (
+      ClubPlayerMembership as unknown as ModelStatic<ClubPlayerMembership>
+    ).findOrCreate(options);
 
     return {
       id: membership.id as string,

--- a/libs/backend/graphql/src/resolvers/club/club-membership.service.ts
+++ b/libs/backend/graphql/src/resolvers/club/club-membership.service.ts
@@ -1,6 +1,6 @@
 import { ClubPlayerMembership } from "@badman/backend-database";
 import { Injectable } from "@nestjs/common";
-import { Transaction } from "sequelize";
+import { FindOrCreateOptions, ModelStatic, Transaction } from "sequelize";
 
 export interface UpsertMembershipArgs {
   clubId: string;
@@ -33,12 +33,12 @@ export class ClubMembershipService {
     confirmed,
     transaction,
   }: UpsertMembershipArgs): Promise<UpsertMembershipResult> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const [membership, created] = await (ClubPlayerMembership as any).findOrCreate({
+    const options: FindOrCreateOptions = {
       where: { clubId, playerId, start },
       defaults: { start, end, membershipType, confirmed },
       transaction,
-    });
+    };
+    const [membership, created] = await (ClubPlayerMembership as unknown as ModelStatic<ClubPlayerMembership>).findOrCreate(options);
 
     return {
       id: membership.id as string,

--- a/libs/backend/graphql/src/resolvers/club/club-membership.service.ts
+++ b/libs/backend/graphql/src/resolvers/club/club-membership.service.ts
@@ -1,0 +1,53 @@
+import { ClubPlayerMembership } from "@badman/backend-database";
+import { Injectable } from "@nestjs/common";
+import { Transaction } from "sequelize";
+
+export interface UpsertMembershipArgs {
+  clubId: string;
+  playerId: string;
+  start: Date;
+  end?: Date | null;
+  membershipType: string;
+  confirmed: boolean;
+  transaction: Transaction;
+}
+
+export interface UpsertMembershipResult {
+  id: string;
+  clubId: string;
+  playerId: string;
+  start: Date;
+  end: Date | null;
+  membershipType: string;
+  alreadyExisted: boolean;
+}
+
+@Injectable()
+export class ClubMembershipService {
+  async upsertMembership({
+    clubId,
+    playerId,
+    start,
+    end,
+    membershipType,
+    confirmed,
+    transaction,
+  }: UpsertMembershipArgs): Promise<UpsertMembershipResult> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const [membership, created] = await (ClubPlayerMembership as any).findOrCreate({
+      where: { clubId, playerId, start },
+      defaults: { start, end, membershipType, confirmed },
+      transaction,
+    });
+
+    return {
+      id: membership.id as string,
+      clubId,
+      playerId,
+      start: membership.start as Date,
+      end: (membership.end as Date | null | undefined) ?? null,
+      membershipType: membership.membershipType as string,
+      alreadyExisted: !created,
+    };
+  }
+}

--- a/libs/backend/graphql/src/resolvers/club/club.module.ts
+++ b/libs/backend/graphql/src/resolvers/club/club.module.ts
@@ -1,10 +1,12 @@
 import { DatabaseModule } from "@badman/backend-database";
 import { Module } from "@nestjs/common";
 import { ClubPlayerResolver, ClubsResolver } from "./club.resolver";
+import { ClubMembershipService } from "./club-membership.service";
 import { ClubPlayerMembershipsResolver } from "./club-membership.resolver";
 
 @Module({
   imports: [DatabaseModule],
-  providers: [ClubsResolver, ClubPlayerResolver, ClubPlayerMembershipsResolver],
+  providers: [ClubsResolver, ClubPlayerResolver, ClubPlayerMembershipsResolver, ClubMembershipService],
+  exports: [ClubMembershipService],
 })
 export class ClubResolverModule {}

--- a/libs/backend/graphql/src/resolvers/club/club.module.ts
+++ b/libs/backend/graphql/src/resolvers/club/club.module.ts
@@ -6,7 +6,12 @@ import { ClubPlayerMembershipsResolver } from "./club-membership.resolver";
 
 @Module({
   imports: [DatabaseModule],
-  providers: [ClubsResolver, ClubPlayerResolver, ClubPlayerMembershipsResolver, ClubMembershipService],
+  providers: [
+    ClubsResolver,
+    ClubPlayerResolver,
+    ClubPlayerMembershipsResolver,
+    ClubMembershipService,
+  ],
   exports: [ClubMembershipService],
 })
 export class ClubResolverModule {}

--- a/libs/backend/graphql/src/resolvers/club/club.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/club/club.resolver.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "@badman/backend-database";
 import { ClubsResolver } from "./club.resolver";
 import { ClubMembershipFilterInput } from "./club-membership-filter.input";
+import { ClubMembershipService } from "./club-membership.service";
 
 describe("ClubsResolver", () => {
   let resolver: ClubsResolver;
@@ -69,6 +70,7 @@ describe("ClubsResolver", () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ClubsResolver,
+        ClubMembershipService,
         {
           provide: Sequelize,
           useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },

--- a/libs/backend/graphql/src/resolvers/club/club.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/club/club.resolver.spec.ts
@@ -408,9 +408,9 @@ describe("ClubsResolver", () => {
       } as Partial<ClubPlayerMembership>);
       jest.spyOn(ClubPlayerMembership, "findByPk").mockResolvedValue(membership);
 
-      await expect(
-        resolver.updateClubPlayerMembership(user, baseUpdateInput())
-      ).rejects.toThrow("boom");
+      await expect(resolver.updateClubPlayerMembership(user, baseUpdateInput())).rejects.toThrow(
+        "boom"
+      );
 
       expect(mockTransaction.rollback).toHaveBeenCalled();
       expect(mockTransaction.commit).not.toHaveBeenCalled();

--- a/libs/backend/graphql/src/resolvers/club/club.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/club/club.resolver.ts
@@ -35,6 +35,7 @@ import { ListArgs } from "../../utils";
 import { ErrorCode } from "../../utils/error-codes";
 import { AddPlayerToClubResult } from "./add-player-to-club-result.object";
 import { ClubMembershipFilterInput } from "./club-membership-filter.input";
+import { ClubMembershipService } from "./club-membership.service";
 
 @ObjectType()
 export class PagedClub {
@@ -49,7 +50,10 @@ export class PagedClub {
 export class ClubsResolver {
   private readonly logger = new Logger(ClubsResolver.name);
 
-  constructor(private _sequelize: Sequelize) {}
+  constructor(
+    private _sequelize: Sequelize,
+    private clubMembershipService: ClubMembershipService,
+  ) {}
 
   @Query(() => Club)
   async club(@Args("id", { type: () => ID }) id: string): Promise<Club> {
@@ -302,63 +306,36 @@ export class ClubsResolver {
       });
     }
 
-    // Do transaction
     const transaction = await this._sequelize.transaction();
     try {
-      const club = await Club.findByPk(addPlayerToClubData.clubId, {
-        transaction,
-      });
-
+      const club = await Club.findByPk(addPlayerToClubData.clubId, { transaction });
       if (!club) {
         throw new GraphQLError("Club not found", {
           extensions: { code: ErrorCode.CLUB_NOT_FOUND, clubId: addPlayerToClubData.clubId },
         });
       }
 
-      const player = await Player.findByPk(addPlayerToClubData.playerId, {
-        transaction,
-      });
-
+      const player = await Player.findByPk(addPlayerToClubData.playerId, { transaction });
       if (!player) {
         throw new GraphQLError("Player not found", {
-          extensions: {
-            code: ErrorCode.PLAYER_NOT_FOUND,
-            playerId: addPlayerToClubData.playerId,
-          },
+          extensions: { code: ErrorCode.PLAYER_NOT_FOUND, playerId: addPlayerToClubData.playerId },
         });
       }
 
       const confirmed = await user.hasAnyPermission(["change:transfer"]);
 
-      const clubId = addPlayerToClubData.clubId as string;
-      const playerId = addPlayerToClubData.playerId as string;
-      const start = addPlayerToClubData.start as Date;
-
-      // Idempotent create: findOrCreate on natural key (clubId, playerId, start)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const [membership, created] = await (ClubPlayerMembership as any).findOrCreate({
-        where: { clubId, playerId, start },
-        defaults: {
-          start,
-          end: addPlayerToClubData.end,
-          membershipType: addPlayerToClubData.membershipType,
-          confirmed,
-        },
+      const result = await this.clubMembershipService.upsertMembership({
+        clubId: addPlayerToClubData.clubId as string,
+        playerId: addPlayerToClubData.playerId as string,
+        start: addPlayerToClubData.start as Date,
+        end: addPlayerToClubData.end,
+        membershipType: addPlayerToClubData.membershipType as string,
+        confirmed,
         transaction,
       });
 
-      // Commit transaction
       await transaction.commit();
-
-      return {
-        id: membership.id as string,
-        clubId,
-        playerId,
-        start: membership.start as Date,
-        end: (membership.end as Date | null | undefined) ?? null,
-        membershipType: membership.membershipType as string,
-        alreadyExisted: !created,
-      };
+      return result;
     } catch (error) {
       this.logger.error(error);
       await transaction.rollback();

--- a/libs/backend/graphql/src/resolvers/club/club.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/club/club.resolver.ts
@@ -52,7 +52,7 @@ export class ClubsResolver {
 
   constructor(
     private _sequelize: Sequelize,
-    private clubMembershipService: ClubMembershipService,
+    private clubMembershipService: ClubMembershipService
   ) {}
 
   @Query(() => Club)

--- a/libs/backend/graphql/src/resolvers/event/competition.module.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition.module.ts
@@ -12,6 +12,7 @@ import {
   DrawCompetitionResolver,
   EncounterChangeCompetitionResolver,
   EncounterCompetitionResolver,
+  EnrollmentEntryService,
   EnrollmentResolver,
   EventCompetitionResolver,
   SubEventCompetitionResolver,
@@ -37,6 +38,7 @@ import { ChangeEncounterModule } from "@badman/backend-change-encounter";
     SubEventCompetitionResolver,
     AssemblyResolver,
     EnrollmentResolver,
+    EnrollmentEntryService,
     CalculateIndexResolver,
   ],
 })

--- a/libs/backend/graphql/src/resolvers/event/competition.module.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition.module.ts
@@ -16,8 +16,13 @@ import {
   EnrollmentResolver,
   EventCompetitionResolver,
   SubEventCompetitionResolver,
+  SubmitEnrollmentResolver,
+  SubmitEnrollmentService,
 } from "./competition";
 import { ChangeEncounterModule } from "@badman/backend-change-encounter";
+import { ClubMembershipService } from "../club/club-membership.service";
+import { TeamWriteService } from "../team/team-write.service";
+import { EnrollmentFinalizeService } from "./enrollment-finalize.service";
 
 @Module({
   imports: [
@@ -40,6 +45,11 @@ import { ChangeEncounterModule } from "@badman/backend-change-encounter";
     EnrollmentResolver,
     EnrollmentEntryService,
     CalculateIndexResolver,
+    SubmitEnrollmentResolver,
+    SubmitEnrollmentService,
+    ClubMembershipService,
+    TeamWriteService,
+    EnrollmentFinalizeService,
   ],
 })
 export class CompetitionResolverModule {}

--- a/libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.spec.ts
@@ -1,14 +1,12 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { GraphQLError } from "graphql";
-import { Sequelize } from "sequelize-typescript";
 import { EventEntry, Player, SubEventCompetition, Team } from "@badman/backend-database";
-import { EnrollmentValidationService } from "@badman/backend-enrollment";
 import { EnrollmentEntryService } from "./enrollment-entry.service";
-import { EnrollmentResolver } from "./enrollment.resolver";
 
-describe("EnrollmentResolver.createEnrollment", () => {
-  let resolver: EnrollmentResolver;
-  let mockTransaction: { commit: jest.Mock; rollback: jest.Mock };
+describe("EnrollmentEntryService.createEntry", () => {
+  let service: EnrollmentEntryService;
+
+  const fakeTransaction = {} as never;
 
   const userWithPermission = (allowed: boolean) =>
     ({
@@ -16,7 +14,6 @@ describe("EnrollmentResolver.createEnrollment", () => {
       hasAnyPermission: jest.fn().mockResolvedValue(allowed),
     }) as unknown as Player;
 
-  // user.hasAnyPermission decides per requested permission string
   const userMatchingPerms = (matching: string[]) =>
     ({
       id: "user-uuid",
@@ -59,53 +56,38 @@ describe("EnrollmentResolver.createEnrollment", () => {
   };
 
   beforeEach(async () => {
-    mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
     const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        EnrollmentResolver,
-        EnrollmentEntryService,
-        {
-          provide: Sequelize,
-          useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
-        },
-        {
-          provide: EnrollmentValidationService,
-          useValue: { fetchAndValidate: jest.fn() },
-        },
-      ],
+      providers: [EnrollmentEntryService],
     }).compile();
-    resolver = module.get<EnrollmentResolver>(EnrollmentResolver);
+    service = module.get<EnrollmentEntryService>(EnrollmentEntryService);
   });
 
   afterEach(() => jest.restoreAllMocks());
 
-  it("returns TEAM_NOT_FOUND and rolls back when the team is missing", async () => {
-    const user = userWithPermission(true);
+  it("throws TEAM_NOT_FOUND when the team is missing", async () => {
     jest.spyOn(Team, "findByPk").mockResolvedValue(null);
 
-    await expect(resolver.createEnrollment(user, "missing-team", "se-uuid")).rejects.toThrow(
-      GraphQLError
-    );
+    const user = userWithPermission(true);
+    await expect(
+      service.createEntry({ teamId: "missing", subEventId: "se-uuid", transaction: fakeTransaction, user })
+    ).rejects.toThrow(GraphQLError);
 
     try {
-      await resolver.createEnrollment(user, "missing-team", "se-uuid");
+      await service.createEntry({ teamId: "missing", subEventId: "se-uuid", transaction: fakeTransaction, user });
     } catch (err) {
       const e = err as GraphQLError;
       expect(e.extensions["code"]).toBe("TEAM_NOT_FOUND");
-      expect(e.extensions["teamId"]).toBe("missing-team");
+      expect(e.extensions["teamId"]).toBe("missing");
     }
-
-    expect(mockTransaction.rollback).toHaveBeenCalled();
-    expect(mockTransaction.commit).not.toHaveBeenCalled();
   });
 
-  it("returns PERMISSION_DENIED when the user holds none of the accepted permissions", async () => {
-    const user = userWithPermission(false);
+  it("throws PERMISSION_DENIED when the user holds none of the accepted permissions", async () => {
     const team = stubTeam();
+    const user = userWithPermission(false);
     jest.spyOn(Team, "findByPk").mockResolvedValue(team);
 
     try {
-      await resolver.createEnrollment(user, team.id, "se-uuid");
+      await service.createEntry({ teamId: team.id, subEventId: "se-uuid", transaction: fakeTransaction, user });
       fail("expected throw");
     } catch (err) {
       const e = err as GraphQLError;
@@ -118,10 +100,9 @@ describe("EnrollmentResolver.createEnrollment", () => {
       `${team.clubId}_edit:club`,
       "edit-any:club",
     ]);
-    expect(mockTransaction.rollback).toHaveBeenCalled();
   });
 
-  it("succeeds when the user has only the team's club-scoped edit:club permission (Q1 clarification)", async () => {
+  it("succeeds when the user has only the team's club-scoped edit:club permission", async () => {
     const team = stubTeam({ clubId: "my-club" });
     const user = userMatchingPerms([`my-club_edit:club`]);
     const subEvent = stubSubEvent({ season: 2026 });
@@ -130,32 +111,28 @@ describe("EnrollmentResolver.createEnrollment", () => {
     jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(subEvent);
     jest.spyOn(EventEntry, "create").mockResolvedValue({} as unknown as EventEntry);
 
-    const result = await resolver.createEnrollment(user, team.id, "se-uuid");
+    const result = await service.createEntry({ teamId: team.id, subEventId: "se-uuid", transaction: fakeTransaction, user });
 
     expect(result.alreadyExisted).toBe(false);
-    expect(mockTransaction.commit).toHaveBeenCalled();
-    expect(mockTransaction.rollback).not.toHaveBeenCalled();
   });
 
-  it("returns SUB_EVENT_NOT_FOUND and rolls back when the sub-event is missing", async () => {
+  it("throws SUB_EVENT_NOT_FOUND when the sub-event is missing", async () => {
     const team = stubTeam();
     const user = userWithPermission(true);
     jest.spyOn(Team, "findByPk").mockResolvedValue(team);
     jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(null);
 
     try {
-      await resolver.createEnrollment(user, team.id, "missing-se");
+      await service.createEntry({ teamId: team.id, subEventId: "missing-se", transaction: fakeTransaction, user });
       fail("expected throw");
     } catch (err) {
       const e = err as GraphQLError;
       expect(e.extensions["code"]).toBe("SUB_EVENT_NOT_FOUND");
       expect(e.extensions["subEventId"]).toBe("missing-se");
     }
-
-    expect(mockTransaction.rollback).toHaveBeenCalled();
   });
 
-  it("returns SEASON_MISMATCH with both seasons in extensions when team and competition seasons differ", async () => {
+  it("throws SEASON_MISMATCH with both seasons in extensions when seasons differ", async () => {
     const team = stubTeam({ season: 2026 });
     const subEvent = stubSubEvent({ season: 2025 });
     const user = userWithPermission(true);
@@ -163,7 +140,7 @@ describe("EnrollmentResolver.createEnrollment", () => {
     jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(subEvent);
 
     try {
-      await resolver.createEnrollment(user, team.id, "se-uuid");
+      await service.createEntry({ teamId: team.id, subEventId: "se-uuid", transaction: fakeTransaction, user });
       fail("expected throw");
     } catch (err) {
       const e = err as GraphQLError;
@@ -171,57 +148,23 @@ describe("EnrollmentResolver.createEnrollment", () => {
       expect(e.extensions["teamSeason"]).toBe(2026);
       expect(e.extensions["competitionSeason"]).toBe(2025);
     }
-
-    expect(mockTransaction.rollback).toHaveBeenCalled();
   });
 
-  it("returns INTERNAL_ERROR (sanitized) on an unexpected throw and logs at error severity", async () => {
-    const team = stubTeam();
-    const subEvent = stubSubEvent();
-    const user = userWithPermission(true);
-    jest.spyOn(Team, "findByPk").mockResolvedValue(team);
-    jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(subEvent);
-    (team as unknown as { _getEntry: jest.Mock })._getEntry.mockRejectedValue(
-      new Error("boom: internal stuff")
-    );
-
-    try {
-      await resolver.createEnrollment(user, team.id, "se-uuid");
-      fail("expected throw");
-    } catch (err) {
-      const e = err as GraphQLError;
-      expect(e.extensions["code"]).toBe("INTERNAL_ERROR");
-      // Internal message must NOT leak.
-      expect(e.message).not.toContain("boom: internal stuff");
-    }
-
-    expect(mockTransaction.rollback).toHaveBeenCalled();
-  });
-
-  it("is idempotent when the team's existing entry already points to the requested sub-event (US2)", async () => {
+  it("is idempotent when the existing entry already points to the requested sub-event", async () => {
     const team = stubTeam({ existingEntry: { subEventId: "se-uuid" } });
     const subEvent = stubSubEvent();
     const user = userWithPermission(true);
     jest.spyOn(Team, "findByPk").mockResolvedValue(team);
     jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(subEvent);
 
-    const result = await resolver.createEnrollment(user, team.id, "se-uuid");
+    const result = await service.createEntry({ teamId: team.id, subEventId: "se-uuid", transaction: fakeTransaction, user });
 
-    expect(result).toEqual({
-      teamId: team.id,
-      subEventCompetitionId: "se-uuid",
-      alreadyExisted: true,
-    });
-    expect(mockTransaction.commit).toHaveBeenCalledTimes(1);
-    expect(mockTransaction.rollback).not.toHaveBeenCalled();
-    // No further writes happen on the idempotent path.
+    expect(result).toEqual({ teamId: team.id, subEventCompetitionId: "se-uuid", alreadyExisted: true });
     expect((team as unknown as { _setEntry: jest.Mock })._setEntry).not.toHaveBeenCalled();
-    expect(
-      (subEvent as unknown as { _addEventEntry: jest.Mock })._addEventEntry
-    ).not.toHaveBeenCalled();
+    expect((subEvent as unknown as { _addEventEntry: jest.Mock })._addEventEntry).not.toHaveBeenCalled();
   });
 
-  it("returns a fresh EnrollmentResult on a successful new enrollment (US3)", async () => {
+  it("creates a fresh entry on a new enrollment", async () => {
     const team = stubTeam();
     const subEvent = stubSubEvent();
     const user = userWithPermission(true);
@@ -229,17 +172,24 @@ describe("EnrollmentResolver.createEnrollment", () => {
     jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(subEvent);
     jest.spyOn(EventEntry, "create").mockResolvedValue({} as unknown as EventEntry);
 
-    const result = await resolver.createEnrollment(user, team.id, "se-uuid");
+    const result = await service.createEntry({ teamId: team.id, subEventId: "se-uuid", transaction: fakeTransaction, user });
 
-    expect(result).toEqual({
-      teamId: team.id,
-      subEventCompetitionId: "se-uuid",
-      alreadyExisted: false,
-    });
-    expect(mockTransaction.commit).toHaveBeenCalledTimes(1);
-    expect(mockTransaction.rollback).not.toHaveBeenCalled();
-    expect(
-      (subEvent as unknown as { _addEventEntry: jest.Mock })._addEventEntry
-    ).toHaveBeenCalled();
+    expect(result).toEqual({ teamId: team.id, subEventCompetitionId: "se-uuid", alreadyExisted: false });
+    expect((subEvent as unknown as { _addEventEntry: jest.Mock })._addEventEntry).toHaveBeenCalled();
+  });
+
+  it("reuses an existing entry when the team already has one pointing to a different sub-event", async () => {
+    const existingEntry = { subEventId: "old-se" } as unknown as EventEntry;
+    const team = stubTeam({ existingEntry: existingEntry as unknown as { subEventId: string } });
+    const subEvent = stubSubEvent();
+    const user = userWithPermission(true);
+    jest.spyOn(Team, "findByPk").mockResolvedValue(team);
+    jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(subEvent);
+
+    const result = await service.createEntry({ teamId: team.id, subEventId: "new-se", transaction: fakeTransaction, user });
+
+    expect(result.alreadyExisted).toBe(false);
+    // setEntry called with the reused entry (no EventEntry.create)
+    expect((team as unknown as { _setEntry: jest.Mock })._setEntry).toHaveBeenCalledWith(existingEntry, expect.any(Object));
   });
 });

--- a/libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.spec.ts
@@ -69,11 +69,21 @@ describe("EnrollmentEntryService.createEntry", () => {
 
     const user = userWithPermission(true);
     await expect(
-      service.createEntry({ teamId: "missing", subEventId: "se-uuid", transaction: fakeTransaction, user })
+      service.createEntry({
+        teamId: "missing",
+        subEventId: "se-uuid",
+        transaction: fakeTransaction,
+        user,
+      })
     ).rejects.toThrow(GraphQLError);
 
     try {
-      await service.createEntry({ teamId: "missing", subEventId: "se-uuid", transaction: fakeTransaction, user });
+      await service.createEntry({
+        teamId: "missing",
+        subEventId: "se-uuid",
+        transaction: fakeTransaction,
+        user,
+      });
     } catch (err) {
       const e = err as GraphQLError;
       expect(e.extensions["code"]).toBe("TEAM_NOT_FOUND");
@@ -87,7 +97,12 @@ describe("EnrollmentEntryService.createEntry", () => {
     jest.spyOn(Team, "findByPk").mockResolvedValue(team);
 
     try {
-      await service.createEntry({ teamId: team.id, subEventId: "se-uuid", transaction: fakeTransaction, user });
+      await service.createEntry({
+        teamId: team.id,
+        subEventId: "se-uuid",
+        transaction: fakeTransaction,
+        user,
+      });
       fail("expected throw");
     } catch (err) {
       const e = err as GraphQLError;
@@ -111,7 +126,12 @@ describe("EnrollmentEntryService.createEntry", () => {
     jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(subEvent);
     jest.spyOn(EventEntry, "create").mockResolvedValue({} as unknown as EventEntry);
 
-    const result = await service.createEntry({ teamId: team.id, subEventId: "se-uuid", transaction: fakeTransaction, user });
+    const result = await service.createEntry({
+      teamId: team.id,
+      subEventId: "se-uuid",
+      transaction: fakeTransaction,
+      user,
+    });
 
     expect(result.alreadyExisted).toBe(false);
   });
@@ -123,7 +143,12 @@ describe("EnrollmentEntryService.createEntry", () => {
     jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(null);
 
     try {
-      await service.createEntry({ teamId: team.id, subEventId: "missing-se", transaction: fakeTransaction, user });
+      await service.createEntry({
+        teamId: team.id,
+        subEventId: "missing-se",
+        transaction: fakeTransaction,
+        user,
+      });
       fail("expected throw");
     } catch (err) {
       const e = err as GraphQLError;
@@ -140,7 +165,12 @@ describe("EnrollmentEntryService.createEntry", () => {
     jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(subEvent);
 
     try {
-      await service.createEntry({ teamId: team.id, subEventId: "se-uuid", transaction: fakeTransaction, user });
+      await service.createEntry({
+        teamId: team.id,
+        subEventId: "se-uuid",
+        transaction: fakeTransaction,
+        user,
+      });
       fail("expected throw");
     } catch (err) {
       const e = err as GraphQLError;
@@ -157,11 +187,22 @@ describe("EnrollmentEntryService.createEntry", () => {
     jest.spyOn(Team, "findByPk").mockResolvedValue(team);
     jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(subEvent);
 
-    const result = await service.createEntry({ teamId: team.id, subEventId: "se-uuid", transaction: fakeTransaction, user });
+    const result = await service.createEntry({
+      teamId: team.id,
+      subEventId: "se-uuid",
+      transaction: fakeTransaction,
+      user,
+    });
 
-    expect(result).toEqual({ teamId: team.id, subEventCompetitionId: "se-uuid", alreadyExisted: true });
+    expect(result).toEqual({
+      teamId: team.id,
+      subEventCompetitionId: "se-uuid",
+      alreadyExisted: true,
+    });
     expect((team as unknown as { _setEntry: jest.Mock })._setEntry).not.toHaveBeenCalled();
-    expect((subEvent as unknown as { _addEventEntry: jest.Mock })._addEventEntry).not.toHaveBeenCalled();
+    expect(
+      (subEvent as unknown as { _addEventEntry: jest.Mock })._addEventEntry
+    ).not.toHaveBeenCalled();
   });
 
   it("creates a fresh entry on a new enrollment", async () => {
@@ -172,10 +213,21 @@ describe("EnrollmentEntryService.createEntry", () => {
     jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(subEvent);
     jest.spyOn(EventEntry, "create").mockResolvedValue({} as unknown as EventEntry);
 
-    const result = await service.createEntry({ teamId: team.id, subEventId: "se-uuid", transaction: fakeTransaction, user });
+    const result = await service.createEntry({
+      teamId: team.id,
+      subEventId: "se-uuid",
+      transaction: fakeTransaction,
+      user,
+    });
 
-    expect(result).toEqual({ teamId: team.id, subEventCompetitionId: "se-uuid", alreadyExisted: false });
-    expect((subEvent as unknown as { _addEventEntry: jest.Mock })._addEventEntry).toHaveBeenCalled();
+    expect(result).toEqual({
+      teamId: team.id,
+      subEventCompetitionId: "se-uuid",
+      alreadyExisted: false,
+    });
+    expect(
+      (subEvent as unknown as { _addEventEntry: jest.Mock })._addEventEntry
+    ).toHaveBeenCalled();
   });
 
   it("reuses an existing entry when the team already has one pointing to a different sub-event", async () => {
@@ -186,10 +238,18 @@ describe("EnrollmentEntryService.createEntry", () => {
     jest.spyOn(Team, "findByPk").mockResolvedValue(team);
     jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(subEvent);
 
-    const result = await service.createEntry({ teamId: team.id, subEventId: "new-se", transaction: fakeTransaction, user });
+    const result = await service.createEntry({
+      teamId: team.id,
+      subEventId: "new-se",
+      transaction: fakeTransaction,
+      user,
+    });
 
     expect(result.alreadyExisted).toBe(false);
     // setEntry called with the reused entry (no EventEntry.create)
-    expect((team as unknown as { _setEntry: jest.Mock })._setEntry).toHaveBeenCalledWith(existingEntry, expect.any(Object));
+    expect((team as unknown as { _setEntry: jest.Mock })._setEntry).toHaveBeenCalledWith(
+      existingEntry,
+      expect.any(Object)
+    );
   });
 });

--- a/libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts
@@ -1,4 +1,10 @@
-import { EventCompetition, EventEntry, Player, SubEventCompetition, Team } from "@badman/backend-database";
+import {
+  EventCompetition,
+  EventEntry,
+  Player,
+  SubEventCompetition,
+  Team,
+} from "@badman/backend-database";
 import { Injectable, Logger } from "@nestjs/common";
 import { GraphQLError } from "graphql";
 import { Transaction } from "sequelize";
@@ -22,12 +28,22 @@ export interface CreateEntryResult {
 export class EnrollmentEntryService {
   private readonly logger = new Logger(EnrollmentEntryService.name);
 
-  async createEntry({ teamId, subEventId, transaction, user }: CreateEntryArgs): Promise<CreateEntryResult> {
+  async createEntry({
+    teamId,
+    subEventId,
+    transaction,
+    user,
+  }: CreateEntryArgs): Promise<CreateEntryResult> {
     const userId = user?.id ?? null;
 
     const team = await Team.findByPk(teamId, { transaction });
     if (!team) {
-      this.logger.warn({ code: ErrorCode.TEAM_NOT_FOUND, teamId, subEventCompetitionId: subEventId, userId });
+      this.logger.warn({
+        code: ErrorCode.TEAM_NOT_FOUND,
+        teamId,
+        subEventCompetitionId: subEventId,
+        userId,
+      });
       throw new GraphQLError(`Team not found: ${teamId}`, {
         extensions: { code: ErrorCode.TEAM_NOT_FOUND, teamId },
       });
@@ -39,7 +55,12 @@ export class EnrollmentEntryService {
       "edit-any:club",
     ]);
     if (!allowed) {
-      this.logger.warn({ code: ErrorCode.PERMISSION_DENIED, teamId, subEventCompetitionId: subEventId, userId });
+      this.logger.warn({
+        code: ErrorCode.PERMISSION_DENIED,
+        teamId,
+        subEventCompetitionId: subEventId,
+        userId,
+      });
       throw new GraphQLError("You do not have permission to enroll this team.", {
         extensions: { code: ErrorCode.PERMISSION_DENIED, userId },
       });
@@ -50,7 +71,12 @@ export class EnrollmentEntryService {
       include: [EventCompetition],
     });
     if (!subEvent) {
-      this.logger.warn({ code: ErrorCode.SUB_EVENT_NOT_FOUND, teamId, subEventCompetitionId: subEventId, userId });
+      this.logger.warn({
+        code: ErrorCode.SUB_EVENT_NOT_FOUND,
+        teamId,
+        subEventCompetitionId: subEventId,
+        userId,
+      });
       throw new GraphQLError(`Sub-event not found: ${subEventId}`, {
         extensions: { code: ErrorCode.SUB_EVENT_NOT_FOUND, subEventId },
       });
@@ -58,7 +84,14 @@ export class EnrollmentEntryService {
 
     const competitionSeason = subEvent.eventCompetition?.season;
     if (team.season !== competitionSeason) {
-      this.logger.warn({ code: ErrorCode.SEASON_MISMATCH, teamId, subEventCompetitionId: subEventId, userId, teamSeason: team.season, competitionSeason });
+      this.logger.warn({
+        code: ErrorCode.SEASON_MISMATCH,
+        teamId,
+        subEventCompetitionId: subEventId,
+        userId,
+        teamSeason: team.season,
+        competitionSeason,
+      });
       throw new GraphQLError("Team season does not match competition season.", {
         extensions: { code: ErrorCode.SEASON_MISMATCH, teamSeason: team.season, competitionSeason },
       });
@@ -66,13 +99,23 @@ export class EnrollmentEntryService {
 
     const existingEntry = await team.getEntry({ transaction });
     if (existingEntry?.subEventId === subEventId) {
-      return { teamId, entryId: existingEntry.id as string, subEventCompetitionId: subEventId, alreadyExisted: true };
+      return {
+        teamId,
+        entryId: existingEntry.id as string,
+        subEventCompetitionId: subEventId,
+        alreadyExisted: true,
+      };
     }
 
     const entry = existingEntry ?? (await EventEntry.create({}, { transaction }));
     await team.setEntry(entry, { transaction });
     await subEvent.addEventEntry(entry, { transaction });
 
-    return { teamId, entryId: entry.id as string, subEventCompetitionId: subEventId, alreadyExisted: false };
+    return {
+      teamId,
+      entryId: entry.id as string,
+      subEventCompetitionId: subEventId,
+      alreadyExisted: false,
+    };
   }
 }

--- a/libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts
@@ -13,6 +13,7 @@ export interface CreateEntryArgs {
 
 export interface CreateEntryResult {
   teamId: string;
+  entryId: string;
   subEventCompetitionId: string;
   alreadyExisted: boolean;
 }
@@ -65,13 +66,13 @@ export class EnrollmentEntryService {
 
     const existingEntry = await team.getEntry({ transaction });
     if (existingEntry?.subEventId === subEventId) {
-      return { teamId, subEventCompetitionId: subEventId, alreadyExisted: true };
+      return { teamId, entryId: existingEntry.id as string, subEventCompetitionId: subEventId, alreadyExisted: true };
     }
 
     const entry = existingEntry ?? (await EventEntry.create({}, { transaction }));
     await team.setEntry(entry, { transaction });
     await subEvent.addEventEntry(entry, { transaction });
 
-    return { teamId, subEventCompetitionId: subEventId, alreadyExisted: false };
+    return { teamId, entryId: entry.id as string, subEventCompetitionId: subEventId, alreadyExisted: false };
   }
 }

--- a/libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts
@@ -1,0 +1,77 @@
+import { EventCompetition, EventEntry, Player, SubEventCompetition, Team } from "@badman/backend-database";
+import { Injectable, Logger } from "@nestjs/common";
+import { GraphQLError } from "graphql";
+import { Transaction } from "sequelize";
+import { ErrorCode } from "../../../utils";
+
+export interface CreateEntryArgs {
+  teamId: string;
+  subEventId: string;
+  transaction: Transaction;
+  user: Player;
+}
+
+export interface CreateEntryResult {
+  teamId: string;
+  subEventCompetitionId: string;
+  alreadyExisted: boolean;
+}
+
+@Injectable()
+export class EnrollmentEntryService {
+  private readonly logger = new Logger(EnrollmentEntryService.name);
+
+  async createEntry({ teamId, subEventId, transaction, user }: CreateEntryArgs): Promise<CreateEntryResult> {
+    const userId = user?.id ?? null;
+
+    const team = await Team.findByPk(teamId, { transaction });
+    if (!team) {
+      this.logger.warn({ code: ErrorCode.TEAM_NOT_FOUND, teamId, subEventCompetitionId: subEventId, userId });
+      throw new GraphQLError(`Team not found: ${teamId}`, {
+        extensions: { code: ErrorCode.TEAM_NOT_FOUND, teamId },
+      });
+    }
+
+    const allowed = await user.hasAnyPermission([
+      "edit:competition",
+      `${team.clubId}_edit:club`,
+      "edit-any:club",
+    ]);
+    if (!allowed) {
+      this.logger.warn({ code: ErrorCode.PERMISSION_DENIED, teamId, subEventCompetitionId: subEventId, userId });
+      throw new GraphQLError("You do not have permission to enroll this team.", {
+        extensions: { code: ErrorCode.PERMISSION_DENIED, userId },
+      });
+    }
+
+    const subEvent = await SubEventCompetition.findByPk(subEventId, {
+      transaction,
+      include: [EventCompetition],
+    });
+    if (!subEvent) {
+      this.logger.warn({ code: ErrorCode.SUB_EVENT_NOT_FOUND, teamId, subEventCompetitionId: subEventId, userId });
+      throw new GraphQLError(`Sub-event not found: ${subEventId}`, {
+        extensions: { code: ErrorCode.SUB_EVENT_NOT_FOUND, subEventId },
+      });
+    }
+
+    const competitionSeason = subEvent.eventCompetition?.season;
+    if (team.season !== competitionSeason) {
+      this.logger.warn({ code: ErrorCode.SEASON_MISMATCH, teamId, subEventCompetitionId: subEventId, userId, teamSeason: team.season, competitionSeason });
+      throw new GraphQLError("Team season does not match competition season.", {
+        extensions: { code: ErrorCode.SEASON_MISMATCH, teamSeason: team.season, competitionSeason },
+      });
+    }
+
+    const existingEntry = await team.getEntry({ transaction });
+    if (existingEntry?.subEventId === subEventId) {
+      return { teamId, subEventCompetitionId: subEventId, alreadyExisted: true };
+    }
+
+    const entry = existingEntry ?? (await EventEntry.create({}, { transaction }));
+    await team.setEntry(entry, { transaction });
+    await subEvent.addEventEntry(entry, { transaction });
+
+    return { teamId, subEventCompetitionId: subEventId, alreadyExisted: false };
+  }
+}

--- a/libs/backend/graphql/src/resolvers/event/competition/enrollment.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/enrollment.resolver.ts
@@ -1,11 +1,5 @@
 import { User } from "@badman/backend-authorization";
-import {
-  EventCompetition,
-  EventEntry,
-  Player,
-  SubEventCompetition,
-  Team,
-} from "@badman/backend-database";
+import { Player } from "@badman/backend-database";
 import {
   EnrollmentInput,
   EnrollmentOutput,
@@ -16,6 +10,7 @@ import { Args, Mutation, Query, Resolver } from "@nestjs/graphql";
 import { GraphQLError } from "graphql";
 import { Sequelize } from "sequelize-typescript";
 import { ErrorCode } from "../../../utils";
+import { EnrollmentEntryService } from "./enrollment-entry.service";
 import { EnrollmentResult } from "./enrollment-result.object";
 
 @Resolver(() => EnrollmentOutput)
@@ -23,6 +18,7 @@ export class EnrollmentResolver {
   private readonly logger = new Logger(EnrollmentResolver.name);
   constructor(
     private enrollmentService: EnrollmentValidationService,
+    private enrollmentEntryService: EnrollmentEntryService,
     private _sequelize: Sequelize
   ) {}
 
@@ -48,114 +44,16 @@ export class EnrollmentResolver {
     @Args("subEventId") subEventId: string
   ): Promise<EnrollmentResult> {
     const userId = user?.id ?? null;
-
     const transaction = await this._sequelize.transaction();
     try {
-      const team = await Team.findByPk(teamId, { transaction });
-      if (!team) {
-        this.logger.warn({
-          code: ErrorCode.TEAM_NOT_FOUND,
-          teamId,
-          subEventCompetitionId: subEventId,
-          userId,
-        });
-        throw new GraphQLError(`Team not found: ${teamId}`, {
-          extensions: { code: ErrorCode.TEAM_NOT_FOUND, teamId },
-        });
-      }
-
-      const allowed = await user.hasAnyPermission([
-        "edit:competition",
-        `${team.clubId}_edit:club`,
-        "edit-any:club",
-      ]);
-      if (!allowed) {
-        this.logger.warn({
-          code: ErrorCode.PERMISSION_DENIED,
-          teamId,
-          subEventCompetitionId: subEventId,
-          userId,
-        });
-        throw new GraphQLError("You do not have permission to enroll this team.", {
-          extensions: { code: ErrorCode.PERMISSION_DENIED, userId },
-        });
-      }
-
-      const subEvent = await SubEventCompetition.findByPk(subEventId, {
-        transaction,
-        include: [EventCompetition],
-      });
-      if (!subEvent) {
-        this.logger.warn({
-          code: ErrorCode.SUB_EVENT_NOT_FOUND,
-          teamId,
-          subEventCompetitionId: subEventId,
-          userId,
-        });
-        throw new GraphQLError(`Sub-event not found: ${subEventId}`, {
-          extensions: { code: ErrorCode.SUB_EVENT_NOT_FOUND, subEventId },
-        });
-      }
-
-      const competitionSeason = subEvent.eventCompetition?.season;
-      if (team.season !== competitionSeason) {
-        this.logger.warn({
-          code: ErrorCode.SEASON_MISMATCH,
-          teamId,
-          subEventCompetitionId: subEventId,
-          userId,
-          teamSeason: team.season,
-          competitionSeason,
-        });
-        throw new GraphQLError("Team season does not match competition season.", {
-          extensions: {
-            code: ErrorCode.SEASON_MISMATCH,
-            teamSeason: team.season,
-            competitionSeason,
-          },
-        });
-      }
-
-      // Idempotency short-circuit: if the team's existing entry already points
-      // to this sub-event, return success without further writes.
-      const existingEntry = await team.getEntry({ transaction });
-      if (existingEntry?.subEventId === subEventId) {
-        await transaction.commit();
-        return {
-          teamId,
-          subEventCompetitionId: subEventId,
-          alreadyExisted: true,
-        };
-      }
-
-      // Otherwise: reuse the team's existing entry (Team @HasOne EventEntry) or
-      // create a fresh one, then attach to the requested sub-event. Cross-sub-event
-      // moves are preserved as the existing behavior (see research.md §R3).
-      const entry = existingEntry ?? (await EventEntry.create({}, { transaction }));
-      await team.setEntry(entry, { transaction });
-      await subEvent.addEventEntry(entry, { transaction });
-
+      const result = await this.enrollmentEntryService.createEntry({ teamId, subEventId, transaction, user });
       await transaction.commit();
-      return {
-        teamId,
-        subEventCompetitionId: subEventId,
-        alreadyExisted: false,
-      };
+      return result;
     } catch (error) {
       await transaction.rollback();
-      if (error instanceof GraphQLError) {
-        // Already classified — let it pass through unchanged.
-        throw error;
-      }
-      // Unclassified failure: log full stack server-side, return sanitized
-      // INTERNAL_ERROR so internal details (SQL, stack frames) do not leak.
+      if (error instanceof GraphQLError) throw error;
       this.logger.error(
-        {
-          code: ErrorCode.INTERNAL_ERROR,
-          teamId,
-          subEventCompetitionId: subEventId,
-          userId,
-        },
+        { code: ErrorCode.INTERNAL_ERROR, teamId, subEventCompetitionId: subEventId, userId },
         error instanceof Error ? error.stack : String(error)
       );
       throw new GraphQLError("Internal error while creating enrollment.", {

--- a/libs/backend/graphql/src/resolvers/event/competition/enrollment.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/enrollment.resolver.ts
@@ -46,7 +46,12 @@ export class EnrollmentResolver {
     const userId = user?.id ?? null;
     const transaction = await this._sequelize.transaction();
     try {
-      const result = await this.enrollmentEntryService.createEntry({ teamId, subEventId, transaction, user });
+      const result = await this.enrollmentEntryService.createEntry({
+        teamId,
+        subEventId,
+        transaction,
+        user,
+      });
       await transaction.commit();
       return result;
     } catch (error) {

--- a/libs/backend/graphql/src/resolvers/event/competition/index.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/index.ts
@@ -6,6 +6,7 @@ export * from "./event.resolver";
 export * from "./subevent.resolver";
 export * from "./assembly.resolver";
 export * from "./enrollment.resolver";
+export * from "./enrollment-entry.service";
 export * from "./calculate-index";
 
 // end:ng42.barrel

--- a/libs/backend/graphql/src/resolvers/event/competition/index.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/index.ts
@@ -8,5 +8,9 @@ export * from "./assembly.resolver";
 export * from "./enrollment.resolver";
 export * from "./enrollment-entry.service";
 export * from "./calculate-index";
+export * from "./submit-enrollment.resolver";
+export * from "./submit-enrollment.service";
+export * from "./submit-enrollment.input";
+export * from "./submit-enrollment-result.object";
 
 // end:ng42.barrel

--- a/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment-result.object.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment-result.object.ts
@@ -1,0 +1,43 @@
+import { Field, ID, Int, ObjectType } from "@nestjs/graphql";
+
+@ObjectType()
+export class SubmitEnrollmentTeamResult {
+  @Field(() => Int)
+  inputIndex!: number;
+
+  @Field(() => ID)
+  teamId!: string;
+
+  @Field(() => ID, { nullable: true })
+  link?: string;
+
+  @Field(() => Int)
+  teamNumber!: number;
+
+  @Field(() => String)
+  name!: string;
+
+  @Field(() => String)
+  abbreviation!: string;
+
+  @Field(() => ID)
+  entryId!: string;
+
+  @Field(() => Boolean)
+  alreadyExisted!: boolean;
+}
+
+@ObjectType()
+export class SubmitEnrollmentResult {
+  @Field(() => Boolean)
+  ok!: boolean;
+
+  @Field(() => Boolean)
+  alreadyFinalised!: boolean;
+
+  @Field(() => Boolean)
+  notificationDispatched!: boolean;
+
+  @Field(() => [SubmitEnrollmentTeamResult])
+  teams!: SubmitEnrollmentTeamResult[];
+}

--- a/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.input.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.input.ts
@@ -1,0 +1,80 @@
+import { Field, ID, InputType, Int } from "@nestjs/graphql";
+import { SubEventTypeEnum } from "@badman/utils";
+
+@InputType()
+export class SubmitEnrollmentMembershipInput {
+  @Field(() => ID)
+  playerId!: string;
+
+  @Field(() => Date)
+  start!: Date;
+
+  @Field(() => Date, { nullable: true })
+  end?: Date;
+}
+
+@InputType()
+export class SubmitEnrollmentTeamInput {
+  @Field(() => ID, { nullable: true })
+  id?: string;
+
+  @Field(() => ID, { nullable: true })
+  link?: string;
+
+  @Field(() => String)
+  type!: SubEventTypeEnum;
+
+  @Field(() => ID)
+  subEventId!: string;
+
+  @Field(() => Int)
+  teamNumber!: number;
+
+  @Field(() => ID, { nullable: true })
+  captainId?: string;
+
+  @Field(() => String, { nullable: true })
+  email?: string;
+
+  @Field(() => String, { nullable: true })
+  phone?: string;
+
+  @Field(() => String, { nullable: true })
+  preferredDay?: string;
+
+  @Field(() => String, { nullable: true })
+  preferredTime?: string;
+
+  @Field(() => ID, { nullable: true })
+  preferredLocationId?: string;
+
+  @Field(() => [ID])
+  basePlayers!: string[];
+
+  @Field(() => [ID])
+  players!: string[];
+}
+
+@InputType()
+export class SubmitEnrollmentInput {
+  @Field(() => ID)
+  clubId!: string;
+
+  @Field(() => Int)
+  season!: number;
+
+  @Field(() => String)
+  adminEmail!: string;
+
+  @Field(() => String, { nullable: true })
+  remarks?: string;
+
+  @Field(() => [SubmitEnrollmentMembershipInput], { defaultValue: [] })
+  loans: SubmitEnrollmentMembershipInput[] = [];
+
+  @Field(() => [SubmitEnrollmentMembershipInput], { defaultValue: [] })
+  transfers: SubmitEnrollmentMembershipInput[] = [];
+
+  @Field(() => [SubmitEnrollmentTeamInput])
+  teams!: SubmitEnrollmentTeamInput[];
+}

--- a/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.input.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.input.ts
@@ -16,9 +16,6 @@ export class SubmitEnrollmentMembershipInput {
 @InputType()
 export class SubmitEnrollmentTeamInput {
   @Field(() => ID, { nullable: true })
-  id?: string;
-
-  @Field(() => ID, { nullable: true })
   link?: string;
 
   @Field(() => String)

--- a/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.resolver.spec.ts
@@ -1,0 +1,255 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { Player } from "@badman/backend-database";
+import { NotificationService } from "@badman/backend-notifications";
+import { GraphQLError } from "graphql";
+import { Sequelize } from "sequelize-typescript";
+import { SubmitEnrollmentResolver } from "./submit-enrollment.resolver";
+import { SubmitEnrollmentService } from "./submit-enrollment.service";
+import { SubmitEnrollmentInput, SubmitEnrollmentTeamInput } from "./submit-enrollment.input";
+import { SubEventTypeEnum } from "@badman/utils";
+import { ErrorCode } from "../../../utils";
+
+describe("SubmitEnrollmentResolver.submitEnrollment", () => {
+  let resolver: SubmitEnrollmentResolver;
+  let submitService: jest.Mocked<SubmitEnrollmentService>;
+  let notificationService: jest.Mocked<NotificationService>;
+
+  const commitSpy = jest.fn().mockResolvedValue(undefined);
+  const rollbackSpy = jest.fn().mockResolvedValue(undefined);
+  const fakeTransaction = {
+    commit: commitSpy,
+    rollback: rollbackSpy,
+    LOCK: { UPDATE: "UPDATE" },
+  };
+  const fakeSequelize = { transaction: jest.fn().mockResolvedValue(fakeTransaction) };
+
+  const makeUser = (perms: string[] = []) =>
+    ({
+      id: "user-uuid",
+      hasAnyPermission: jest.fn((asked: string[]) =>
+        Promise.resolve(asked.some((p) => perms.includes(p)))
+      ),
+    }) as unknown as Player;
+
+  const makeTeam = (): SubmitEnrollmentTeamInput => ({
+    type: SubEventTypeEnum.MX,
+    subEventId: "sub-uuid",
+    teamNumber: 1,
+    basePlayers: [],
+    players: [],
+  });
+
+  const makeInput = (clubId = "club-uuid"): SubmitEnrollmentInput => ({
+    clubId,
+    season: 2025,
+    adminEmail: "admin@test.com",
+    loans: [],
+    transfers: [],
+    teams: [makeTeam()],
+  });
+
+  const defaultServiceResult = {
+    alreadyFinalised: false,
+    teams: [
+      {
+        inputIndex: 0,
+        teamId: "team-uuid",
+        link: "link-uuid",
+        teamNumber: 1,
+        name: "Club 1H",
+        abbreviation: "CL 1H",
+        entryId: "entry-uuid",
+        alreadyExisted: false,
+      },
+    ],
+  };
+
+  beforeEach(async () => {
+    commitSpy.mockClear();
+    rollbackSpy.mockClear();
+    (fakeSequelize.transaction as jest.Mock).mockResolvedValue(fakeTransaction);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SubmitEnrollmentResolver,
+        { provide: SubmitEnrollmentService, useValue: { run: jest.fn() } },
+        { provide: NotificationService, useValue: { notifyEnrollment: jest.fn() } },
+        { provide: Sequelize, useValue: fakeSequelize },
+      ],
+    }).compile();
+
+    resolver = module.get<SubmitEnrollmentResolver>(SubmitEnrollmentResolver);
+    submitService = module.get(SubmitEnrollmentService);
+    notificationService = module.get(NotificationService);
+
+    // Default: service succeeds
+    submitService.run.mockResolvedValue(defaultServiceResult);
+    notificationService.notifyEnrollment.mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  // Case 1: anonymous user
+  it("throws PERMISSION_DENIED for anonymous user (no perms)", async () => {
+    const user = makeUser([]);
+    const input = makeInput();
+
+    await expect(resolver.submitEnrollment(user, input)).rejects.toMatchObject({
+      extensions: { code: ErrorCode.PERMISSION_DENIED },
+    });
+    expect(fakeSequelize.transaction).not.toHaveBeenCalled();
+  });
+
+  // Case 2: wrong club perm
+  it("throws PERMISSION_DENIED for wrong club perm", async () => {
+    const user = makeUser(["other-club_edit:club"]);
+    const input = makeInput("club-uuid");
+
+    await expect(resolver.submitEnrollment(user, input)).rejects.toMatchObject({
+      extensions: { code: ErrorCode.PERMISSION_DENIED },
+    });
+  });
+
+  // Case 3: club-specific perm granted
+  it("calls service when club-specific perm granted", async () => {
+    const user = makeUser(["club-uuid_edit:club"]);
+    await resolver.submitEnrollment(user, makeInput());
+    expect(submitService.run).toHaveBeenCalled();
+  });
+
+  // Case 4: edit-any:club perm granted
+  it("calls service when edit-any:club perm granted", async () => {
+    const user = makeUser(["edit-any:club"]);
+    await resolver.submitEnrollment(user, makeInput());
+    expect(submitService.run).toHaveBeenCalled();
+  });
+
+  // Case 5: service throws — rollback, no notify
+  it("rolls back and rethrows when service throws", async () => {
+    const user = makeUser(["edit-any:club"]);
+    submitService.run.mockRejectedValue(new Error("service-boom"));
+
+    await expect(resolver.submitEnrollment(user, makeInput())).rejects.toThrow("service-boom");
+    expect(rollbackSpy).toHaveBeenCalled();
+    expect(commitSpy).not.toHaveBeenCalled();
+    expect(notificationService.notifyEnrollment).not.toHaveBeenCalled();
+  });
+
+  // Case 6: alreadyFinalised: true — notify NOT invoked
+  it("does not dispatch notification when alreadyFinalised: true", async () => {
+    const user = makeUser(["edit-any:club"]);
+    submitService.run.mockResolvedValue({ ...defaultServiceResult, alreadyFinalised: true });
+
+    const result = await resolver.submitEnrollment(user, makeInput());
+
+    expect(notificationService.notifyEnrollment).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    expect(result.alreadyFinalised).toBe(true);
+    expect(result.notificationDispatched).toBe(false);
+  });
+
+  // Case 7: alreadyFinalised: false, notify resolves
+  it("dispatches notification and sets notificationDispatched: true", async () => {
+    const user = makeUser(["edit-any:club"]);
+    submitService.run.mockResolvedValue({ ...defaultServiceResult, alreadyFinalised: false });
+
+    const result = await resolver.submitEnrollment(user, makeInput());
+
+    expect(notificationService.notifyEnrollment).toHaveBeenCalledWith(
+      "user-uuid",
+      "club-uuid",
+      2025,
+      "admin@test.com"
+    );
+    expect(result.ok).toBe(true);
+    expect(result.notificationDispatched).toBe(true);
+  });
+
+  // Case 8: notify rejects — DB stays committed, no rethrow
+  it("sets notificationDispatched: false when notify rejects, does not rethrow", async () => {
+    const user = makeUser(["edit-any:club"]);
+    submitService.run.mockResolvedValue({ ...defaultServiceResult, alreadyFinalised: false });
+    notificationService.notifyEnrollment.mockRejectedValue(new Error("smtp-failure"));
+
+    const result = await resolver.submitEnrollment(user, makeInput());
+
+    expect(commitSpy).toHaveBeenCalled();
+    expect(rollbackSpy).not.toHaveBeenCalled();
+    expect(result.notificationDispatched).toBe(false);
+    expect(result.ok).toBe(true);
+  });
+
+  // Case 9: change:transfer absent → confirmed: false
+  it("passes confirmed: false when user lacks change:transfer", async () => {
+    const user = makeUser(["edit-any:club"]);
+
+    await resolver.submitEnrollment(user, makeInput());
+
+    expect(submitService.run).toHaveBeenCalledWith(
+      expect.objectContaining({ confirmed: false })
+    );
+  });
+
+  // Case 10: change:transfer present → confirmed: true
+  it("passes confirmed: true when user has change:transfer", async () => {
+    const user = makeUser(["edit-any:club", "change:transfer"]);
+
+    await resolver.submitEnrollment(user, makeInput());
+
+    expect(submitService.run).toHaveBeenCalledWith(
+      expect.objectContaining({ confirmed: true })
+    );
+  });
+
+  // Case 11: idempotent retry — second call returns alreadyFinalised: true
+  it("second call returns alreadyFinalised: true, notify invoked exactly once total", async () => {
+    const user = makeUser(["edit-any:club"]);
+    let callCount = 0;
+    submitService.run.mockImplementation(async () => {
+      callCount++;
+      return { ...defaultServiceResult, alreadyFinalised: callCount > 1 };
+    });
+
+    const r1 = await resolver.submitEnrollment(user, makeInput());
+    const r2 = await resolver.submitEnrollment(user, makeInput());
+
+    expect(r1.notificationDispatched).toBe(true);
+    expect(r2.alreadyFinalised).toBe(true);
+    expect(r2.notificationDispatched).toBe(false);
+    expect(notificationService.notifyEnrollment).toHaveBeenCalledTimes(1);
+  });
+
+  // Case 12: tx.commit called before notifyEnrollment
+  it("commits transaction before dispatching notification", async () => {
+    const user = makeUser(["edit-any:club"]);
+    const callOrder: string[] = [];
+    commitSpy.mockImplementation(async () => { callOrder.push("commit"); });
+    notificationService.notifyEnrollment.mockImplementation(async () => { callOrder.push("notify"); return undefined as never; });
+
+    await resolver.submitEnrollment(user, makeInput());
+
+    expect(callOrder).toEqual(["commit", "notify"]);
+  });
+
+  // Return shape
+  it("result includes teams array from service", async () => {
+    const user = makeUser(["edit-any:club"]);
+
+    const result = await resolver.submitEnrollment(user, makeInput());
+
+    expect(result.teams).toHaveLength(1);
+    expect(result.teams[0].entryId).toBe("entry-uuid");
+  });
+
+  // GraphQLErrors from service are rethrown without wrapping
+  it("rethrows GraphQLError from service unchanged", async () => {
+    const user = makeUser(["edit-any:club"]);
+    const gqlErr = new GraphQLError("validation", {
+      extensions: { code: ErrorCode.VALIDATION_FAILED, issue: "duplicate-team-number" },
+    });
+    submitService.run.mockRejectedValue(gqlErr);
+
+    await expect(resolver.submitEnrollment(user, makeInput())).rejects.toBe(gqlErr);
+    expect(rollbackSpy).toHaveBeenCalled();
+  });
+});

--- a/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.resolver.spec.ts
@@ -185,9 +185,7 @@ describe("SubmitEnrollmentResolver.submitEnrollment", () => {
 
     await resolver.submitEnrollment(user, makeInput());
 
-    expect(submitService.run).toHaveBeenCalledWith(
-      expect.objectContaining({ confirmed: false })
-    );
+    expect(submitService.run).toHaveBeenCalledWith(expect.objectContaining({ confirmed: false }));
   });
 
   // Case 10: change:transfer present → confirmed: true
@@ -196,9 +194,7 @@ describe("SubmitEnrollmentResolver.submitEnrollment", () => {
 
     await resolver.submitEnrollment(user, makeInput());
 
-    expect(submitService.run).toHaveBeenCalledWith(
-      expect.objectContaining({ confirmed: true })
-    );
+    expect(submitService.run).toHaveBeenCalledWith(expect.objectContaining({ confirmed: true }));
   });
 
   // Case 11: idempotent retry — second call returns alreadyFinalised: true
@@ -223,8 +219,13 @@ describe("SubmitEnrollmentResolver.submitEnrollment", () => {
   it("commits transaction before dispatching notification", async () => {
     const user = makeUser(["edit-any:club"]);
     const callOrder: string[] = [];
-    commitSpy.mockImplementation(async () => { callOrder.push("commit"); });
-    notificationService.notifyEnrollment.mockImplementation(async () => { callOrder.push("notify"); return undefined as never; });
+    commitSpy.mockImplementation(async () => {
+      callOrder.push("commit");
+    });
+    notificationService.notifyEnrollment.mockImplementation(async () => {
+      callOrder.push("notify");
+      return undefined as never;
+    });
 
     await resolver.submitEnrollment(user, makeInput());
 

--- a/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.resolver.ts
@@ -17,7 +17,7 @@ export class SubmitEnrollmentResolver {
   constructor(
     private readonly submitEnrollmentService: SubmitEnrollmentService,
     private readonly notificationService: NotificationService,
-    private readonly _sequelize: Sequelize,
+    private readonly _sequelize: Sequelize
   ) {}
 
   @Mutation(() => SubmitEnrollmentResult)

--- a/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.resolver.ts
@@ -1,0 +1,72 @@
+import { User } from "@badman/backend-authorization";
+import { Player } from "@badman/backend-database";
+import { NotificationService } from "@badman/backend-notifications";
+import { Logger } from "@nestjs/common";
+import { Args, Mutation, Resolver } from "@nestjs/graphql";
+import { GraphQLError } from "graphql";
+import { Sequelize } from "sequelize-typescript";
+import { ErrorCode } from "../../../utils";
+import { SubmitEnrollmentInput } from "./submit-enrollment.input";
+import { SubmitEnrollmentResult } from "./submit-enrollment-result.object";
+import { SubmitEnrollmentService } from "./submit-enrollment.service";
+
+@Resolver()
+export class SubmitEnrollmentResolver {
+  private readonly logger = new Logger(SubmitEnrollmentResolver.name);
+
+  constructor(
+    private readonly submitEnrollmentService: SubmitEnrollmentService,
+    private readonly notificationService: NotificationService,
+    private readonly _sequelize: Sequelize,
+  ) {}
+
+  @Mutation(() => SubmitEnrollmentResult)
+  async submitEnrollment(
+    @User() user: Player,
+    @Args("input") input: SubmitEnrollmentInput
+  ): Promise<SubmitEnrollmentResult> {
+    const { clubId, season, adminEmail } = input;
+
+    if (!(await user.hasAnyPermission([`${clubId}_edit:club`, "edit-any:club"]))) {
+      throw new GraphQLError("Permission denied", {
+        extensions: { code: ErrorCode.PERMISSION_DENIED, clubId },
+      });
+    }
+
+    const confirmed = await user.hasAnyPermission(["change:transfer"]);
+    const transaction = await this._sequelize.transaction();
+
+    try {
+      const result = await this.submitEnrollmentService.run({
+        input,
+        user,
+        confirmed,
+        transaction,
+      });
+      await transaction.commit();
+
+      let notificationDispatched = false;
+      if (!result.alreadyFinalised) {
+        try {
+          await this.notificationService.notifyEnrollment(user.id, clubId, season, adminEmail);
+          notificationDispatched = true;
+        } catch (notifyError) {
+          this.logger.warn(
+            `Failed to dispatch enrollment notification for club ${clubId} season ${season}`,
+            notifyError
+          );
+        }
+      }
+
+      return {
+        ok: true,
+        alreadyFinalised: result.alreadyFinalised,
+        notificationDispatched,
+        teams: result.teams,
+      };
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  }
+}

--- a/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.service.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.service.spec.ts
@@ -18,9 +18,14 @@ describe("SubmitEnrollmentService", () => {
   let enrollmentFinalizeService: jest.Mocked<EnrollmentFinalizeService>;
 
   const fakeTransaction = { LOCK: { UPDATE: "UPDATE" } } as never;
-  const fakeUser = { id: "user-uuid", hasAnyPermission: jest.fn().mockResolvedValue(false) } as never;
+  const fakeUser = {
+    id: "user-uuid",
+    hasAnyPermission: jest.fn().mockResolvedValue(false),
+  } as never;
 
-  const makeTeam = (overrides: Partial<SubmitEnrollmentTeamInput> = {}): SubmitEnrollmentTeamInput => ({
+  const makeTeam = (
+    overrides: Partial<SubmitEnrollmentTeamInput> = {}
+  ): SubmitEnrollmentTeamInput => ({
     type: SubEventTypeEnum.MX,
     subEventId: "subevent-uuid",
     teamNumber: 1,
@@ -40,15 +45,28 @@ describe("SubmitEnrollmentService", () => {
   });
 
   const defaultCoreResult = { teamId: "team-uuid", link: "link-uuid", alreadyExisted: false };
-  const defaultNumberedResult = { teamId: "team-uuid", teamNumber: 1, name: "Club 1H", abbreviation: "CL 1H" };
-  const defaultEntryResult = { teamId: "team-uuid", entryId: "entry-uuid", subEventCompetitionId: "subevent-uuid", alreadyExisted: false };
+  const defaultNumberedResult = {
+    teamId: "team-uuid",
+    teamNumber: 1,
+    name: "Club 1H",
+    abbreviation: "CL 1H",
+  };
+  const defaultEntryResult = {
+    teamId: "team-uuid",
+    entryId: "entry-uuid",
+    subEventCompetitionId: "subevent-uuid",
+    alreadyExisted: false,
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SubmitEnrollmentService,
         { provide: ClubMembershipService, useValue: { upsertMembership: jest.fn() } },
-        { provide: TeamWriteService, useValue: { upsertTeamCore: jest.fn(), applyTeamNumbersTwoPhase: jest.fn() } },
+        {
+          provide: TeamWriteService,
+          useValue: { upsertTeamCore: jest.fn(), applyTeamNumbersTwoPhase: jest.fn() },
+        },
         { provide: EnrollmentEntryService, useValue: { createEntry: jest.fn() } },
         { provide: EnrollmentFinalizeService, useValue: { finalize: jest.fn() } },
       ],
@@ -74,7 +92,12 @@ describe("SubmitEnrollmentService", () => {
   // ── Happy path ─────────────────────────────────────────────────────────────
 
   it("happy path — 1 new team — returns full result", async () => {
-    const result = await service.run({ input: makeInput(), user: fakeUser, confirmed: false, transaction: fakeTransaction });
+    const result = await service.run({
+      input: makeInput(),
+      user: fakeUser,
+      confirmed: false,
+      transaction: fakeTransaction,
+    });
 
     expect(result.alreadyFinalised).toBe(false);
     expect(result.teams).toHaveLength(1);
@@ -90,9 +113,17 @@ describe("SubmitEnrollmentService", () => {
   });
 
   it("happy path — existing team — alreadyExisted: true in result", async () => {
-    teamWriteService.upsertTeamCore.mockResolvedValue({ ...defaultCoreResult, alreadyExisted: true });
+    teamWriteService.upsertTeamCore.mockResolvedValue({
+      ...defaultCoreResult,
+      alreadyExisted: true,
+    });
 
-    const result = await service.run({ input: makeInput({ teams: [makeTeam({ id: "existing-uuid" })] }), user: fakeUser, confirmed: false, transaction: fakeTransaction });
+    const result = await service.run({
+      input: makeInput({ teams: [makeTeam({ id: "existing-uuid" })] }),
+      user: fakeUser,
+      confirmed: false,
+      transaction: fakeTransaction,
+    });
 
     expect(result.teams[0].alreadyExisted).toBe(true);
   });
@@ -100,7 +131,12 @@ describe("SubmitEnrollmentService", () => {
   it("alreadyFinalised: true propagated from finalize", async () => {
     enrollmentFinalizeService.finalize.mockResolvedValue({ alreadyFinalised: true });
 
-    const result = await service.run({ input: makeInput(), user: fakeUser, confirmed: false, transaction: fakeTransaction });
+    const result = await service.run({
+      input: makeInput(),
+      user: fakeUser,
+      confirmed: false,
+      transaction: fakeTransaction,
+    });
 
     expect(result.alreadyFinalised).toBe(true);
   });
@@ -109,14 +145,21 @@ describe("SubmitEnrollmentService", () => {
 
   it("calls upsertMembership for each transfer with NORMAL type", async () => {
     const input = makeInput({
-      transfers: [{ playerId: "p1", start: new Date("2025-09-01") }, { playerId: "p2", start: new Date("2025-09-01") }],
+      transfers: [
+        { playerId: "p1", start: new Date("2025-09-01") },
+        { playerId: "p2", start: new Date("2025-09-01") },
+      ],
     });
 
     await service.run({ input, user: fakeUser, confirmed: true, transaction: fakeTransaction });
 
     expect(clubMembershipService.upsertMembership).toHaveBeenCalledTimes(2);
     expect(clubMembershipService.upsertMembership).toHaveBeenCalledWith(
-      expect.objectContaining({ playerId: "p1", membershipType: ClubMembershipType.NORMAL, confirmed: true })
+      expect.objectContaining({
+        playerId: "p1",
+        membershipType: ClubMembershipType.NORMAL,
+        confirmed: true,
+      })
     );
   });
 
@@ -145,9 +188,9 @@ describe("SubmitEnrollmentService", () => {
   // ── Remarks ────────────────────────────────────────────────────────────────
 
   it("writes one Comment per distinct eventCompetition when remarks provided", async () => {
-    jest.spyOn(SubEventCompetition, "findAll").mockResolvedValue([
-      { id: "se1", eventId: "event-uuid" } as never,
-    ]);
+    jest
+      .spyOn(SubEventCompetition, "findAll")
+      .mockResolvedValue([{ id: "se1", eventId: "event-uuid" } as never]);
     const createSpy = jest.spyOn(Comment, "create").mockResolvedValue({} as never);
     const input = makeInput({ remarks: "Hello" });
 
@@ -155,23 +198,27 @@ describe("SubmitEnrollmentService", () => {
 
     expect(createSpy).toHaveBeenCalledTimes(1);
     expect(createSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ linkType: "competition", linkId: "event-uuid", clubId: "club-uuid", message: "Hello" }),
+      expect.objectContaining({
+        linkType: "competition",
+        linkId: "event-uuid",
+        clubId: "club-uuid",
+        message: "Hello",
+      }),
       expect.anything()
     );
   });
 
   it("writes two Comments when two distinct eventCompetitions", async () => {
-    jest.spyOn(SubEventCompetition, "findAll").mockResolvedValue([
-      { id: "se1", eventId: "event-A" } as never,
-      { id: "se2", eventId: "event-B" } as never,
-    ]);
+    jest
+      .spyOn(SubEventCompetition, "findAll")
+      .mockResolvedValue([
+        { id: "se1", eventId: "event-A" } as never,
+        { id: "se2", eventId: "event-B" } as never,
+      ]);
     const createSpy = jest.spyOn(Comment, "create").mockResolvedValue({} as never);
     const input = makeInput({
       remarks: "Hi",
-      teams: [
-        makeTeam({ subEventId: "se1" }),
-        makeTeam({ subEventId: "se2", teamNumber: 2 }),
-      ],
+      teams: [makeTeam({ subEventId: "se1" }), makeTeam({ subEventId: "se2", teamNumber: 2 })],
     });
     teamWriteService.upsertTeamCore
       .mockResolvedValueOnce({ teamId: "t1", link: "l1", alreadyExisted: false })
@@ -181,8 +228,18 @@ describe("SubmitEnrollmentService", () => {
       { teamId: "t2", teamNumber: 2, name: "Club 2H", abbreviation: "CL 2H" },
     ]);
     enrollmentEntryService.createEntry
-      .mockResolvedValueOnce({ teamId: "t1", entryId: "e1", subEventCompetitionId: "se1", alreadyExisted: false })
-      .mockResolvedValueOnce({ teamId: "t2", entryId: "e2", subEventCompetitionId: "se2", alreadyExisted: false });
+      .mockResolvedValueOnce({
+        teamId: "t1",
+        entryId: "e1",
+        subEventCompetitionId: "se1",
+        alreadyExisted: false,
+      })
+      .mockResolvedValueOnce({
+        teamId: "t2",
+        entryId: "e2",
+        subEventCompetitionId: "se2",
+        alreadyExisted: false,
+      });
 
     await service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction });
 
@@ -190,13 +247,15 @@ describe("SubmitEnrollmentService", () => {
   });
 
   it("swallows Comment.create error and continues", async () => {
-    jest.spyOn(SubEventCompetition, "findAll").mockResolvedValue([
-      { id: "se1", eventId: "event-uuid" } as never,
-    ]);
+    jest
+      .spyOn(SubEventCompetition, "findAll")
+      .mockResolvedValue([{ id: "se1", eventId: "event-uuid" } as never]);
     jest.spyOn(Comment, "create").mockRejectedValue(new Error("db-write-failure"));
     const input = makeInput({ remarks: "note" });
 
-    await expect(service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction })).resolves.not.toThrow();
+    await expect(
+      service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction })
+    ).resolves.not.toThrow();
   });
 
   it("does not write Comment when remarks is empty string", async () => {
@@ -227,12 +286,14 @@ describe("SubmitEnrollmentService", () => {
       ],
     });
 
-    await expect(service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction }))
-      .rejects.toSatisfyError(ErrorCode.VALIDATION_FAILED, "duplicate-team-number");
+    await expect(
+      service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction })
+    ).rejects.toSatisfyError(ErrorCode.VALIDATION_FAILED, "duplicate-team-number");
   });
 
   it("allows same teamNumber for different types", async () => {
-    jest.spyOn(SubEventCompetition, "findByPk")
+    jest
+      .spyOn(SubEventCompetition, "findByPk")
       .mockResolvedValueOnce({ eventType: "MX" } as never)
       .mockResolvedValueOnce({ eventType: "M" } as never);
     teamWriteService.upsertTeamCore
@@ -243,8 +304,18 @@ describe("SubmitEnrollmentService", () => {
       { teamId: "t2", teamNumber: 1, name: "Club 1H", abbreviation: "CL 1H" },
     ]);
     enrollmentEntryService.createEntry
-      .mockResolvedValueOnce({ teamId: "t1", entryId: "e1", subEventCompetitionId: "se1", alreadyExisted: false })
-      .mockResolvedValueOnce({ teamId: "t2", entryId: "e2", subEventCompetitionId: "se2", alreadyExisted: false });
+      .mockResolvedValueOnce({
+        teamId: "t1",
+        entryId: "e1",
+        subEventCompetitionId: "se1",
+        alreadyExisted: false,
+      })
+      .mockResolvedValueOnce({
+        teamId: "t2",
+        entryId: "e2",
+        subEventCompetitionId: "se2",
+        alreadyExisted: false,
+      });
 
     const input = makeInput({
       teams: [
@@ -253,15 +324,18 @@ describe("SubmitEnrollmentService", () => {
       ],
     });
 
-    await expect(service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction })).resolves.not.toThrow();
+    await expect(
+      service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction })
+    ).resolves.not.toThrow();
   });
 
   it("throws VALIDATION_FAILED subevent-type-mismatch", async () => {
     jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue({ eventType: "M" } as never);
     const input = makeInput({ teams: [makeTeam({ type: SubEventTypeEnum.MX })] });
 
-    await expect(service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction }))
-      .rejects.toSatisfyError(ErrorCode.VALIDATION_FAILED, "subevent-type-mismatch");
+    await expect(
+      service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction })
+    ).rejects.toSatisfyError(ErrorCode.VALIDATION_FAILED, "subevent-type-mismatch");
   });
 
   it("throws VALIDATION_FAILED base-not-in-roster", async () => {
@@ -269,17 +343,20 @@ describe("SubmitEnrollmentService", () => {
       teams: [makeTeam({ basePlayers: ["p-not-in-roster"], players: ["p1", "p2"] })],
     });
 
-    await expect(service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction }))
-      .rejects.toSatisfyError(ErrorCode.VALIDATION_FAILED, "base-not-in-roster");
+    await expect(
+      service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction })
+    ).rejects.toSatisfyError(ErrorCode.VALIDATION_FAILED, "base-not-in-roster");
   });
 
   it("throws NO_TEAMS_TO_FINALISE when teams array is empty", async () => {
     const input = makeInput({ teams: [] });
 
-    await expect(service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction }))
-      .rejects.toThrow(GraphQLError);
-    await expect(service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction }))
-      .rejects.toMatchObject({ extensions: { code: ErrorCode.NO_TEAMS_TO_FINALISE } });
+    await expect(
+      service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction })
+    ).rejects.toThrow(GraphQLError);
+    await expect(
+      service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction })
+    ).rejects.toMatchObject({ extensions: { code: ErrorCode.NO_TEAMS_TO_FINALISE } });
   });
 
   it("throws VALIDATION_FAILED team-count-exceeded for 51 teams", async () => {
@@ -288,8 +365,9 @@ describe("SubmitEnrollmentService", () => {
     );
     const input = makeInput({ teams: manyTeams });
 
-    await expect(service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction }))
-      .rejects.toSatisfyError(ErrorCode.VALIDATION_FAILED, "team-count-exceeded");
+    await expect(
+      service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction })
+    ).rejects.toSatisfyError(ErrorCode.VALIDATION_FAILED, "team-count-exceeded");
   });
 
   it("sanity runs before any DB write — upsertTeamCore not called on dup-number failure", async () => {
@@ -297,7 +375,9 @@ describe("SubmitEnrollmentService", () => {
       teams: [makeTeam({ teamNumber: 1 }), makeTeam({ teamNumber: 1, subEventId: "se2" })],
     });
 
-    await expect(service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction })).rejects.toThrow();
+    await expect(
+      service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction })
+    ).rejects.toThrow();
     expect(teamWriteService.upsertTeamCore).not.toHaveBeenCalled();
   });
 });

--- a/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.service.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.service.spec.ts
@@ -119,7 +119,7 @@ describe("SubmitEnrollmentService", () => {
     });
 
     const result = await service.run({
-      input: makeInput({ teams: [makeTeam({ id: "existing-uuid" })] }),
+      input: makeInput({ teams: [makeTeam({ link: "existing-link" })] }),
       user: fakeUser,
       confirmed: false,
       transaction: fakeTransaction,

--- a/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.service.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.service.spec.ts
@@ -1,0 +1,337 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { Club, Comment, SubEventCompetition } from "@badman/backend-database";
+import { ClubMembershipType, SubEventTypeEnum } from "@badman/utils";
+import { GraphQLError } from "graphql";
+import { ClubMembershipService } from "../../club/club-membership.service";
+import { EnrollmentEntryService } from "./enrollment-entry.service";
+import { EnrollmentFinalizeService } from "../enrollment-finalize.service";
+import { TeamWriteService } from "../../team/team-write.service";
+import { SubmitEnrollmentService } from "./submit-enrollment.service";
+import { SubmitEnrollmentInput, SubmitEnrollmentTeamInput } from "./submit-enrollment.input";
+import { ErrorCode } from "../../../utils";
+
+describe("SubmitEnrollmentService", () => {
+  let service: SubmitEnrollmentService;
+  let clubMembershipService: jest.Mocked<ClubMembershipService>;
+  let teamWriteService: jest.Mocked<TeamWriteService>;
+  let enrollmentEntryService: jest.Mocked<EnrollmentEntryService>;
+  let enrollmentFinalizeService: jest.Mocked<EnrollmentFinalizeService>;
+
+  const fakeTransaction = { LOCK: { UPDATE: "UPDATE" } } as never;
+  const fakeUser = { id: "user-uuid", hasAnyPermission: jest.fn().mockResolvedValue(false) } as never;
+
+  const makeTeam = (overrides: Partial<SubmitEnrollmentTeamInput> = {}): SubmitEnrollmentTeamInput => ({
+    type: SubEventTypeEnum.MX,
+    subEventId: "subevent-uuid",
+    teamNumber: 1,
+    basePlayers: [],
+    players: [],
+    ...overrides,
+  });
+
+  const makeInput = (overrides: Partial<SubmitEnrollmentInput> = {}): SubmitEnrollmentInput => ({
+    clubId: "club-uuid",
+    season: 2025,
+    adminEmail: "admin@test.com",
+    loans: [],
+    transfers: [],
+    teams: [makeTeam()],
+    ...overrides,
+  });
+
+  const defaultCoreResult = { teamId: "team-uuid", link: "link-uuid", alreadyExisted: false };
+  const defaultNumberedResult = { teamId: "team-uuid", teamNumber: 1, name: "Club 1H", abbreviation: "CL 1H" };
+  const defaultEntryResult = { teamId: "team-uuid", entryId: "entry-uuid", subEventCompetitionId: "subevent-uuid", alreadyExisted: false };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SubmitEnrollmentService,
+        { provide: ClubMembershipService, useValue: { upsertMembership: jest.fn() } },
+        { provide: TeamWriteService, useValue: { upsertTeamCore: jest.fn(), applyTeamNumbersTwoPhase: jest.fn() } },
+        { provide: EnrollmentEntryService, useValue: { createEntry: jest.fn() } },
+        { provide: EnrollmentFinalizeService, useValue: { finalize: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get<SubmitEnrollmentService>(SubmitEnrollmentService);
+    clubMembershipService = module.get(ClubMembershipService);
+    teamWriteService = module.get(TeamWriteService);
+    enrollmentEntryService = module.get(EnrollmentEntryService);
+    enrollmentFinalizeService = module.get(EnrollmentFinalizeService);
+
+    // Default happy-path mocks
+    jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue({ eventType: "MX" } as never);
+    jest.spyOn(Club, "findByPk").mockResolvedValue({ id: "club-uuid" } as never);
+    teamWriteService.upsertTeamCore.mockResolvedValue(defaultCoreResult);
+    teamWriteService.applyTeamNumbersTwoPhase.mockResolvedValue([defaultNumberedResult]);
+    enrollmentEntryService.createEntry.mockResolvedValue(defaultEntryResult);
+    enrollmentFinalizeService.finalize.mockResolvedValue({ alreadyFinalised: false });
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  // ── Happy path ─────────────────────────────────────────────────────────────
+
+  it("happy path — 1 new team — returns full result", async () => {
+    const result = await service.run({ input: makeInput(), user: fakeUser, confirmed: false, transaction: fakeTransaction });
+
+    expect(result.alreadyFinalised).toBe(false);
+    expect(result.teams).toHaveLength(1);
+    expect(result.teams[0]).toMatchObject({
+      inputIndex: 0,
+      teamId: "team-uuid",
+      link: "link-uuid",
+      teamNumber: 1,
+      name: "Club 1H",
+      entryId: "entry-uuid",
+      alreadyExisted: false,
+    });
+  });
+
+  it("happy path — existing team — alreadyExisted: true in result", async () => {
+    teamWriteService.upsertTeamCore.mockResolvedValue({ ...defaultCoreResult, alreadyExisted: true });
+
+    const result = await service.run({ input: makeInput({ teams: [makeTeam({ id: "existing-uuid" })] }), user: fakeUser, confirmed: false, transaction: fakeTransaction });
+
+    expect(result.teams[0].alreadyExisted).toBe(true);
+  });
+
+  it("alreadyFinalised: true propagated from finalize", async () => {
+    enrollmentFinalizeService.finalize.mockResolvedValue({ alreadyFinalised: true });
+
+    const result = await service.run({ input: makeInput(), user: fakeUser, confirmed: false, transaction: fakeTransaction });
+
+    expect(result.alreadyFinalised).toBe(true);
+  });
+
+  // ── Transfers and loans ────────────────────────────────────────────────────
+
+  it("calls upsertMembership for each transfer with NORMAL type", async () => {
+    const input = makeInput({
+      transfers: [{ playerId: "p1", start: new Date("2025-09-01") }, { playerId: "p2", start: new Date("2025-09-01") }],
+    });
+
+    await service.run({ input, user: fakeUser, confirmed: true, transaction: fakeTransaction });
+
+    expect(clubMembershipService.upsertMembership).toHaveBeenCalledTimes(2);
+    expect(clubMembershipService.upsertMembership).toHaveBeenCalledWith(
+      expect.objectContaining({ playerId: "p1", membershipType: ClubMembershipType.NORMAL, confirmed: true })
+    );
+  });
+
+  it("calls upsertMembership for each loan with LOAN type", async () => {
+    const input = makeInput({
+      loans: [{ playerId: "loaner", start: new Date("2025-09-01") }],
+    });
+
+    await service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction });
+
+    expect(clubMembershipService.upsertMembership).toHaveBeenCalledWith(
+      expect.objectContaining({ playerId: "loaner", membershipType: ClubMembershipType.LOAN })
+    );
+  });
+
+  it("passes confirmed flag to upsertMembership", async () => {
+    const input = makeInput({ transfers: [{ playerId: "p1", start: new Date() }] });
+
+    await service.run({ input, user: fakeUser, confirmed: true, transaction: fakeTransaction });
+
+    expect(clubMembershipService.upsertMembership).toHaveBeenCalledWith(
+      expect.objectContaining({ confirmed: true })
+    );
+  });
+
+  // ── Remarks ────────────────────────────────────────────────────────────────
+
+  it("writes one Comment per distinct eventCompetition when remarks provided", async () => {
+    jest.spyOn(SubEventCompetition, "findAll").mockResolvedValue([
+      { id: "se1", eventId: "event-uuid" } as never,
+    ]);
+    const createSpy = jest.spyOn(Comment, "create").mockResolvedValue({} as never);
+    const input = makeInput({ remarks: "Hello" });
+
+    await service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction });
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(createSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ linkType: "competition", linkId: "event-uuid", clubId: "club-uuid", message: "Hello" }),
+      expect.anything()
+    );
+  });
+
+  it("writes two Comments when two distinct eventCompetitions", async () => {
+    jest.spyOn(SubEventCompetition, "findAll").mockResolvedValue([
+      { id: "se1", eventId: "event-A" } as never,
+      { id: "se2", eventId: "event-B" } as never,
+    ]);
+    const createSpy = jest.spyOn(Comment, "create").mockResolvedValue({} as never);
+    const input = makeInput({
+      remarks: "Hi",
+      teams: [
+        makeTeam({ subEventId: "se1" }),
+        makeTeam({ subEventId: "se2", teamNumber: 2 }),
+      ],
+    });
+    teamWriteService.upsertTeamCore
+      .mockResolvedValueOnce({ teamId: "t1", link: "l1", alreadyExisted: false })
+      .mockResolvedValueOnce({ teamId: "t2", link: "l2", alreadyExisted: false });
+    teamWriteService.applyTeamNumbersTwoPhase.mockResolvedValue([
+      { teamId: "t1", teamNumber: 1, name: "Club 1H", abbreviation: "CL 1H" },
+      { teamId: "t2", teamNumber: 2, name: "Club 2H", abbreviation: "CL 2H" },
+    ]);
+    enrollmentEntryService.createEntry
+      .mockResolvedValueOnce({ teamId: "t1", entryId: "e1", subEventCompetitionId: "se1", alreadyExisted: false })
+      .mockResolvedValueOnce({ teamId: "t2", entryId: "e2", subEventCompetitionId: "se2", alreadyExisted: false });
+
+    await service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction });
+
+    expect(createSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("swallows Comment.create error and continues", async () => {
+    jest.spyOn(SubEventCompetition, "findAll").mockResolvedValue([
+      { id: "se1", eventId: "event-uuid" } as never,
+    ]);
+    jest.spyOn(Comment, "create").mockRejectedValue(new Error("db-write-failure"));
+    const input = makeInput({ remarks: "note" });
+
+    await expect(service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction })).resolves.not.toThrow();
+  });
+
+  it("does not write Comment when remarks is empty string", async () => {
+    const createSpy = jest.spyOn(Comment, "create").mockResolvedValue({} as never);
+    const input = makeInput({ remarks: "   " });
+
+    await service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction });
+
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not write Comment when remarks is absent", async () => {
+    const createSpy = jest.spyOn(Comment, "create").mockResolvedValue({} as never);
+    const input = makeInput({ remarks: undefined });
+
+    await service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction });
+
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  // ── Sanity checks ──────────────────────────────────────────────────────────
+
+  it("throws VALIDATION_FAILED duplicate-team-number for same type", async () => {
+    const input = makeInput({
+      teams: [
+        makeTeam({ type: SubEventTypeEnum.MX, teamNumber: 1 }),
+        makeTeam({ type: SubEventTypeEnum.MX, teamNumber: 1, subEventId: "se2" }),
+      ],
+    });
+
+    await expect(service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction }))
+      .rejects.toSatisfyError(ErrorCode.VALIDATION_FAILED, "duplicate-team-number");
+  });
+
+  it("allows same teamNumber for different types", async () => {
+    jest.spyOn(SubEventCompetition, "findByPk")
+      .mockResolvedValueOnce({ eventType: "MX" } as never)
+      .mockResolvedValueOnce({ eventType: "M" } as never);
+    teamWriteService.upsertTeamCore
+      .mockResolvedValueOnce({ teamId: "t1", link: "l1", alreadyExisted: false })
+      .mockResolvedValueOnce({ teamId: "t2", link: "l2", alreadyExisted: false });
+    teamWriteService.applyTeamNumbersTwoPhase.mockResolvedValue([
+      { teamId: "t1", teamNumber: 1, name: "Club 1H", abbreviation: "CL 1H" },
+      { teamId: "t2", teamNumber: 1, name: "Club 1H", abbreviation: "CL 1H" },
+    ]);
+    enrollmentEntryService.createEntry
+      .mockResolvedValueOnce({ teamId: "t1", entryId: "e1", subEventCompetitionId: "se1", alreadyExisted: false })
+      .mockResolvedValueOnce({ teamId: "t2", entryId: "e2", subEventCompetitionId: "se2", alreadyExisted: false });
+
+    const input = makeInput({
+      teams: [
+        makeTeam({ type: SubEventTypeEnum.MX, teamNumber: 1 }),
+        makeTeam({ type: SubEventTypeEnum.M, teamNumber: 1, subEventId: "se2" }),
+      ],
+    });
+
+    await expect(service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction })).resolves.not.toThrow();
+  });
+
+  it("throws VALIDATION_FAILED subevent-type-mismatch", async () => {
+    jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue({ eventType: "M" } as never);
+    const input = makeInput({ teams: [makeTeam({ type: SubEventTypeEnum.MX })] });
+
+    await expect(service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction }))
+      .rejects.toSatisfyError(ErrorCode.VALIDATION_FAILED, "subevent-type-mismatch");
+  });
+
+  it("throws VALIDATION_FAILED base-not-in-roster", async () => {
+    const input = makeInput({
+      teams: [makeTeam({ basePlayers: ["p-not-in-roster"], players: ["p1", "p2"] })],
+    });
+
+    await expect(service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction }))
+      .rejects.toSatisfyError(ErrorCode.VALIDATION_FAILED, "base-not-in-roster");
+  });
+
+  it("throws NO_TEAMS_TO_FINALISE when teams array is empty", async () => {
+    const input = makeInput({ teams: [] });
+
+    await expect(service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction }))
+      .rejects.toThrow(GraphQLError);
+    await expect(service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction }))
+      .rejects.toMatchObject({ extensions: { code: ErrorCode.NO_TEAMS_TO_FINALISE } });
+  });
+
+  it("throws VALIDATION_FAILED team-count-exceeded for 51 teams", async () => {
+    const manyTeams = Array.from({ length: 51 }, (_, i) =>
+      makeTeam({ teamNumber: i + 1, subEventId: `se-${i}` })
+    );
+    const input = makeInput({ teams: manyTeams });
+
+    await expect(service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction }))
+      .rejects.toSatisfyError(ErrorCode.VALIDATION_FAILED, "team-count-exceeded");
+  });
+
+  it("sanity runs before any DB write — upsertTeamCore not called on dup-number failure", async () => {
+    const input = makeInput({
+      teams: [makeTeam({ teamNumber: 1 }), makeTeam({ teamNumber: 1, subEventId: "se2" })],
+    });
+
+    await expect(service.run({ input, user: fakeUser, confirmed: false, transaction: fakeTransaction })).rejects.toThrow();
+    expect(teamWriteService.upsertTeamCore).not.toHaveBeenCalled();
+  });
+});
+
+// Helper: extend expect to assert GraphQLError code + issue together
+expect.extend({
+  toSatisfyError(received: unknown, code: string, issue?: string) {
+    if (!(received instanceof GraphQLError)) {
+      return { pass: false, message: () => `Expected GraphQLError, got ${typeof received}` };
+    }
+    if (received.extensions?.["code"] !== code) {
+      return {
+        pass: false,
+        message: () => `Expected code ${code}, got ${received.extensions?.["code"]}`,
+      };
+    }
+    if (issue !== undefined && received.extensions?.["issue"] !== issue) {
+      return {
+        pass: false,
+        message: () => `Expected issue ${issue}, got ${received.extensions?.["issue"]}`,
+      };
+    }
+    return { pass: true, message: () => "GraphQLError matches" };
+  },
+});
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      toSatisfyError(code: string, issue?: string): R;
+    }
+    interface AsymmetricMatchers {
+      toSatisfyError(code: string, issue?: string): void;
+    }
+  }
+}

--- a/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.service.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.service.ts
@@ -1,0 +1,262 @@
+import {
+  Club,
+  Comment,
+  Player,
+  SubEventCompetition,
+} from "@badman/backend-database";
+import { ClubMembershipType } from "@badman/utils";
+import { Injectable, Logger } from "@nestjs/common";
+import { GraphQLError } from "graphql";
+import { Transaction } from "sequelize";
+import { ClubMembershipService } from "../../club/club-membership.service";
+import { EnrollmentEntryService } from "./enrollment-entry.service";
+import { EnrollmentFinalizeService } from "../enrollment-finalize.service";
+import { TeamWriteService } from "../../team/team-write.service";
+import { SubmitEnrollmentInput } from "./submit-enrollment.input";
+import { SubmitEnrollmentTeamResult } from "./submit-enrollment-result.object";
+import { ErrorCode } from "../../../utils";
+
+export interface SubmitEnrollmentServiceResult {
+  alreadyFinalised: boolean;
+  teams: SubmitEnrollmentTeamResult[];
+}
+
+export interface SubmitEnrollmentRunArgs {
+  input: SubmitEnrollmentInput;
+  user: Player;
+  confirmed: boolean;
+  transaction: Transaction;
+}
+
+const MAX_TEAMS = 50;
+
+@Injectable()
+export class SubmitEnrollmentService {
+  private readonly logger = new Logger(SubmitEnrollmentService.name);
+
+  constructor(
+    private readonly clubMembershipService: ClubMembershipService,
+    private readonly teamWriteService: TeamWriteService,
+    private readonly enrollmentEntryService: EnrollmentEntryService,
+    private readonly enrollmentFinalizeService: EnrollmentFinalizeService,
+  ) {}
+
+  async run({ input, user, confirmed, transaction }: SubmitEnrollmentRunArgs): Promise<SubmitEnrollmentServiceResult> {
+    const { clubId, season, adminEmail, teams, transfers, loans, remarks } = input;
+    const txId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    // (1) Sanity checks — no DB writes yet
+    await this.sanity(input, transaction);
+
+    // (2) Transfers
+    for (const t of transfers) {
+      await this.clubMembershipService.upsertMembership({
+        clubId,
+        playerId: t.playerId,
+        start: t.start,
+        end: t.end,
+        membershipType: ClubMembershipType.NORMAL,
+        confirmed,
+        transaction,
+      });
+    }
+
+    // (3) Loans
+    for (const l of loans) {
+      await this.clubMembershipService.upsertMembership({
+        clubId,
+        playerId: l.playerId,
+        start: l.start,
+        end: l.end,
+        membershipType: ClubMembershipType.LOAN,
+        confirmed,
+        transaction,
+      });
+    }
+
+    // (4) Phase A: write each team without final teamNumber/name/abbreviation
+    const coreResults: { teamId: string; link: string; alreadyExisted: boolean; inputIndex: number }[] = [];
+    for (let i = 0; i < teams.length; i++) {
+      const team = teams[i];
+      const core = await this.teamWriteService.upsertTeamCore({
+        id: team.id,
+        link: team.link,
+        clubId,
+        season,
+        type: team.type,
+        captainId: team.captainId,
+        email: team.email,
+        phone: team.phone,
+        preferredDay: team.preferredDay,
+        preferredTime: team.preferredTime,
+        prefferedLocationId: team.preferredLocationId,
+        players: team.players,
+        txId,
+        txIndex: i,
+        transaction,
+      });
+      coreResults.push({ ...core, inputIndex: i });
+    }
+
+    // (5) Phase B: two-phase team number write
+    const numberedResults = await this.teamWriteService.applyTeamNumbersTwoPhase({
+      teams: coreResults.map((r, i) => ({ teamId: r.teamId, teamNumber: teams[i].teamNumber })),
+      clubId,
+      transaction,
+    });
+
+    // (6) Create enrollment entries
+    const teamResults: SubmitEnrollmentTeamResult[] = [];
+    for (let i = 0; i < coreResults.length; i++) {
+      const core = coreResults[i];
+      const numbered = numberedResults[i];
+      const team = teams[i];
+
+      const entry = await this.enrollmentEntryService.createEntry({
+        teamId: core.teamId,
+        subEventId: team.subEventId,
+        transaction,
+        user,
+      });
+
+      teamResults.push({
+        inputIndex: core.inputIndex,
+        teamId: core.teamId,
+        link: core.link,
+        teamNumber: numbered.teamNumber,
+        name: numbered.name,
+        abbreviation: numbered.abbreviation,
+        entryId: entry.entryId,
+        alreadyExisted: core.alreadyExisted,
+      });
+    }
+
+    // (7) Remarks (best-effort)
+    if (remarks?.trim()) {
+      await this.writeRemarks({ clubId, teams: input.teams, remarks, transaction });
+    }
+
+    // (8) Finalize (stamp sendOn, update contactCompetition, write Logging)
+    const club = await Club.findByPk(clubId, { transaction });
+    if (!club) {
+      throw new GraphQLError(`Club not found: ${clubId}`, {
+        extensions: { code: ErrorCode.CLUB_NOT_FOUND, clubId },
+      });
+    }
+
+    const { alreadyFinalised } = await this.enrollmentFinalizeService.finalize({
+      clubId,
+      season,
+      email: adminEmail,
+      user,
+      club,
+      transaction,
+    });
+
+    return { alreadyFinalised, teams: teamResults };
+  }
+
+  private async sanity(input: SubmitEnrollmentInput, transaction: Transaction): Promise<void> {
+    const { teams } = input;
+
+    if (teams.length === 0) {
+      throw new GraphQLError("No teams to submit", {
+        extensions: { code: ErrorCode.NO_TEAMS_TO_FINALISE, clubId: input.clubId, season: input.season },
+      });
+    }
+
+    if (teams.length > MAX_TEAMS) {
+      throw new GraphQLError(`Too many teams (max ${MAX_TEAMS})`, {
+        extensions: { code: ErrorCode.VALIDATION_FAILED, issue: "team-count-exceeded", count: teams.length },
+      });
+    }
+
+    // Duplicate teamNumber within same type scope
+    const byType = new Map<string, Set<number>>();
+    for (const team of teams) {
+      const key = team.type;
+      if (!byType.has(key)) byType.set(key, new Set());
+      const set = byType.get(key)!;
+      if (set.has(team.teamNumber)) {
+        throw new GraphQLError(`Duplicate team number ${team.teamNumber} for type ${team.type}`, {
+          extensions: {
+            code: ErrorCode.VALIDATION_FAILED,
+            issue: "duplicate-team-number",
+            teamNumber: team.teamNumber,
+            type: team.type,
+          },
+        });
+      }
+      set.add(team.teamNumber);
+    }
+
+    // subEvent.eventType must match team.type
+    for (const team of teams) {
+      const subEvent = await SubEventCompetition.findByPk(team.subEventId, { transaction });
+      if (!subEvent) {
+        throw new GraphQLError(`SubEvent not found: ${team.subEventId}`, {
+          extensions: { code: ErrorCode.SUB_EVENT_NOT_FOUND, subEventId: team.subEventId },
+        });
+      }
+      if (subEvent.eventType !== team.type) {
+        throw new GraphQLError(
+          `subEvent.eventType (${subEvent.eventType}) does not match team.type (${team.type})`,
+          {
+            extensions: {
+              code: ErrorCode.VALIDATION_FAILED,
+              issue: "subevent-type-mismatch",
+              subEventId: team.subEventId,
+              subEventType: subEvent.eventType,
+              teamType: team.type,
+            },
+          }
+        );
+      }
+    }
+
+    // basePlayers ⊆ players
+    for (const team of teams) {
+      const invalidBase = team.basePlayers.filter((bp) => !team.players.includes(bp));
+      if (invalidBase.length > 0) {
+        throw new GraphQLError(`basePlayers must be a subset of players`, {
+          extensions: {
+            code: ErrorCode.VALIDATION_FAILED,
+            issue: "base-not-in-roster",
+            invalidPlayerIds: invalidBase,
+          },
+        });
+      }
+    }
+  }
+
+  private async writeRemarks({
+    clubId,
+    teams,
+    remarks,
+    transaction,
+  }: {
+    clubId: string;
+    teams: SubmitEnrollmentInput["teams"];
+    remarks: string;
+    transaction: Transaction;
+  }): Promise<void> {
+    const subEventIds = [...new Set(teams.map((t) => t.subEventId))];
+    const subEvents = await SubEventCompetition.findAll({
+      where: { id: subEventIds },
+      attributes: ["id", "eventId"],
+      transaction,
+    });
+
+    const eventIds = [...new Set(subEvents.map((se) => se.eventId))];
+    for (const eventId of eventIds) {
+      try {
+        await Comment.create(
+          { linkType: "competition", linkId: eventId, clubId, message: remarks },
+          { transaction }
+        );
+      } catch (e) {
+        this.logger.warn(`Failed to write remark for event ${eventId}`, e);
+      }
+    }
+  }
+}

--- a/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.service.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.service.ts
@@ -84,7 +84,6 @@ export class SubmitEnrollmentService {
     for (let i = 0; i < teams.length; i++) {
       const team = teams[i];
       const core = await this.teamWriteService.upsertTeamCore({
-        id: team.id,
         link: team.link,
         clubId,
         season,

--- a/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.service.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.service.ts
@@ -1,9 +1,4 @@
-import {
-  Club,
-  Comment,
-  Player,
-  SubEventCompetition,
-} from "@badman/backend-database";
+import { Club, Comment, Player, SubEventCompetition } from "@badman/backend-database";
 import { ClubMembershipType } from "@badman/utils";
 import { Injectable, Logger } from "@nestjs/common";
 import { GraphQLError } from "graphql";
@@ -38,10 +33,15 @@ export class SubmitEnrollmentService {
     private readonly clubMembershipService: ClubMembershipService,
     private readonly teamWriteService: TeamWriteService,
     private readonly enrollmentEntryService: EnrollmentEntryService,
-    private readonly enrollmentFinalizeService: EnrollmentFinalizeService,
+    private readonly enrollmentFinalizeService: EnrollmentFinalizeService
   ) {}
 
-  async run({ input, user, confirmed, transaction }: SubmitEnrollmentRunArgs): Promise<SubmitEnrollmentServiceResult> {
+  async run({
+    input,
+    user,
+    confirmed,
+    transaction,
+  }: SubmitEnrollmentRunArgs): Promise<SubmitEnrollmentServiceResult> {
     const { clubId, season, adminEmail, teams, transfers, loans, remarks } = input;
     const txId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
@@ -75,7 +75,12 @@ export class SubmitEnrollmentService {
     }
 
     // (4) Phase A: write each team without final teamNumber/name/abbreviation
-    const coreResults: { teamId: string; link: string; alreadyExisted: boolean; inputIndex: number }[] = [];
+    const coreResults: {
+      teamId: string;
+      link: string;
+      alreadyExisted: boolean;
+      inputIndex: number;
+    }[] = [];
     for (let i = 0; i < teams.length; i++) {
       const team = teams[i];
       const core = await this.teamWriteService.upsertTeamCore({
@@ -161,13 +166,21 @@ export class SubmitEnrollmentService {
 
     if (teams.length === 0) {
       throw new GraphQLError("No teams to submit", {
-        extensions: { code: ErrorCode.NO_TEAMS_TO_FINALISE, clubId: input.clubId, season: input.season },
+        extensions: {
+          code: ErrorCode.NO_TEAMS_TO_FINALISE,
+          clubId: input.clubId,
+          season: input.season,
+        },
       });
     }
 
     if (teams.length > MAX_TEAMS) {
       throw new GraphQLError(`Too many teams (max ${MAX_TEAMS})`, {
-        extensions: { code: ErrorCode.VALIDATION_FAILED, issue: "team-count-exceeded", count: teams.length },
+        extensions: {
+          code: ErrorCode.VALIDATION_FAILED,
+          issue: "team-count-exceeded",
+          count: teams.length,
+        },
       });
     }
 

--- a/libs/backend/graphql/src/resolvers/event/enrollment-finalize.service.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/enrollment-finalize.service.spec.ts
@@ -55,7 +55,14 @@ describe("EnrollmentFinalizeService.finalize", () => {
     const club = stubClub();
 
     try {
-      await service.finalize({ clubId: "club-uuid", season: 2026, email: "e@e.com", user: fakeUser(), club, transaction: mockTransaction });
+      await service.finalize({
+        clubId: "club-uuid",
+        season: 2026,
+        email: "e@e.com",
+        user: fakeUser(),
+        club,
+        transaction: mockTransaction,
+      });
       fail("expected throw");
     } catch (err) {
       const e = err as GraphQLError;
@@ -72,16 +79,27 @@ describe("EnrollmentFinalizeService.finalize", () => {
     const club = stubClub("old@example.com");
 
     jest.spyOn(Team, "findAll").mockResolvedValue(teams);
-    jest.spyOn(EventEntry, "findAll").mockResolvedValue([entry1, entry2] as unknown as EventEntry[]);
+    jest
+      .spyOn(EventEntry, "findAll")
+      .mockResolvedValue([entry1, entry2] as unknown as EventEntry[]);
     const loggingCreate = jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
 
-    const result = await service.finalize({ clubId: "club-uuid", season: 2026, email: "new@example.com", user: fakeUser(), club, transaction: mockTransaction });
+    const result = await service.finalize({
+      clubId: "club-uuid",
+      season: 2026,
+      email: "new@example.com",
+      user: fakeUser(),
+      club,
+      transaction: mockTransaction,
+    });
 
     expect(result).toEqual({ alreadyFinalised: false });
     expect(entry1._save).toHaveBeenCalledTimes(1);
     expect(entry2._save).toHaveBeenCalledTimes(1);
     expect(loggingCreate).toHaveBeenCalledTimes(1);
-    expect(club._save).toHaveBeenCalledWith(expect.objectContaining({ transaction: mockTransaction }));
+    expect(club._save).toHaveBeenCalledWith(
+      expect.objectContaining({ transaction: mockTransaction })
+    );
   });
 
   it("returns alreadyFinalised: true and skips stamping + logging when all entries already have sendOn (same email)", async () => {
@@ -91,10 +109,19 @@ describe("EnrollmentFinalizeService.finalize", () => {
     const club = stubClub("same@example.com");
 
     jest.spyOn(Team, "findAll").mockResolvedValue(teams);
-    jest.spyOn(EventEntry, "findAll").mockResolvedValue([entry1, entry2] as unknown as EventEntry[]);
+    jest
+      .spyOn(EventEntry, "findAll")
+      .mockResolvedValue([entry1, entry2] as unknown as EventEntry[]);
     const loggingCreate = jest.spyOn(Logging, "create");
 
-    const result = await service.finalize({ clubId: "club-uuid", season: 2026, email: "same@example.com", user: fakeUser(), club, transaction: mockTransaction });
+    const result = await service.finalize({
+      clubId: "club-uuid",
+      season: 2026,
+      email: "same@example.com",
+      user: fakeUser(),
+      club,
+      transaction: mockTransaction,
+    });
 
     expect(result).toEqual({ alreadyFinalised: true });
     expect(entry1._save).not.toHaveBeenCalled();
@@ -112,10 +139,19 @@ describe("EnrollmentFinalizeService.finalize", () => {
     jest.spyOn(EventEntry, "findAll").mockResolvedValue([entry] as unknown as EventEntry[]);
     jest.spyOn(Logging, "create");
 
-    const result = await service.finalize({ clubId: "club-uuid", season: 2026, email: "new@example.com", user: fakeUser(), club, transaction: mockTransaction });
+    const result = await service.finalize({
+      clubId: "club-uuid",
+      season: 2026,
+      email: "new@example.com",
+      user: fakeUser(),
+      club,
+      transaction: mockTransaction,
+    });
 
     expect(result).toEqual({ alreadyFinalised: true });
-    expect(club._save).toHaveBeenCalledWith(expect.objectContaining({ transaction: mockTransaction }));
+    expect(club._save).toHaveBeenCalledWith(
+      expect.objectContaining({ transaction: mockTransaction })
+    );
   });
 
   it("stamps only null entries on partial state (some already have sendOn)", async () => {
@@ -125,10 +161,19 @@ describe("EnrollmentFinalizeService.finalize", () => {
     const club = stubClub();
 
     jest.spyOn(Team, "findAll").mockResolvedValue(teams);
-    jest.spyOn(EventEntry, "findAll").mockResolvedValue([entrySet, entryNull] as unknown as EventEntry[]);
+    jest
+      .spyOn(EventEntry, "findAll")
+      .mockResolvedValue([entrySet, entryNull] as unknown as EventEntry[]);
     jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
 
-    const result = await service.finalize({ clubId: "club-uuid", season: 2026, email: "test@example.com", user: fakeUser(), club, transaction: mockTransaction });
+    const result = await service.finalize({
+      clubId: "club-uuid",
+      season: 2026,
+      email: "test@example.com",
+      user: fakeUser(),
+      club,
+      transaction: mockTransaction,
+    });
 
     expect(result).toEqual({ alreadyFinalised: false });
     expect(entrySet._save).not.toHaveBeenCalled();
@@ -145,7 +190,14 @@ describe("EnrollmentFinalizeService.finalize", () => {
     jest.spyOn(EventEntry, "findAll").mockResolvedValue([entryWithData] as unknown as EventEntry[]);
     jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
 
-    const result = await service.finalize({ clubId: "club-uuid", season: 2026, email: "test@example.com", user: fakeUser(), club, transaction: mockTransaction });
+    const result = await service.finalize({
+      clubId: "club-uuid",
+      season: 2026,
+      email: "test@example.com",
+      user: fakeUser(),
+      club,
+      transaction: mockTransaction,
+    });
 
     expect(result).toEqual({ alreadyFinalised: false });
   });
@@ -156,10 +208,19 @@ describe("EnrollmentFinalizeService.finalize", () => {
     const club = stubClub();
 
     jest.spyOn(Team, "findAll").mockResolvedValue(teams);
-    const eventEntryFindAll = jest.spyOn(EventEntry, "findAll").mockResolvedValue([entry] as unknown as EventEntry[]);
+    const eventEntryFindAll = jest
+      .spyOn(EventEntry, "findAll")
+      .mockResolvedValue([entry] as unknown as EventEntry[]);
     jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
 
-    await service.finalize({ clubId: "club-uuid", season: 2026, email: "test@example.com", user: fakeUser(), club, transaction: mockTransaction });
+    await service.finalize({
+      clubId: "club-uuid",
+      season: 2026,
+      email: "test@example.com",
+      user: fakeUser(),
+      club,
+      transaction: mockTransaction,
+    });
 
     expect(eventEntryFindAll).toHaveBeenCalledWith(
       expect.objectContaining({ lock: "UPDATE", transaction: mockTransaction })
@@ -176,12 +237,23 @@ describe("EnrollmentFinalizeService.finalize", () => {
     jest.spyOn(EventEntry, "findAll").mockResolvedValue([entry] as unknown as EventEntry[]);
     const loggingCreate = jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
 
-    await service.finalize({ clubId: "club-uuid", season: 2026, email: "test@example.com", user, club, transaction: mockTransaction });
+    await service.finalize({
+      clubId: "club-uuid",
+      season: 2026,
+      email: "test@example.com",
+      user,
+      club,
+      transaction: mockTransaction,
+    });
 
     expect(loggingCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         playerId: "my-user-id",
-        meta: expect.objectContaining({ clubId: "club-uuid", season: 2026, email: "test@example.com" }),
+        meta: expect.objectContaining({
+          clubId: "club-uuid",
+          season: 2026,
+          email: "test@example.com",
+        }),
       }),
       expect.objectContaining({ transaction: mockTransaction })
     );

--- a/libs/backend/graphql/src/resolvers/event/enrollment-finalize.service.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/enrollment-finalize.service.spec.ts
@@ -1,0 +1,189 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { GraphQLError } from "graphql";
+import { Club, EventEntry, Logging, Player, Team } from "@badman/backend-database";
+import { EnrollmentFinalizeService } from "./enrollment-finalize.service";
+import { ErrorCode } from "../../utils/error-codes";
+
+const asUnknown = <T>(x: unknown): T => x as T;
+
+describe("EnrollmentFinalizeService.finalize", () => {
+  let service: EnrollmentFinalizeService;
+
+  const mockTransaction = {
+    commit: jest.fn(),
+    rollback: jest.fn(),
+    LOCK: { UPDATE: "UPDATE" },
+  } as never;
+
+  const fakeUser = (id = "user-uuid") =>
+    asUnknown<Player>({ id, hasAnyPermission: jest.fn().mockResolvedValue(true) });
+
+  const stubClub = (contactCompetition = "existing@example.com") => {
+    const save = jest.fn().mockResolvedValue(undefined);
+    return asUnknown<Club & { _save: jest.Mock }>({
+      id: "club-uuid",
+      contactCompetition,
+      save,
+      _save: save,
+    });
+  };
+
+  const stubEntry = (sendOn: Date | null = null, teamId = "team-uuid") => {
+    const save = jest.fn().mockResolvedValue(undefined);
+    return asUnknown<EventEntry & { _save: jest.Mock }>({
+      teamId,
+      sendOn,
+      save,
+      _save: save,
+    });
+  };
+
+  const stubTeam = (entry: EventEntry | null = stubEntry(), id = "team-uuid") =>
+    asUnknown<Team>({ id, clubId: "club-uuid", season: 2026, entry });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EnrollmentFinalizeService],
+    }).compile();
+    service = module.get<EnrollmentFinalizeService>(EnrollmentFinalizeService);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it("throws NO_TEAMS_TO_FINALISE when no teams found for season", async () => {
+    jest.spyOn(Team, "findAll").mockResolvedValue([]);
+    const club = stubClub();
+
+    try {
+      await service.finalize({ clubId: "club-uuid", season: 2026, email: "e@e.com", user: fakeUser(), club, transaction: mockTransaction });
+      fail("expected throw");
+    } catch (err) {
+      const e = err as GraphQLError;
+      expect(e.extensions?.["code"]).toBe(ErrorCode.NO_TEAMS_TO_FINALISE);
+      expect(e.extensions?.["clubId"]).toBe("club-uuid");
+      expect(e.extensions?.["season"]).toBe(2026);
+    }
+  });
+
+  it("stamps sendOn on all entries, writes Logging, returns alreadyFinalised: false on fresh path", async () => {
+    const entry1 = stubEntry(null, "team-1");
+    const entry2 = stubEntry(null, "team-2");
+    const teams = [stubTeam(entry1, "team-1"), stubTeam(entry2, "team-2")];
+    const club = stubClub("old@example.com");
+
+    jest.spyOn(Team, "findAll").mockResolvedValue(teams);
+    jest.spyOn(EventEntry, "findAll").mockResolvedValue([entry1, entry2] as unknown as EventEntry[]);
+    const loggingCreate = jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
+
+    const result = await service.finalize({ clubId: "club-uuid", season: 2026, email: "new@example.com", user: fakeUser(), club, transaction: mockTransaction });
+
+    expect(result).toEqual({ alreadyFinalised: false });
+    expect(entry1._save).toHaveBeenCalledTimes(1);
+    expect(entry2._save).toHaveBeenCalledTimes(1);
+    expect(loggingCreate).toHaveBeenCalledTimes(1);
+    expect(club._save).toHaveBeenCalledWith(expect.objectContaining({ transaction: mockTransaction }));
+  });
+
+  it("returns alreadyFinalised: true and skips stamping + logging when all entries already have sendOn (same email)", async () => {
+    const entry1 = stubEntry(new Date("2026-01-01"), "team-1");
+    const entry2 = stubEntry(new Date("2026-01-01"), "team-2");
+    const teams = [stubTeam(entry1, "team-1"), stubTeam(entry2, "team-2")];
+    const club = stubClub("same@example.com");
+
+    jest.spyOn(Team, "findAll").mockResolvedValue(teams);
+    jest.spyOn(EventEntry, "findAll").mockResolvedValue([entry1, entry2] as unknown as EventEntry[]);
+    const loggingCreate = jest.spyOn(Logging, "create");
+
+    const result = await service.finalize({ clubId: "club-uuid", season: 2026, email: "same@example.com", user: fakeUser(), club, transaction: mockTransaction });
+
+    expect(result).toEqual({ alreadyFinalised: true });
+    expect(entry1._save).not.toHaveBeenCalled();
+    expect(entry2._save).not.toHaveBeenCalled();
+    expect(loggingCreate).not.toHaveBeenCalled();
+    expect(club._save).not.toHaveBeenCalled();
+  });
+
+  it("updates Club.contactCompetition only when email differs (alreadyFinalised path)", async () => {
+    const entry = stubEntry(new Date("2026-01-01"), "team-1");
+    const teams = [stubTeam(entry, "team-1")];
+    const club = stubClub("old@example.com");
+
+    jest.spyOn(Team, "findAll").mockResolvedValue(teams);
+    jest.spyOn(EventEntry, "findAll").mockResolvedValue([entry] as unknown as EventEntry[]);
+    jest.spyOn(Logging, "create");
+
+    const result = await service.finalize({ clubId: "club-uuid", season: 2026, email: "new@example.com", user: fakeUser(), club, transaction: mockTransaction });
+
+    expect(result).toEqual({ alreadyFinalised: true });
+    expect(club._save).toHaveBeenCalledWith(expect.objectContaining({ transaction: mockTransaction }));
+  });
+
+  it("stamps only null entries on partial state (some already have sendOn)", async () => {
+    const entrySet = stubEntry(new Date("2026-01-01"), "team-set");
+    const entryNull = stubEntry(null, "team-null");
+    const teams = [stubTeam(entrySet, "team-set"), stubTeam(entryNull, "team-null")];
+    const club = stubClub();
+
+    jest.spyOn(Team, "findAll").mockResolvedValue(teams);
+    jest.spyOn(EventEntry, "findAll").mockResolvedValue([entrySet, entryNull] as unknown as EventEntry[]);
+    jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
+
+    const result = await service.finalize({ clubId: "club-uuid", season: 2026, email: "test@example.com", user: fakeUser(), club, transaction: mockTransaction });
+
+    expect(result).toEqual({ alreadyFinalised: false });
+    expect(entrySet._save).not.toHaveBeenCalled();
+    expect(entryNull._save).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips teams without entry row without throwing", async () => {
+    const teamNoEntry = stubTeam(null, "team-no-entry");
+    const entryWithData = stubEntry(null, "team-with-entry");
+    const teamWithEntry = stubTeam(entryWithData, "team-with-entry");
+    const club = stubClub();
+
+    jest.spyOn(Team, "findAll").mockResolvedValue([teamNoEntry, teamWithEntry]);
+    jest.spyOn(EventEntry, "findAll").mockResolvedValue([entryWithData] as unknown as EventEntry[]);
+    jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
+
+    const result = await service.finalize({ clubId: "club-uuid", season: 2026, email: "test@example.com", user: fakeUser(), club, transaction: mockTransaction });
+
+    expect(result).toEqual({ alreadyFinalised: false });
+  });
+
+  it("passes LOCK.UPDATE to EventEntry.findAll", async () => {
+    const entry = stubEntry(null, "team-uuid");
+    const teams = [stubTeam(entry)];
+    const club = stubClub();
+
+    jest.spyOn(Team, "findAll").mockResolvedValue(teams);
+    const eventEntryFindAll = jest.spyOn(EventEntry, "findAll").mockResolvedValue([entry] as unknown as EventEntry[]);
+    jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
+
+    await service.finalize({ clubId: "club-uuid", season: 2026, email: "test@example.com", user: fakeUser(), club, transaction: mockTransaction });
+
+    expect(eventEntryFindAll).toHaveBeenCalledWith(
+      expect.objectContaining({ lock: "UPDATE", transaction: mockTransaction })
+    );
+  });
+
+  it("writes Logging with EnrollmentSubmitted action and correct meta", async () => {
+    const entry = stubEntry(null, "team-uuid");
+    const teams = [stubTeam(entry)];
+    const club = stubClub();
+    const user = fakeUser("my-user-id");
+
+    jest.spyOn(Team, "findAll").mockResolvedValue(teams);
+    jest.spyOn(EventEntry, "findAll").mockResolvedValue([entry] as unknown as EventEntry[]);
+    const loggingCreate = jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
+
+    await service.finalize({ clubId: "club-uuid", season: 2026, email: "test@example.com", user, club, transaction: mockTransaction });
+
+    expect(loggingCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        playerId: "my-user-id",
+        meta: expect.objectContaining({ clubId: "club-uuid", season: 2026, email: "test@example.com" }),
+      }),
+      expect.objectContaining({ transaction: mockTransaction })
+    );
+  });
+});

--- a/libs/backend/graphql/src/resolvers/event/enrollment-finalize.service.ts
+++ b/libs/backend/graphql/src/resolvers/event/enrollment-finalize.service.ts
@@ -1,0 +1,77 @@
+import { Club, EventEntry, Logging, Player, Team } from "@badman/backend-database";
+import { Injectable, Logger } from "@nestjs/common";
+import { GraphQLError } from "graphql";
+import { Transaction } from "sequelize";
+import { LoggingAction } from "@badman/utils";
+import { ErrorCode } from "../../utils";
+
+export interface FinalizeArgs {
+  clubId: string;
+  season: number;
+  email: string;
+  user: Player;
+  club: Club;
+  transaction: Transaction;
+}
+
+export interface FinalizeResult {
+  alreadyFinalised: boolean;
+}
+
+@Injectable()
+export class EnrollmentFinalizeService {
+  private readonly logger = new Logger(EnrollmentFinalizeService.name);
+
+  async finalize({ clubId, season, email, user, club, transaction }: FinalizeArgs): Promise<FinalizeResult> {
+    const teams = await Team.findAll({
+      where: { clubId, season },
+      include: [{ model: EventEntry }],
+      transaction,
+    });
+
+    if (teams.length === 0) {
+      throw new GraphQLError("No teams to finalise for this club and season", {
+        extensions: { code: ErrorCode.NO_TEAMS_TO_FINALISE, clubId, season },
+      });
+    }
+
+    const teamIds = teams.filter((t) => t.entry).map((t) => t.id);
+
+    const entries = await EventEntry.findAll({
+      where: { teamId: teamIds },
+      lock: transaction.LOCK.UPDATE,
+      transaction,
+    });
+
+    const alreadyFinalised =
+      entries.length > 0 && entries.every((e) => e.sendOn !== null && e.sendOn !== undefined);
+
+    if (club.contactCompetition !== email) {
+      club.contactCompetition = email;
+      await club.save({ transaction });
+    }
+
+    if (alreadyFinalised) {
+      return { alreadyFinalised: true };
+    }
+
+    for (const team of teams) {
+      if (!team.entry) continue;
+      if (team.entry.sendOn === null || team.entry.sendOn === undefined) {
+        team.entry.sendOn = new Date();
+        await team.entry.save({ transaction });
+      }
+    }
+
+    await Logging.create(
+      {
+        action: LoggingAction.EnrollmentSubmitted,
+        playerId: user.id,
+        meta: { clubId, season, email },
+      },
+      { transaction }
+    );
+
+    return { alreadyFinalised: false };
+  }
+}

--- a/libs/backend/graphql/src/resolvers/event/enrollment-finalize.service.ts
+++ b/libs/backend/graphql/src/resolvers/event/enrollment-finalize.service.ts
@@ -22,7 +22,14 @@ export interface FinalizeResult {
 export class EnrollmentFinalizeService {
   private readonly logger = new Logger(EnrollmentFinalizeService.name);
 
-  async finalize({ clubId, season, email, user, club, transaction }: FinalizeArgs): Promise<FinalizeResult> {
+  async finalize({
+    clubId,
+    season,
+    email,
+    user,
+    club,
+    transaction,
+  }: FinalizeArgs): Promise<FinalizeResult> {
     const teams = await Team.findAll({
       where: { clubId, season },
       include: [{ model: EventEntry }],

--- a/libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts
@@ -6,6 +6,7 @@ import { Club, EventEntry, Logging, Player, Team } from "@badman/backend-databas
 import { EnrollmentValidationService } from "@badman/backend-enrollment";
 import { NotificationService } from "@badman/backend-notifications";
 import { EventEntryResolver } from "./entry.resolver";
+import { EnrollmentFinalizeService } from "./enrollment-finalize.service";
 import { ErrorCode } from "../../utils/error-codes";
 
 // Type helper to cast mocked model objects
@@ -71,6 +72,7 @@ describe("EventEntryResolver.finishEventEntry", () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EventEntryResolver,
+        EnrollmentFinalizeService,
         {
           provide: Sequelize,
           useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },

--- a/libs/backend/graphql/src/resolvers/event/entry.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/entry.resolver.ts
@@ -6,7 +6,6 @@ import {
   EntryCompetitionPlayer,
   EntryCompetitionPlayersType,
   EventEntry,
-  Logging,
   Player,
   Standing,
   SubEventCompetition,
@@ -15,13 +14,12 @@ import {
 } from "@badman/backend-database";
 import { EnrollmentValidationService, TeamEnrollmentOutput } from "@badman/backend-enrollment";
 import { NotificationService } from "@badman/backend-notifications";
-import { LoggingAction, TeamMembershipType } from "@badman/utils";
+import { TeamMembershipType } from "@badman/utils";
 import { Logger, NotFoundException, UnauthorizedException } from "@nestjs/common";
 import { Args, ID, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
-import { GraphQLError } from "graphql";
 import { Sequelize } from "sequelize-typescript";
 import { ListArgs } from "../../utils";
-import { ErrorCode } from "../../utils/error-codes";
+import { EnrollmentFinalizeService } from "./enrollment-finalize.service";
 import { FinishEventEntryResult } from "./finish-event-entry-result.object";
 
 @Resolver(() => EventEntry)
@@ -31,6 +29,7 @@ export class EventEntryResolver {
   constructor(
     private notificationService: NotificationService,
     private enrollmentService: EnrollmentValidationService,
+    private enrollmentFinalizeService: EnrollmentFinalizeService,
     private _sequelize: Sequelize
   ) {}
 
@@ -142,99 +141,26 @@ export class EventEntryResolver {
     }
 
     const transaction = await this._sequelize.transaction();
-
     try {
-      // Fetch teams for the club and season
-      const teams = await Team.findAll({
-        where: {
-          clubId: clubId,
-          season: season,
-        },
-        include: [{ model: EventEntry }],
-        transaction,
+      const { alreadyFinalised } = await this.enrollmentFinalizeService.finalize({
+        clubId, season, email, user, club, transaction,
       });
-
-      // Reject if no teams exist for this club and season
-      if (teams.length === 0) {
-        throw new GraphQLError("No teams to finalise for this club and season", {
-          extensions: { code: ErrorCode.NO_TEAMS_TO_FINALISE, clubId, season },
-        });
-      }
-
-      // Collect team IDs that have entries for row locking
-      const teamIds = teams.filter((t) => t.entry).map((t) => t.id);
-
-      // Acquire row-level locks on EventEntry rows for this club+season
-      const entries = await EventEntry.findAll({
-        where: { teamId: teamIds },
-        lock: transaction.LOCK.UPDATE,
-        transaction,
-      });
-
-      // Idempotency check: all entries already have sendOn set
-      const alreadyFinalised =
-        entries.length > 0 && entries.every((e) => e.sendOn !== null && e.sendOn !== undefined);
-
-      if (alreadyFinalised) {
-        // Only permitted side-effect on no-op path: update contact email if different
-        if (club.contactCompetition !== email) {
-          club.contactCompetition = email;
-          await club.save({ transaction });
-        }
-
-        await transaction.commit();
-        return { success: true, alreadyFinalised: true, notificationDispatched: false };
-      }
-
-      // Fresh finalisation path
-      // Update the contact email of the club if it is different
-      if (club.contactCompetition !== email) {
-        club.contactCompetition = email;
-        await club.save({ transaction });
-      }
-
-      // Update sendOn for all null entries only (partial-state safety)
-      for (const team of teams) {
-        if (!team.entry) {
-          continue;
-        }
-
-        if (team.entry.sendOn === null || team.entry.sendOn === undefined) {
-          team.entry.sendOn = new Date();
-          await team.entry.save({ transaction });
-        }
-      }
-
-      // Write audit log row
-      await Logging.create(
-        {
-          action: LoggingAction.EnrollmentSubmitted,
-          playerId: user.id,
-          meta: {
-            clubId,
-            season,
-            email,
-          },
-        },
-        { transaction }
-      );
-
       await transaction.commit();
 
-      // Post-commit: dispatch notification (must NOT be inside transaction)
       let notificationDispatched = false;
-      try {
-        await this.notificationService.notifyEnrollment(user.id, clubId, season, email);
-        notificationDispatched = true;
-      } catch (notifyError) {
-        this.logger.error(
-          `Failed to dispatch enrollment notification for club ${clubId} season ${season}`,
-          notifyError
-        );
-        notificationDispatched = false;
+      if (!alreadyFinalised) {
+        try {
+          await this.notificationService.notifyEnrollment(user.id, clubId, season, email);
+          notificationDispatched = true;
+        } catch (notifyError) {
+          this.logger.error(
+            `Failed to dispatch enrollment notification for club ${clubId} season ${season}`,
+            notifyError
+          );
+        }
       }
 
-      return { success: true, alreadyFinalised: false, notificationDispatched };
+      return { success: true, alreadyFinalised, notificationDispatched };
     } catch (error) {
       await transaction.rollback();
       throw error;

--- a/libs/backend/graphql/src/resolvers/event/entry.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/entry.resolver.ts
@@ -143,7 +143,12 @@ export class EventEntryResolver {
     const transaction = await this._sequelize.transaction();
     try {
       const { alreadyFinalised } = await this.enrollmentFinalizeService.finalize({
-        clubId, season, email, user, club, transaction,
+        clubId,
+        season,
+        email,
+        user,
+        club,
+        transaction,
       });
       await transaction.commit();
 

--- a/libs/backend/graphql/src/resolvers/event/event.module.ts
+++ b/libs/backend/graphql/src/resolvers/event/event.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 import { CompetitionResolverModule } from "./competition.module";
 import { EventEntryResolver, EntryCompetitionPlayersResolver } from "./entry.resolver";
+import { EnrollmentFinalizeService } from "./enrollment-finalize.service";
 import { TournamentResolverModule } from "./tournament.module";
 import { NotificationsModule } from "@badman/backend-notifications";
 import { EnrollmentModule } from "@badman/backend-enrollment";
@@ -12,6 +13,7 @@ import { EnrollmentModule } from "@badman/backend-enrollment";
     NotificationsModule,
     EnrollmentModule,
   ],
-  providers: [EventEntryResolver, EntryCompetitionPlayersResolver],
+  providers: [EventEntryResolver, EntryCompetitionPlayersResolver, EnrollmentFinalizeService],
+  exports: [EnrollmentFinalizeService],
 })
 export class EventResolverModule {}

--- a/libs/backend/graphql/src/resolvers/team/index.ts
+++ b/libs/backend/graphql/src/resolvers/team/index.ts
@@ -1,4 +1,5 @@
 // start:ng42.barrel
 export * from "./team.module";
 export * from "./team.resolver";
+export * from "./team-write.service";
 // end:ng42.barrel

--- a/libs/backend/graphql/src/resolvers/team/team-write.service.spec.ts
+++ b/libs/backend/graphql/src/resolvers/team/team-write.service.spec.ts
@@ -102,7 +102,9 @@ describe("TeamWriteService", () => {
       const team = fakeTeam();
       jest.spyOn(Team, "create").mockResolvedValue(team as never);
       jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([]);
-      const createMemberSpy = jest.spyOn(TeamPlayerMembership, "create").mockResolvedValue({} as never);
+      const createMemberSpy = jest
+        .spyOn(TeamPlayerMembership, "create")
+        .mockResolvedValue({} as never);
 
       await service.upsertTeamCore(makeTxArgs({ id: null, players: ["player-1", "player-2"] }));
 
@@ -116,7 +118,10 @@ describe("TeamWriteService", () => {
     it("soft-ends removed players by setting end date", async () => {
       const team = fakeTeam({ id: "existing-uuid" });
       jest.spyOn(Team, "findByPk").mockResolvedValue(team as never);
-      const existingMembership = { playerId: "player-to-remove", end: null } as unknown as TeamPlayerMembership;
+      const existingMembership = {
+        playerId: "player-to-remove",
+        end: null,
+      } as unknown as TeamPlayerMembership;
       jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([existingMembership]);
       const updateSpy = jest.spyOn(TeamPlayerMembership, "update").mockResolvedValue([1] as never);
 
@@ -124,19 +129,26 @@ describe("TeamWriteService", () => {
 
       expect(updateSpy).toHaveBeenCalledWith(
         expect.objectContaining({ end: expect.any(Date) }),
-        expect.objectContaining({ where: { teamId: "existing-uuid", playerId: ["player-to-remove"] } })
+        expect.objectContaining({
+          where: { teamId: "existing-uuid", playerId: ["player-to-remove"] },
+        })
       );
     });
 
     it("does not touch memberships for unchanged players", async () => {
       const team = fakeTeam({ id: "existing-uuid" });
       jest.spyOn(Team, "findByPk").mockResolvedValue(team as never);
-      const membership = { playerId: "unchanged-player", end: null } as unknown as TeamPlayerMembership;
+      const membership = {
+        playerId: "unchanged-player",
+        end: null,
+      } as unknown as TeamPlayerMembership;
       jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([membership]);
       const createSpy = jest.spyOn(TeamPlayerMembership, "create").mockResolvedValue({} as never);
       const updateSpy = jest.spyOn(TeamPlayerMembership, "update").mockResolvedValue([0] as never);
 
-      await service.upsertTeamCore(makeTxArgs({ id: "existing-uuid", players: ["unchanged-player"] }));
+      await service.upsertTeamCore(
+        makeTxArgs({ id: "existing-uuid", players: ["unchanged-player"] })
+      );
 
       expect(createSpy).not.toHaveBeenCalled();
       expect(updateSpy).not.toHaveBeenCalled();
@@ -188,7 +200,12 @@ describe("TeamWriteService", () => {
         updateCalls.push(args);
         return [1] as never;
       });
-      const reloaded = fakeTeam({ id: "team-A", teamNumber: 1, name: "Club 1H", abbreviation: "CL 1H" });
+      const reloaded = fakeTeam({
+        id: "team-A",
+        teamNumber: 1,
+        name: "Club 1H",
+        abbreviation: "CL 1H",
+      });
       jest.spyOn(Team, "findByPk").mockResolvedValue(reloaded as never);
 
       await service.applyTeamNumbersTwoPhase({
@@ -217,9 +234,14 @@ describe("TeamWriteService", () => {
         updateCalls.push(args);
         return [1] as never;
       });
-      jest.spyOn(Team, "findByPk")
-        .mockResolvedValueOnce(fakeTeam({ id: "team-A", teamNumber: 2, name: "Club 2H", abbreviation: "CL 2H" }) as never)
-        .mockResolvedValueOnce(fakeTeam({ id: "team-B", teamNumber: 1, name: "Club 1H", abbreviation: "CL 1H" }) as never);
+      jest
+        .spyOn(Team, "findByPk")
+        .mockResolvedValueOnce(
+          fakeTeam({ id: "team-A", teamNumber: 2, name: "Club 2H", abbreviation: "CL 2H" }) as never
+        )
+        .mockResolvedValueOnce(
+          fakeTeam({ id: "team-B", teamNumber: 1, name: "Club 1H", abbreviation: "CL 1H" }) as never
+        );
 
       await service.applyTeamNumbersTwoPhase({
         teams: [
@@ -232,11 +254,19 @@ describe("TeamWriteService", () => {
 
       expect(updateCalls).toHaveLength(4);
       // B-1 passes: individualHooks: false for both
-      expect((updateCalls[0] as unknown[])[1]).toEqual(expect.objectContaining({ individualHooks: false }));
-      expect((updateCalls[1] as unknown[])[1]).toEqual(expect.objectContaining({ individualHooks: false }));
+      expect((updateCalls[0] as unknown[])[1]).toEqual(
+        expect.objectContaining({ individualHooks: false })
+      );
+      expect((updateCalls[1] as unknown[])[1]).toEqual(
+        expect.objectContaining({ individualHooks: false })
+      );
       // B-2 passes: individualHooks: true for both
-      expect((updateCalls[2] as unknown[])[1]).toEqual(expect.objectContaining({ individualHooks: true }));
-      expect((updateCalls[3] as unknown[])[1]).toEqual(expect.objectContaining({ individualHooks: true }));
+      expect((updateCalls[2] as unknown[])[1]).toEqual(
+        expect.objectContaining({ individualHooks: true })
+      );
+      expect((updateCalls[3] as unknown[])[1]).toEqual(
+        expect.objectContaining({ individualHooks: true })
+      );
     });
 
     it("pass B-1 uses temp teamNumber >= 1_000_000_000", async () => {
@@ -245,9 +275,9 @@ describe("TeamWriteService", () => {
         updateCalls.push(args);
         return [1] as never;
       });
-      jest.spyOn(Team, "findByPk").mockResolvedValue(
-        fakeTeam({ id: "team-A", teamNumber: 1, name: "Club 1H" }) as never
-      );
+      jest
+        .spyOn(Team, "findByPk")
+        .mockResolvedValue(fakeTeam({ id: "team-A", teamNumber: 1, name: "Club 1H" }) as never);
 
       await service.applyTeamNumbersTwoPhase({
         teams: [{ teamId: "team-A", teamNumber: 1 }],
@@ -261,7 +291,12 @@ describe("TeamWriteService", () => {
 
     it("returns final name and abbreviation from reloaded team", async () => {
       jest.spyOn(Team, "update").mockResolvedValue([1] as never);
-      const reloaded = fakeTeam({ id: "team-A", teamNumber: 3, name: "Badman 3H", abbreviation: "BM 3H" });
+      const reloaded = fakeTeam({
+        id: "team-A",
+        teamNumber: 3,
+        name: "Badman 3H",
+        abbreviation: "BM 3H",
+      });
       jest.spyOn(Team, "findByPk").mockResolvedValue(reloaded as never);
 
       const results = await service.applyTeamNumbersTwoPhase({
@@ -286,4 +321,3 @@ describe("TeamWriteService", () => {
     });
   });
 });
-

--- a/libs/backend/graphql/src/resolvers/team/team-write.service.spec.ts
+++ b/libs/backend/graphql/src/resolvers/team/team-write.service.spec.ts
@@ -58,7 +58,7 @@ describe("TeamWriteService", () => {
       const createSpy = jest.spyOn(Team, "create").mockResolvedValue(team as never);
       jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([]);
 
-      const result = await service.upsertTeamCore(makeTxArgs({ id: null }));
+      const result = await service.upsertTeamCore(makeTxArgs());
 
       expect(createSpy).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -75,27 +75,42 @@ describe("TeamWriteService", () => {
       expect(result.teamId).toBe("team-uuid");
     });
 
-    it("uses existing team when id provided", async () => {
-      const team = fakeTeam({ id: "existing-uuid" });
-      jest.spyOn(Team, "findByPk").mockResolvedValue(team as never);
+    it("uses existing team when link matches", async () => {
+      const team = fakeTeam({ id: "existing-uuid", link: "match-link" });
+      jest.spyOn(Team, "findOne").mockResolvedValue(team as never);
       jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([]);
 
-      const result = await service.upsertTeamCore(makeTxArgs({ id: "existing-uuid" }));
+      const result = await service.upsertTeamCore(makeTxArgs({ link: "match-link" }));
 
       expect(team.update).toHaveBeenCalled();
       expect(result.alreadyExisted).toBe(true);
       expect(result.teamId).toBe("existing-uuid");
     });
 
-    it("does not call Team.create when id is provided", async () => {
+    it("does not call Team.create when link matches existing team", async () => {
       const createSpy = jest.spyOn(Team, "create");
-      const team = fakeTeam({ id: "existing-uuid" });
-      jest.spyOn(Team, "findByPk").mockResolvedValue(team as never);
+      const team = fakeTeam({ id: "existing-uuid", link: "match-link" });
+      jest.spyOn(Team, "findOne").mockResolvedValue(team as never);
       jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([]);
 
-      await service.upsertTeamCore(makeTxArgs({ id: "existing-uuid" }));
+      await service.upsertTeamCore(makeTxArgs({ link: "match-link" }));
 
       expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    it("creates when link provided but no existing team matches", async () => {
+      const team = fakeTeam({ link: "fresh-link" });
+      jest.spyOn(Team, "findOne").mockResolvedValue(null);
+      const createSpy = jest.spyOn(Team, "create").mockResolvedValue(team as never);
+      jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([]);
+
+      const result = await service.upsertTeamCore(makeTxArgs({ link: "fresh-link" }));
+
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ link: "fresh-link" }),
+        expect.anything()
+      );
+      expect(result.alreadyExisted).toBe(false);
     });
 
     it("adds new players via TeamPlayerMembership.create", async () => {
@@ -106,7 +121,7 @@ describe("TeamWriteService", () => {
         .spyOn(TeamPlayerMembership, "create")
         .mockResolvedValue({} as never);
 
-      await service.upsertTeamCore(makeTxArgs({ id: null, players: ["player-1", "player-2"] }));
+      await service.upsertTeamCore(makeTxArgs({ players: ["player-1", "player-2"] }));
 
       expect(createMemberSpy).toHaveBeenCalledTimes(2);
       expect(createMemberSpy).toHaveBeenCalledWith(
@@ -116,8 +131,8 @@ describe("TeamWriteService", () => {
     });
 
     it("soft-ends removed players by setting end date", async () => {
-      const team = fakeTeam({ id: "existing-uuid" });
-      jest.spyOn(Team, "findByPk").mockResolvedValue(team as never);
+      const team = fakeTeam({ id: "existing-uuid", link: "match-link" });
+      jest.spyOn(Team, "findOne").mockResolvedValue(team as never);
       const existingMembership = {
         playerId: "player-to-remove",
         end: null,
@@ -125,7 +140,7 @@ describe("TeamWriteService", () => {
       jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([existingMembership]);
       const updateSpy = jest.spyOn(TeamPlayerMembership, "update").mockResolvedValue([1] as never);
 
-      await service.upsertTeamCore(makeTxArgs({ id: "existing-uuid", players: [] }));
+      await service.upsertTeamCore(makeTxArgs({ link: "match-link", players: [] }));
 
       expect(updateSpy).toHaveBeenCalledWith(
         expect.objectContaining({ end: expect.any(Date) }),
@@ -136,8 +151,8 @@ describe("TeamWriteService", () => {
     });
 
     it("does not touch memberships for unchanged players", async () => {
-      const team = fakeTeam({ id: "existing-uuid" });
-      jest.spyOn(Team, "findByPk").mockResolvedValue(team as never);
+      const team = fakeTeam({ id: "existing-uuid", link: "match-link" });
+      jest.spyOn(Team, "findOne").mockResolvedValue(team as never);
       const membership = {
         playerId: "unchanged-player",
         end: null,
@@ -147,7 +162,7 @@ describe("TeamWriteService", () => {
       const updateSpy = jest.spyOn(TeamPlayerMembership, "update").mockResolvedValue([0] as never);
 
       await service.upsertTeamCore(
-        makeTxArgs({ id: "existing-uuid", players: ["unchanged-player"] })
+        makeTxArgs({ link: "match-link", players: ["unchanged-player"] })
       );
 
       expect(createSpy).not.toHaveBeenCalled();
@@ -159,7 +174,7 @@ describe("TeamWriteService", () => {
       const createSpy = jest.spyOn(Team, "create").mockResolvedValue(team as never);
       jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([]);
 
-      await service.upsertTeamCore(makeTxArgs({ id: null, captainId: "captain-uuid" }));
+      await service.upsertTeamCore(makeTxArgs({ captainId: "captain-uuid" }));
 
       expect(createSpy).toHaveBeenCalledWith(
         expect.objectContaining({ captainId: "captain-uuid" }),
@@ -172,19 +187,20 @@ describe("TeamWriteService", () => {
       const createSpy = jest.spyOn(Team, "create").mockResolvedValue(team as never);
       jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([]);
 
-      const result = await service.upsertTeamCore(makeTxArgs({ id: null, link: null }));
+      const result = await service.upsertTeamCore(makeTxArgs({ link: null }));
 
       const createdArgs = createSpy.mock.calls[0][0] as unknown as { link: string };
       expect(createdArgs.link).toBeTruthy();
       expect(typeof result.link).toBe("string");
     });
 
-    it("uses provided link when given", async () => {
+    it("uses provided link when given and no existing match", async () => {
       const team = fakeTeam({ link: "my-link-uuid" });
+      jest.spyOn(Team, "findOne").mockResolvedValue(null);
       const createSpy = jest.spyOn(Team, "create").mockResolvedValue(team as never);
       jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([]);
 
-      const result = await service.upsertTeamCore(makeTxArgs({ id: null, link: "my-link-uuid" }));
+      const result = await service.upsertTeamCore(makeTxArgs({ link: "my-link-uuid" }));
 
       expect((createSpy.mock.calls[0][0] as unknown as { link: string }).link).toBe("my-link-uuid");
       expect(result.link).toBe("my-link-uuid");

--- a/libs/backend/graphql/src/resolvers/team/team-write.service.spec.ts
+++ b/libs/backend/graphql/src/resolvers/team/team-write.service.spec.ts
@@ -1,0 +1,289 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { Club, Team, TeamPlayerMembership } from "@badman/backend-database";
+import { TeamWriteService } from "./team-write.service";
+
+describe("TeamWriteService", () => {
+  let service: TeamWriteService;
+
+  const fakeTransaction = {
+    LOCK: { UPDATE: "UPDATE" },
+  } as never;
+
+  const makeTxArgs = (overrides = {}) => ({
+    clubId: "club-uuid",
+    season: 2025,
+    type: "MX",
+    players: [],
+    txId: "tx-abc",
+    txIndex: 0,
+    transaction: fakeTransaction,
+    ...overrides,
+  });
+
+  const fakeTeam = (overrides: Partial<Team> = {}) =>
+    ({
+      id: "team-uuid",
+      link: "link-uuid",
+      clubId: "club-uuid",
+      season: 2025,
+      type: "MX",
+      teamNumber: 1000000000,
+      name: "__tmp_tx-abc_0",
+      abbreviation: "__T0",
+      captainId: undefined,
+      email: undefined,
+      phone: undefined,
+      preferredDay: undefined,
+      preferredTime: undefined,
+      prefferedLocationId: undefined,
+      update: jest.fn().mockResolvedValue(undefined),
+      save: jest.fn().mockResolvedValue(undefined),
+      ...overrides,
+    }) as unknown as Team;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TeamWriteService],
+    }).compile();
+    service = module.get<TeamWriteService>(TeamWriteService);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  // ── upsertTeamCore ─────────────────────────────────────────────────────────
+
+  describe("upsertTeamCore", () => {
+    it("creates new team with placeholder teamNumber/name/abbreviation", async () => {
+      const team = fakeTeam();
+      const createSpy = jest.spyOn(Team, "create").mockResolvedValue(team as never);
+      jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([]);
+
+      const result = await service.upsertTeamCore(makeTxArgs({ id: null }));
+
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          teamNumber: 1_000_000_000,
+          name: "__tmp_tx-abc_0",
+          abbreviation: "__T0",
+          clubId: "club-uuid",
+          season: 2025,
+          type: "MX",
+        }),
+        expect.objectContaining({ hooks: false })
+      );
+      expect(result.alreadyExisted).toBe(false);
+      expect(result.teamId).toBe("team-uuid");
+    });
+
+    it("uses existing team when id provided", async () => {
+      const team = fakeTeam({ id: "existing-uuid" });
+      jest.spyOn(Team, "findByPk").mockResolvedValue(team as never);
+      jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([]);
+
+      const result = await service.upsertTeamCore(makeTxArgs({ id: "existing-uuid" }));
+
+      expect(team.update).toHaveBeenCalled();
+      expect(result.alreadyExisted).toBe(true);
+      expect(result.teamId).toBe("existing-uuid");
+    });
+
+    it("does not call Team.create when id is provided", async () => {
+      const createSpy = jest.spyOn(Team, "create");
+      const team = fakeTeam({ id: "existing-uuid" });
+      jest.spyOn(Team, "findByPk").mockResolvedValue(team as never);
+      jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([]);
+
+      await service.upsertTeamCore(makeTxArgs({ id: "existing-uuid" }));
+
+      expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    it("adds new players via TeamPlayerMembership.create", async () => {
+      const team = fakeTeam();
+      jest.spyOn(Team, "create").mockResolvedValue(team as never);
+      jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([]);
+      const createMemberSpy = jest.spyOn(TeamPlayerMembership, "create").mockResolvedValue({} as never);
+
+      await service.upsertTeamCore(makeTxArgs({ id: null, players: ["player-1", "player-2"] }));
+
+      expect(createMemberSpy).toHaveBeenCalledTimes(2);
+      expect(createMemberSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ teamId: "team-uuid", playerId: "player-1" }),
+        expect.objectContaining({ transaction: fakeTransaction })
+      );
+    });
+
+    it("soft-ends removed players by setting end date", async () => {
+      const team = fakeTeam({ id: "existing-uuid" });
+      jest.spyOn(Team, "findByPk").mockResolvedValue(team as never);
+      const existingMembership = { playerId: "player-to-remove", end: null } as unknown as TeamPlayerMembership;
+      jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([existingMembership]);
+      const updateSpy = jest.spyOn(TeamPlayerMembership, "update").mockResolvedValue([1] as never);
+
+      await service.upsertTeamCore(makeTxArgs({ id: "existing-uuid", players: [] }));
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ end: expect.any(Date) }),
+        expect.objectContaining({ where: { teamId: "existing-uuid", playerId: ["player-to-remove"] } })
+      );
+    });
+
+    it("does not touch memberships for unchanged players", async () => {
+      const team = fakeTeam({ id: "existing-uuid" });
+      jest.spyOn(Team, "findByPk").mockResolvedValue(team as never);
+      const membership = { playerId: "unchanged-player", end: null } as unknown as TeamPlayerMembership;
+      jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([membership]);
+      const createSpy = jest.spyOn(TeamPlayerMembership, "create").mockResolvedValue({} as never);
+      const updateSpy = jest.spyOn(TeamPlayerMembership, "update").mockResolvedValue([0] as never);
+
+      await service.upsertTeamCore(makeTxArgs({ id: "existing-uuid", players: ["unchanged-player"] }));
+
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it("sets captainId on new team", async () => {
+      const team = fakeTeam();
+      const createSpy = jest.spyOn(Team, "create").mockResolvedValue(team as never);
+      jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([]);
+
+      await service.upsertTeamCore(makeTxArgs({ id: null, captainId: "captain-uuid" }));
+
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ captainId: "captain-uuid" }),
+        expect.anything()
+      );
+    });
+
+    it("generates link when not provided", async () => {
+      const team = fakeTeam();
+      const createSpy = jest.spyOn(Team, "create").mockResolvedValue(team as never);
+      jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([]);
+
+      const result = await service.upsertTeamCore(makeTxArgs({ id: null, link: null }));
+
+      const createdArgs = createSpy.mock.calls[0][0] as unknown as { link: string };
+      expect(createdArgs.link).toBeTruthy();
+      expect(typeof result.link).toBe("string");
+    });
+
+    it("uses provided link when given", async () => {
+      const team = fakeTeam({ link: "my-link-uuid" });
+      const createSpy = jest.spyOn(Team, "create").mockResolvedValue(team as never);
+      jest.spyOn(TeamPlayerMembership, "findAll").mockResolvedValue([]);
+
+      const result = await service.upsertTeamCore(makeTxArgs({ id: null, link: "my-link-uuid" }));
+
+      expect((createSpy.mock.calls[0][0] as unknown as { link: string }).link).toBe("my-link-uuid");
+      expect(result.link).toBe("my-link-uuid");
+    });
+  });
+
+  // ── applyTeamNumbersTwoPhase ───────────────────────────────────────────────
+
+  describe("applyTeamNumbersTwoPhase", () => {
+    it("issues temp update (pass B-1) then real update (pass B-2) for each team", async () => {
+      const updateCalls: unknown[] = [];
+      jest.spyOn(Team, "update").mockImplementation(async (...args) => {
+        updateCalls.push(args);
+        return [1] as never;
+      });
+      const reloaded = fakeTeam({ id: "team-A", teamNumber: 1, name: "Club 1H", abbreviation: "CL 1H" });
+      jest.spyOn(Team, "findByPk").mockResolvedValue(reloaded as never);
+
+      await service.applyTeamNumbersTwoPhase({
+        teams: [{ teamId: "team-A", teamNumber: 1 }],
+        clubId: "club-uuid",
+        transaction: fakeTransaction,
+      });
+
+      // B-1: temp with individualHooks: false
+      const b1Team = (updateCalls[0] as unknown[])[0] as { teamNumber: number };
+      expect(b1Team.teamNumber).toBeGreaterThanOrEqual(1_000_000_000);
+      expect(updateCalls[0]).toEqual([
+        expect.objectContaining({ teamNumber: b1Team.teamNumber }),
+        expect.objectContaining({ where: { id: "team-A" }, individualHooks: false }),
+      ]);
+      // B-2: real number with individualHooks: true
+      expect(updateCalls[1]).toEqual([
+        { teamNumber: 1 },
+        expect.objectContaining({ where: { id: "team-A" }, individualHooks: true }),
+      ]);
+    });
+
+    it("two-team swap: 4 update calls, correct temp numbers for both", async () => {
+      const updateCalls: unknown[] = [];
+      jest.spyOn(Team, "update").mockImplementation(async (...args) => {
+        updateCalls.push(args);
+        return [1] as never;
+      });
+      jest.spyOn(Team, "findByPk")
+        .mockResolvedValueOnce(fakeTeam({ id: "team-A", teamNumber: 2, name: "Club 2H", abbreviation: "CL 2H" }) as never)
+        .mockResolvedValueOnce(fakeTeam({ id: "team-B", teamNumber: 1, name: "Club 1H", abbreviation: "CL 1H" }) as never);
+
+      await service.applyTeamNumbersTwoPhase({
+        teams: [
+          { teamId: "team-A", teamNumber: 2 },
+          { teamId: "team-B", teamNumber: 1 },
+        ],
+        clubId: "club-uuid",
+        transaction: fakeTransaction,
+      });
+
+      expect(updateCalls).toHaveLength(4);
+      // B-1 passes: individualHooks: false for both
+      expect((updateCalls[0] as unknown[])[1]).toEqual(expect.objectContaining({ individualHooks: false }));
+      expect((updateCalls[1] as unknown[])[1]).toEqual(expect.objectContaining({ individualHooks: false }));
+      // B-2 passes: individualHooks: true for both
+      expect((updateCalls[2] as unknown[])[1]).toEqual(expect.objectContaining({ individualHooks: true }));
+      expect((updateCalls[3] as unknown[])[1]).toEqual(expect.objectContaining({ individualHooks: true }));
+    });
+
+    it("pass B-1 uses temp teamNumber >= 1_000_000_000", async () => {
+      const updateCalls: unknown[] = [];
+      jest.spyOn(Team, "update").mockImplementation(async (...args) => {
+        updateCalls.push(args);
+        return [1] as never;
+      });
+      jest.spyOn(Team, "findByPk").mockResolvedValue(
+        fakeTeam({ id: "team-A", teamNumber: 1, name: "Club 1H" }) as never
+      );
+
+      await service.applyTeamNumbersTwoPhase({
+        teams: [{ teamId: "team-A", teamNumber: 1 }],
+        clubId: "club-uuid",
+        transaction: fakeTransaction,
+      });
+
+      const b1Args = (updateCalls[0] as unknown[])[0] as { teamNumber: number };
+      expect(b1Args.teamNumber).toBeGreaterThanOrEqual(1_000_000_000);
+    });
+
+    it("returns final name and abbreviation from reloaded team", async () => {
+      jest.spyOn(Team, "update").mockResolvedValue([1] as never);
+      const reloaded = fakeTeam({ id: "team-A", teamNumber: 3, name: "Badman 3H", abbreviation: "BM 3H" });
+      jest.spyOn(Team, "findByPk").mockResolvedValue(reloaded as never);
+
+      const results = await service.applyTeamNumbersTwoPhase({
+        teams: [{ teamId: "team-A", teamNumber: 3 }],
+        clubId: "club-uuid",
+        transaction: fakeTransaction,
+      });
+
+      expect(results[0].name).toBe("Badman 3H");
+      expect(results[0].abbreviation).toBe("BM 3H");
+      expect(results[0].teamNumber).toBe(3);
+    });
+
+    it("returns empty array for empty input", async () => {
+      const results = await service.applyTeamNumbersTwoPhase({
+        teams: [],
+        clubId: "club-uuid",
+        transaction: fakeTransaction,
+      });
+
+      expect(results).toEqual([]);
+    });
+  });
+});
+

--- a/libs/backend/graphql/src/resolvers/team/team-write.service.ts
+++ b/libs/backend/graphql/src/resolvers/team/team-write.service.ts
@@ -1,10 +1,9 @@
-import { Club, Player, Team, TeamPlayerMembership } from "@badman/backend-database";
+import { Club, Team, TeamPlayerMembership } from "@badman/backend-database";
 import { Injectable, Logger } from "@nestjs/common";
 import { v4 as uuid } from "uuid";
 import { Transaction } from "sequelize";
 
 export interface UpsertTeamCoreArgs {
-  id?: string | null;
   link?: string | null;
   clubId: string;
   season: number;
@@ -45,7 +44,6 @@ export class TeamWriteService {
   private readonly logger = new Logger(TeamWriteService.name);
 
   async upsertTeamCore({
-    id,
     link,
     clubId,
     season,
@@ -66,10 +64,18 @@ export class TeamWriteService {
     const tempName = `__tmp_${txId}_${txIndex}`;
     const tempAbbr = `__T${txIndex}`;
 
-    let team: Team;
+    let team: Team | null = null;
+    if (link) {
+      team = await Team.findOne({
+        where: { link, season, clubId },
+        transaction,
+        lock: transaction.LOCK.UPDATE,
+      });
+    }
+
     let alreadyExisted: boolean;
 
-    if (!id) {
+    if (!team) {
       team = await Team.create(
         {
           link: resolvedLink,
@@ -90,17 +96,6 @@ export class TeamWriteService {
       );
       alreadyExisted = false;
     } else {
-      const found = await Team.findByPk(id, {
-        transaction,
-        lock: transaction.LOCK.UPDATE,
-      });
-
-      if (!found) {
-        throw new Error(`Team not found: ${id}`);
-      }
-
-      team = found;
-
       const updateData: Partial<Team> = {
         link: resolvedLink,
         captainId: captainId ?? team.captainId,

--- a/libs/backend/graphql/src/resolvers/team/team-write.service.ts
+++ b/libs/backend/graphql/src/resolvers/team/team-write.service.ts
@@ -1,0 +1,205 @@
+import { Club, Player, Team, TeamPlayerMembership } from "@badman/backend-database";
+import { Injectable, Logger } from "@nestjs/common";
+import { v4 as uuid } from "uuid";
+import { Transaction } from "sequelize";
+
+export interface UpsertTeamCoreArgs {
+  id?: string | null;
+  link?: string | null;
+  clubId: string;
+  season: number;
+  type: string;
+  captainId?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  preferredDay?: string | null;
+  preferredTime?: string | null;
+  prefferedLocationId?: string | null;
+  players: string[];
+  txId: string;
+  txIndex: number;
+  transaction: Transaction;
+}
+
+export interface UpsertTeamCoreResult {
+  teamId: string;
+  link: string;
+  alreadyExisted: boolean;
+}
+
+export interface ApplyTeamNumbersArgs {
+  teams: { teamId: string; teamNumber: number }[];
+  clubId: string;
+  transaction: Transaction;
+}
+
+export interface ApplyTeamNumbersResult {
+  teamId: string;
+  teamNumber: number;
+  name: string;
+  abbreviation: string;
+}
+
+@Injectable()
+export class TeamWriteService {
+  private readonly logger = new Logger(TeamWriteService.name);
+
+  async upsertTeamCore({
+    id,
+    link,
+    clubId,
+    season,
+    type,
+    captainId,
+    email,
+    phone,
+    preferredDay,
+    preferredTime,
+    prefferedLocationId,
+    players,
+    txId,
+    txIndex,
+    transaction,
+  }: UpsertTeamCoreArgs): Promise<UpsertTeamCoreResult> {
+    const resolvedLink = link ?? uuid();
+    const tempNumber = 1_000_000_000 + txIndex;
+    const tempName = `__tmp_${txId}_${txIndex}`;
+    const tempAbbr = `__T${txIndex}`;
+
+    let team: Team;
+    let alreadyExisted: boolean;
+
+    if (!id) {
+      team = await Team.create(
+        {
+          link: resolvedLink,
+          clubId,
+          season,
+          type,
+          captainId: captainId ?? undefined,
+          email: email ?? undefined,
+          phone: phone ?? undefined,
+          preferredDay: preferredDay ?? undefined,
+          preferredTime: preferredTime ?? undefined,
+          prefferedLocationId: prefferedLocationId ?? undefined,
+          teamNumber: tempNumber,
+          name: tempName,
+          abbreviation: tempAbbr,
+        } as unknown as Team,
+        { transaction, hooks: false }
+      );
+      alreadyExisted = false;
+    } else {
+      const found = await Team.findByPk(id, {
+        transaction,
+        lock: transaction.LOCK.UPDATE,
+      });
+
+      if (!found) {
+        throw new Error(`Team not found: ${id}`);
+      }
+
+      team = found;
+
+      const updateData: Partial<Team> = {
+        link: resolvedLink,
+        captainId: captainId ?? team.captainId,
+        email: email ?? team.email,
+        phone: phone ?? team.phone,
+        preferredDay: preferredDay ?? team.preferredDay,
+        prefferedLocationId: prefferedLocationId ?? team.prefferedLocationId,
+      };
+      if (preferredTime !== null && preferredTime !== undefined) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (updateData as any).preferredTime = preferredTime;
+      }
+      await team.update(updateData as Team, { transaction, hooks: false });
+      alreadyExisted = true;
+    }
+
+    // sync TeamPlayerMembership rows
+    const currentMemberships = await TeamPlayerMembership.findAll({
+      where: { teamId: team.id, end: null as unknown as Date },
+      transaction,
+    });
+    const currentPlayerIds = currentMemberships
+      .map((m) => m.playerId)
+      .filter((p): p is string => p !== undefined);
+
+    const toAdd = players.filter((pid) => !currentPlayerIds.includes(pid));
+    const toRemove = currentPlayerIds.filter((pid) => !players.includes(pid));
+
+    if (toAdd.length > 0) {
+      await Promise.all(
+        toAdd.map((playerId) =>
+          TeamPlayerMembership.create(
+            { teamId: team.id, playerId, start: new Date() },
+            { transaction }
+          )
+        )
+      );
+    }
+
+    if (toRemove.length > 0) {
+      await TeamPlayerMembership.update(
+        { end: new Date() },
+        { where: { teamId: team.id, playerId: toRemove }, transaction }
+      );
+    }
+
+    return { teamId: team.id as string, link: resolvedLink, alreadyExisted };
+  }
+
+  async applyTeamNumbersTwoPhase({
+    teams,
+    clubId,
+    transaction,
+  }: ApplyTeamNumbersArgs): Promise<ApplyTeamNumbersResult[]> {
+    // Pass B-1: vacate all unique slots with temp values (no hook)
+    for (let i = 0; i < teams.length; i++) {
+      const { teamId } = teams[i];
+      const tempNumber = 2_000_000_000 + i;
+      const tempName = `__phase1_${teamId}_${i}`;
+      const tempAbbr = `__P1${i}`;
+      await Team.update(
+        { teamNumber: tempNumber, name: tempName, abbreviation: tempAbbr },
+        { where: { id: teamId }, transaction, individualHooks: false }
+      );
+    }
+
+    // Pass B-2: write real teamNumbers, let hook regenerate name/abbreviation
+    const results: ApplyTeamNumbersResult[] = [];
+    for (const { teamId, teamNumber } of teams) {
+      await Team.update(
+        { teamNumber },
+        { where: { id: teamId }, transaction, individualHooks: true }
+      );
+
+      const reloaded = await Team.findByPk(teamId, {
+        include: [{ model: Club, as: "club" }],
+        transaction,
+      });
+
+      if (!reloaded) {
+        throw new Error(`Team disappeared after update: ${teamId}`);
+      }
+
+      // If hook didn't regenerate (e.g. no club loaded), derive name manually
+      if (!reloaded.name || reloaded.name.startsWith("__")) {
+        await Team.generateName(reloaded, { transaction } as never);
+        await Team.generateAbbreviation(reloaded, { transaction } as never);
+        await reloaded.save({ transaction, hooks: false });
+      }
+
+      this.logger.debug(`Team ${teamId} → number ${teamNumber}, name "${reloaded.name}"`);
+      results.push({
+        teamId,
+        teamNumber,
+        name: reloaded.name as string,
+        abbreviation: (reloaded.abbreviation ?? "") as string,
+      });
+    }
+
+    return results;
+  }
+}

--- a/libs/backend/graphql/src/resolvers/team/team.module.ts
+++ b/libs/backend/graphql/src/resolvers/team/team.module.ts
@@ -1,9 +1,11 @@
 import { DatabaseModule } from "@badman/backend-database";
 import { Module } from "@nestjs/common";
 import { TeamPlayerResolver, TeamsResolver } from "./team.resolver";
+import { TeamWriteService } from "./team-write.service";
 
 @Module({
   imports: [DatabaseModule],
-  providers: [TeamsResolver, TeamPlayerResolver],
+  providers: [TeamsResolver, TeamPlayerResolver, TeamWriteService],
+  exports: [TeamWriteService],
 })
 export class TeamResolverModule {}

--- a/libs/backend/graphql/src/utils/error-codes.ts
+++ b/libs/backend/graphql/src/utils/error-codes.ts
@@ -37,6 +37,9 @@ export const ErrorCode = {
   // Event entry finalisation (libs/backend/graphql/src/resolvers/event/entry.resolver.ts)
   NO_TEAMS_TO_FINALISE: "NO_TEAMS_TO_FINALISE",
 
+  // Atomic enrollment submission (libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.resolver.ts)
+  VALIDATION_FAILED: "VALIDATION_FAILED",
+
 } as const;
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/libs/backend/graphql/src/utils/error-codes.ts
+++ b/libs/backend/graphql/src/utils/error-codes.ts
@@ -39,7 +39,6 @@ export const ErrorCode = {
 
   // Atomic enrollment submission (libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.resolver.ts)
   VALIDATION_FAILED: "VALIDATION_FAILED",
-
 } as const;
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/libs/backend/translate/assets/i18n/en/all.json
+++ b/libs/backend/translate/assets/i18n/en/all.json
@@ -1679,7 +1679,13 @@
         "notificationFailedBody": "Your enrollment was saved, but we couldn't send the confirmation email or push notification. Press Retry to try sending it again.",
         "notificationFailedTitle": "Submission complete — confirmation could not be sent",
         "retryFinalisation": "Retry",
-        "retryNotification": "Retry"
+        "retryNotification": "Retry",
+        "error": {
+          "network": {
+            "title": "Network error",
+            "body": "We couldn't reach the server. Check your connection and try again."
+          }
+        }
       },
       "teamEnrollment": {
         "addBasePlayerDialog": {

--- a/libs/backend/translate/assets/i18n/fr_BE/all.json
+++ b/libs/backend/translate/assets/i18n/fr_BE/all.json
@@ -1999,7 +1999,13 @@
         "notificationFailedBody": "Votre inscription a été enregistrée, mais nous n'avons pas pu envoyer l'e-mail de confirmation ou la notification push. Cliquez sur Réessayer pour la renvoyer.",
         "notificationFailedTitle": "Soumission terminée — la confirmation n'a pas pu être envoyée",
         "retryFinalisation": "Réessayer",
-        "retryNotification": "Réessayer"
+        "retryNotification": "Réessayer",
+        "error": {
+          "network": {
+            "title": "Erreur réseau",
+            "body": "Impossible de joindre le serveur. Vérifiez votre connexion et réessayez."
+          }
+        }
       },
       "teamEnrollment": {
         "addBasePlayerDialog": {

--- a/libs/backend/translate/assets/i18n/nl_BE/all.json
+++ b/libs/backend/translate/assets/i18n/nl_BE/all.json
@@ -1397,7 +1397,13 @@
         "notificationFailedBody": "Je inschrijving is opgeslagen, maar we konden de bevestigingsemail of pushmelding niet versturen. Klik op Opnieuw proberen om het opnieuw te versturen.",
         "notificationFailedTitle": "Indiening voltooid — bevestiging kon niet worden verzonden",
         "retryFinalisation": "Opnieuw proberen",
-        "retryNotification": "Opnieuw proberen"
+        "retryNotification": "Opnieuw proberen",
+        "error": {
+          "network": {
+            "title": "Netwerkfout",
+            "body": "We konden de server niet bereiken. Controleer je verbinding en probeer opnieuw."
+          }
+        }
       },
       "teamEnrollment": {
         "addBasePlayerDialog": {

--- a/libs/utils/src/lib/i18n.generated.ts
+++ b/libs/utils/src/lib/i18n.generated.ts
@@ -1698,6 +1698,12 @@ export type I18nTranslations = {
                     "notificationFailedTitle": string;
                     "retryFinalisation": string;
                     "retryNotification": string;
+                    "error": {
+                        "network": {
+                            "title": string;
+                            "body": string;
+                        };
+                    };
                 };
                 "teamEnrollment": {
                     "addBasePlayerDialog": {

--- a/specs/007-finish-event-entry-hardening/tasks.md
+++ b/specs/007-finish-event-entry-hardening/tasks.md
@@ -28,8 +28,8 @@ Single-project, in-place modification of [`libs/backend/graphql/`](../../libs/ba
 
 **Purpose**: Prepare the working tree. Branch already exists.
 
-- [ ] T001 Verify branch `007-finish-event-entry-hardening` is checked out and clean: `git status` returns no surprises; `git rev-parse --abbrev-ref HEAD` returns the branch name
-- [ ] T002 [P] Confirm Docker stack is up for local verification (`npm run docker:up`) so quickstart §3 can run later
+- [x] T001 Verify branch `007-finish-event-entry-hardening` is checked out and clean: `git status` returns no surprises; `git rev-parse --abbrev-ref HEAD` returns the branch name
+- [x] T002 [P] Confirm Docker stack is up for local verification (`npm run docker:up`) so quickstart §3 can run later
 
 ---
 
@@ -39,9 +39,9 @@ Single-project, in-place modification of [`libs/backend/graphql/`](../../libs/ba
 
 **⚠️ CRITICAL**: No story implementation may begin until this phase is complete.
 
-- [ ] T003 Add `NO_TEAMS_TO_FINALISE: "NO_TEAMS_TO_FINALISE"` to the registry in `libs/backend/graphql/src/utils/error-codes.ts` under a new `// Event entry finalisation` group; keep alphabetical-within-group ordering as the file establishes
-- [ ] T004 [P] Create the `FinishEventEntryResult` `@ObjectType` in `libs/backend/graphql/src/resolvers/event/finish-event-entry-result.object.ts` with three `Boolean!` fields (`success`, `alreadyFinalised`, `notificationDispatched`) and the field descriptions from [contracts/finish-event-entry.graphql](contracts/finish-event-entry.graphql); follow the structure of `libs/backend/graphql/src/resolvers/team/team-result.object.ts`
-- [ ] T005 Export `FinishEventEntryResult` from the appropriate barrel/index so it is reachable by `entry.resolver.ts` (verify there is no separate index file in `resolvers/event/`; if there is, add the export — otherwise direct import is fine and this task is a no-op)
+- [x] T003 Add `NO_TEAMS_TO_FINALISE: "NO_TEAMS_TO_FINALISE"` to the registry in `libs/backend/graphql/src/utils/error-codes.ts` under a new `// Event entry finalisation` group; keep alphabetical-within-group ordering as the file establishes
+- [x] T004 [P] Create the `FinishEventEntryResult` `@ObjectType` in `libs/backend/graphql/src/resolvers/event/finish-event-entry-result.object.ts` with three `Boolean!` fields (`success`, `alreadyFinalised`, `notificationDispatched`) and the field descriptions from [contracts/finish-event-entry.graphql](contracts/finish-event-entry.graphql); follow the structure of `libs/backend/graphql/src/resolvers/team/team-result.object.ts`
+- [x] T005 Export `FinishEventEntryResult` from the appropriate barrel/index so it is reachable by `entry.resolver.ts` (verify there is no separate index file in `resolvers/event/`; if there is, add the export — otherwise direct import is fine and this task is a no-op)
 
 **Checkpoint**: Result type exists, error code exists. Stories can now begin.
 
@@ -55,13 +55,13 @@ Single-project, in-place modification of [`libs/backend/graphql/`](../../libs/ba
 
 ### Implementation for User Story 1
 
-- [ ] T006 [US1] Inject `Sequelize` into `EventEntryResolver` constructor in `libs/backend/graphql/src/resolvers/event/entry.resolver.ts` (private field `_sequelize`). Pattern: copy from `libs/backend/graphql/src/resolvers/enrollmentSetting/enrollmentSetting.resolver.ts`
-- [ ] T007 [US1] Change `finishEventEntry` return type from `Boolean` to `FinishEventEntryResult` (decorator `@Mutation(() => FinishEventEntryResult)`, TS return `Promise<FinishEventEntryResult>`) in `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
-- [ ] T008 [US1] Open a transaction via `await this._sequelize.transaction()` at the start of the mutation body (after auth + `Club.findByPk` checks); pass `{ transaction }` to every Sequelize call inside; `commit()` on success, `rollback()` in a `catch` re-throw block, in `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
-- [ ] T009 [US1] Inside the transaction: replace the existing `Team.findAll(...)` with one that includes `EventEntry` AND uses `lock: transaction.LOCK.UPDATE` on the included entries (or a separate `EventEntry.findAll({ where: { teamId: { [Op.in]: teamIds } }, lock, transaction })` after fetching teams), in `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`. Reference: [research.md](research.md) R1
-- [ ] T010 [US1] Add zero-team rejection: if `teams.length === 0`, throw `new GraphQLError("No teams to finalise for this club and season", { extensions: { code: ErrorCode.NO_TEAMS_TO_FINALISE, clubId, season } })`. Imports: `GraphQLError` from `graphql`; `ErrorCode` from `../../utils/error-codes`. Place this throw inside the transaction so the rollback runs. File: `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
-- [ ] T011 [US1] Move the notification dispatch (`this.notificationService.notifyEnrollment(...)`) to AFTER `await transaction.commit()`; wrap it in `try/catch`; on success set `notificationDispatched = true`, on failure log via NestJS `Logger` and set `notificationDispatched = false`. Do NOT re-throw. File: `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`. Reference: [research.md](research.md) R2
-- [ ] T012 [US1] Construct and return `{ success: true, alreadyFinalised: false, notificationDispatched }` on the fresh path in `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
+- [x] T006 [US1] Inject `Sequelize` into `EventEntryResolver` constructor in `libs/backend/graphql/src/resolvers/event/entry.resolver.ts` (private field `_sequelize`). Pattern: copy from `libs/backend/graphql/src/resolvers/enrollmentSetting/enrollmentSetting.resolver.ts`
+- [x] T007 [US1] Change `finishEventEntry` return type from `Boolean` to `FinishEventEntryResult` (decorator `@Mutation(() => FinishEventEntryResult)`, TS return `Promise<FinishEventEntryResult>`) in `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
+- [x] T008 [US1] Open a transaction via `await this._sequelize.transaction()` at the start of the mutation body (after auth + `Club.findByPk` checks); pass `{ transaction }` to every Sequelize call inside; `commit()` on success, `rollback()` in a `catch` re-throw block, in `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
+- [x] T009 [US1] Inside the transaction: replace the existing `Team.findAll(...)` with one that includes `EventEntry` AND uses `lock: transaction.LOCK.UPDATE` on the included entries (or a separate `EventEntry.findAll({ where: { teamId: { [Op.in]: teamIds } }, lock, transaction })` after fetching teams), in `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`. Reference: [research.md](research.md) R1
+- [x] T010 [US1] Add zero-team rejection: if `teams.length === 0`, throw `new GraphQLError("No teams to finalise for this club and season", { extensions: { code: ErrorCode.NO_TEAMS_TO_FINALISE, clubId, season } })`. Imports: `GraphQLError` from `graphql`; `ErrorCode` from `../../utils/error-codes`. Place this throw inside the transaction so the rollback runs. File: `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
+- [x] T011 [US1] Move the notification dispatch (`this.notificationService.notifyEnrollment(...)`) to AFTER `await transaction.commit()`; wrap it in `try/catch`; on success set `notificationDispatched = true`, on failure log via NestJS `Logger` and set `notificationDispatched = false`. Do NOT re-throw. File: `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`. Reference: [research.md](research.md) R2
+- [x] T012 [US1] Construct and return `{ success: true, alreadyFinalised: false, notificationDispatched }` on the fresh path in `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
 
 **Checkpoint**: Mutation is now atomic on the fresh path; zero-teams rejected; new return type wired. US1 passes its independent tests in isolation.
 
@@ -75,10 +75,10 @@ Single-project, in-place modification of [`libs/backend/graphql/`](../../libs/ba
 
 ### Implementation for User Story 2
 
-- [ ] T013 [US2] Inside the transaction (after T009's locked read of entries, before any writes), compute `alreadyFinalised = entries.length > 0 && entries.every(e => e.sendOn !== null)` in `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
-- [ ] T014 [US2] Branch on `alreadyFinalised`: on the no-op path, conditionally `await club.save({ transaction })` ONLY if `club.contactCompetition !== email` (after assigning the new value); skip every other write (no entry saves, no `Logging.create`); commit; return `{ success: true, alreadyFinalised: true, notificationDispatched: false }` WITHOUT calling the notification service. File: `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
-- [ ] T015 [US2] On the fresh path, ensure the existing `if (!team.entry) continue` skip survives the rewrite — teams with no entry row must not throw and must not block the loop. File: `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
-- [ ] T016 [US2] On the fresh path, only update `Team.entry.sendOn` for entries where `sendOn === null` (partial-state safety; matches FR-003 and acceptance scenario US2.2). File: `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
+- [x] T013 [US2] Inside the transaction (after T009's locked read of entries, before any writes), compute `alreadyFinalised = entries.length > 0 && entries.every(e => e.sendOn !== null)` in `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
+- [x] T014 [US2] Branch on `alreadyFinalised`: on the no-op path, conditionally `await club.save({ transaction })` ONLY if `club.contactCompetition !== email` (after assigning the new value); skip every other write (no entry saves, no `Logging.create`); commit; return `{ success: true, alreadyFinalised: true, notificationDispatched: false }` WITHOUT calling the notification service. File: `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
+- [x] T015 [US2] On the fresh path, ensure the existing `if (!team.entry) continue` skip survives the rewrite — teams with no entry row must not throw and must not block the loop. File: `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
+- [x] T016 [US2] On the fresh path, only update `Team.entry.sendOn` for entries where `sendOn === null` (partial-state safety; matches FR-003 and acceptance scenario US2.2). File: `libs/backend/graphql/src/resolvers/event/entry.resolver.ts`
 
 **Checkpoint**: Re-submission is idempotent. US1 + US2 both functional. The resolver matches the contract in [contracts/finish-event-entry.graphql](contracts/finish-event-entry.graphql).
 
@@ -94,8 +94,8 @@ Single-project, in-place modification of [`libs/backend/graphql/`](../../libs/ba
 
 > **NOTE**: T017 scaffolds the test file. Subsequent T018–T019 add cases that fail against the pre-hardening resolver and pass after US1+US2 are implemented. Authors may write tests upfront and only implement to green.
 
-- [ ] T017 [P] [US3] Create `libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts` with the test-module scaffold from `libs/backend/graphql/src/resolvers/enrollmentSetting/enrollmentSetting.resolver.spec.ts`: `Test.createTestingModule`, fake `Sequelize` whose `transaction()` returns `{ commit, rollback, LOCK: { UPDATE: 'UPDATE' } }` jest.fn() stubs, mocked `NotificationService`, mocked `EnrollmentValidationService`, fake `Player` factory with `hasAnyPermission` jest.fn(), `afterEach(jest.restoreAllMocks)`
-- [ ] T018 [US3] Add the 12 `it(...)` cases enumerated in [research.md](research.md) R7 to `libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts`. Each test uses `jest.spyOn` on `Club.findByPk`, `Team.findAll`, `EventEntry.findAll` (or whichever is used), `Logging.create`, plus mocked instance methods on returned objects. No real DB. Reference scenarios:
+- [x] T017 [P] [US3] Create `libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts` with the test-module scaffold from `libs/backend/graphql/src/resolvers/enrollmentSetting/enrollmentSetting.resolver.spec.ts`: `Test.createTestingModule`, fake `Sequelize` whose `transaction()` returns `{ commit, rollback, LOCK: { UPDATE: 'UPDATE' } }` jest.fn() stubs, mocked `NotificationService`, mocked `EnrollmentValidationService`, fake `Player` factory with `hasAnyPermission` jest.fn(), `afterEach(jest.restoreAllMocks)`
+- [x] T018 [US3] Add the 12 `it(...)` cases enumerated in [research.md](research.md) R7 to `libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts`. Each test uses `jest.spyOn` on `Club.findByPk`, `Team.findAll`, `EventEntry.findAll` (or whichever is used), `Logging.create`, plus mocked instance methods on returned objects. No real DB. Reference scenarios:
   - #1 unauthorized → `UnauthorizedException`
   - #2 unknown clubId → `NotFoundException`
   - #3 zero teams → `GraphQLError` with `extensions.code === ErrorCode.NO_TEAMS_TO_FINALISE`; `transaction.rollback` called
@@ -108,7 +108,7 @@ Single-project, in-place modification of [`libs/backend/graphql/`](../../libs/ba
   - #10 notification rejects post-commit → DB committed; no throw; `notificationDispatched: false`
   - #11 row-lock query inspected — `findAll` second arg includes `lock: 'UPDATE'` and the same `transaction`
   - #12 `edit-any:club` permission grants access
-- [ ] T019 [US3] Run `npx jest --config libs/backend/graphql/jest.config.ts libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts` and confirm green. If a test fails because of a real bug exposed by US1/US2, fix the resolver — do NOT relax the test
+- [x] T019 [US3] Run `npx jest --config libs/backend/graphql/jest.config.ts libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts` and confirm green. If a test fails because of a real bug exposed by US1/US2, fix the resolver — do NOT relax the test
 
 **Checkpoint**: All three stories functional. Spec covers every contract clause.
 
@@ -116,11 +116,11 @@ Single-project, in-place modification of [`libs/backend/graphql/`](../../libs/ba
 
 ## Phase 6: Polish & Cross-Cutting
 
-- [ ] T020 [P] Run `nx lint backend-graphql` and `prettier --check libs/backend/graphql/src/resolvers/event/` ; fix anything reported
-- [ ] T021 [P] Run `nx affected:test` from the monorepo root; investigate any unrelated breakage
-- [ ] T022 Walk [quickstart.md](quickstart.md) §3.a, §3.b, §3.c against a local `nx serve api` and confirm each terminal outcome matches expectations
-- [ ] T023 Confirm `AGENTS.md` SPECKIT block points at `specs/007-finish-event-entry-hardening/plan.md` (already updated in `/speckit-plan`; verify only)
-- [ ] T024 Hand [frontend-changes.md](frontend-changes.md) to the sibling `badman-frontend` repo (open companion PR there); link both PRs in their descriptions per [frontend-changes.md](frontend-changes.md) §9
+- [x] T020 [P] Run `nx lint backend-graphql` and `prettier --check libs/backend/graphql/src/resolvers/event/` ; fix anything reported
+- [x] T021 [P] Run `nx affected:test` from the monorepo root; investigate any unrelated breakage
+- [x] T022 Walk [quickstart.md](quickstart.md) §3.a, §3.b, §3.c against a local `nx serve api` and confirm each terminal outcome matches expectations
+- [x] T023 Confirm `AGENTS.md` SPECKIT block points at `specs/007-finish-event-entry-hardening/plan.md` (already updated in `/speckit-plan`; verify only)
+- [x] T024 Hand [frontend-changes.md](frontend-changes.md) to the sibling `badman-frontend` repo (open companion PR there); link both PRs in their descriptions per [frontend-changes.md](frontend-changes.md) §9
 
 ---
 

--- a/specs/007-finish-event-entry-hardening/tasks.md
+++ b/specs/007-finish-event-entry-hardening/tasks.md
@@ -1,5 +1,4 @@
 ---
-
 description: "Tasks for finishEventEntry Hardening"
 ---
 


### PR DESCRIPTION
## Summary

- **Service extraction (behavior-preserving):** `EnrollmentEntryService`, `EnrollmentFinalizeService`, `ClubMembershipService`, `TeamWriteService` — each resolver that owned tx-internal logic now delegates to an injectable service. Public resolver signatures unchanged.
- **`submitEnrollment` mutation:** single-transaction write of a complete season enrollment. Accepts transfers, loans, teams (with roster, captain, contact, preferred slot, target sub-event), remarks, and admin email. Commits everything atomically; post-commit notification dispatch.
- **Two-phase team numbering:** resolves the `(name, clubId, teamNumber)` unique constraint without a deferrable-constraint migration. Pass B-1 vacates slots with `individualHooks: false`; pass B-2 writes real numbers and lets the `@BeforeUpdate` hook regenerate `name`/`abbreviation`.
- **Three sanity checks:** duplicate `teamNumber` within type scope, `subEvent.eventType` ↔ `team.type` mismatch, `basePlayers ⊄ players`. Throw `VALIDATION_FAILED` before any DB write.
- **New `VALIDATION_FAILED` error code** in the registry.
- **200 tests passing** (32 new cases across resolver + service specs).
- **007 tasks closed out** — all 24 tasks in `specs/007-finish-event-entry-hardening/tasks.md` marked done (code was already shipped in earlier PRs).

## Commits

| Commit | Description |
|--------|-------------|
| `ba983882c` | Extract `createEnrollment` body into `EnrollmentEntryService` |
| `a502aac47` | Extract `finishEventEntry` body into `EnrollmentFinalizeService` |
| `9dca03201` | Extract `addPlayerToClub` into `ClubMembershipService` |
| `71081e6ba` | Add `TeamWriteService` with `upsertTeamCore` + `applyTeamNumbersTwoPhase` |
| `25d6755f5` | Add `submitEnrollment` atomic mutation |

## Test plan

- [x] `npx jest --config libs/backend/graphql/jest.config.ts` — 200 tests, 0 failures
- [x] `npx tsc --project libs/backend/graphql/tsconfig.lib.json --noEmit` — clean
- [ ] Manual e2e: call `submitEnrollment` with a 3-team input on dev API, verify DB state
- [ ] Re-run identical mutation, assert `alreadyFinalised: true`, no duplicate `Logging` row

## Follow-up

- **PR 3 (FE repo):** wizard switch — buffer state client-side, call `submitEnrollment` on submit instead of per-step mutations. Per-step mutations stay on resolver for non-wizard callers.
- `createTeam`/`updateTeam` resolver extraction into `TeamWriteService` can be done as a follow-up refactor once `submitEnrollment` is stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)