### PR TITLE
fix(visual): coerce numeric Match.CourtName to string

### DIFF
--- a/libs/backend/visual/src/utils/__tests__/visual-result.spec.ts
+++ b/libs/backend/visual/src/utils/__tests__/visual-result.spec.ts
@@ -203,6 +203,13 @@ describe("requiredCoercedString invariant", () => {
     }
   });
 
+  // Visual API sometimes returns CourtName as a numeric court number (Sentry #117823630).
+  it("XmlMatchSchema: coerces numeric CourtName to string", () => {
+    const result = XmlMatchSchema.safeParse({ Code: "M1", CourtName: 3 });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.CourtName).toBe("3");
+  });
+
   it("XmlTeamMatchSchema: coerces numeric Team1/Team2 to undefined", () => {
     const result = XmlTeamMatchSchema.safeParse({ Code: "TM1", Team1: 42, Team2: 99 });
     expect(result.success).toBe(true);

--- a/libs/backend/visual/src/utils/visual-result.ts
+++ b/libs/backend/visual/src/utils/visual-result.ts
@@ -295,7 +295,7 @@ export const XmlMatchSchema = z
     LocationCode: z.coerce.string().optional(),
     LocationName: z.string().optional(),
     CourtCode: z.coerce.string().optional(),
-    CourtName: z.string().optional(),
+    CourtName: z.coerce.string().optional(),
     MatchTypeID: z.coerce.number().optional(),
     MatchTypeNo: z.coerce.string().optional(),
     MatchOrder: z.coerce.number().optional(),


### PR DESCRIPTION
## Summary
- Visual API returned a numeric `CourtName` (court index), causing Zod validation to throw and crashing the tournament sync worker (Sentry #117823630).
- Switched `XmlMatchSchema.CourtName` from `z.string()` to `z.coerce.string()`, matching the existing pattern already used for sibling fields like `CourtCode`, `EventCode`, `TournamentTimezone`.
- Added a regression test for the numeric `CourtName` case.

## Test plan
- [x] `npx jest --config libs/backend/visual/jest.config.ts libs/backend/visual/src/utils/__tests__/visual-result.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)