### PR TITLE
fix(sync): process tournament subevents sequentially

### DIFF
--- a/apps/worker/sync/src/app/processors/sync-events/tournament-sync/processors/game.ts
+++ b/apps/worker/sync/src/app/processors/sync-events/tournament-sync/processors/game.ts
@@ -13,7 +13,7 @@ import {
   XmlScoreStatus,
   XmlTournament,
 } from "@badman/backend-visual";
-import { GameStatus, getRankingProtected, runParallel } from "@badman/utils";
+import { GameStatus, getRankingProtected } from "@badman/utils";
 import { Logger, NotFoundException } from "@nestjs/common";
 import { isBefore, subWeeks } from "date-fns";
 import { fromZonedTime } from "date-fns-tz";
@@ -62,7 +62,9 @@ export class TournamentSyncGameProcessor extends StepProcessor {
       transaction: this.transaction,
     });
 
-    await runParallel(this.draws?.map((e) => this._processSubevent(e.draw, e.internalId)) ?? []);
+    for (const e of this.draws ?? []) {
+      await this._processSubevent(e.draw, e.internalId);
+    }
 
     return this._games;
   }


### PR DESCRIPTION
## Summary
- Sentry issue 117823628: `rollback has been called on this transaction(...)` from `TournamentSyncGameProcessor._processSubevent`.
- `runParallel(this.draws.map(...))` eagerly started every subevent promise with the shared transaction. When one rejected, the outer handler in `sync-events.processor.ts` rolled back, while siblings were still issuing inserts/updates against the now-finished transaction — surfacing as unhandled rejections.
- Replaced with a sequential `for…of` loop so any failure stops further work on the transaction before rollback.

## Test plan
- [ ] Worker sync runs a tournament with multiple draws to completion.
- [ ] Inject a failing draw and confirm the job fails with the original error (no trailing `rollback has been called` unhandled rejections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)