### PR TITLE
fix(enrollment): unify baseIndex on validator's rule

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,6 @@ name: badman-next
 services:
   # Databases
   postgres:
-    platform: linux/amd64
     image: postgis/postgis:16-master
     platform: linux/amd64
     shm_size: 1gb

--- a/libs/backend/competition/enrollment/src/services/index-calculation/index-calculation.service.spec.ts
+++ b/libs/backend/competition/enrollment/src/services/index-calculation/index-calculation.service.spec.ts
@@ -6,11 +6,7 @@ import {
   RankingSystem,
   SubEventCompetition,
 } from "@badman/backend-database";
-import {
-  getIndexFromPlayers,
-  INDEX_CALCULATION_FIXTURES,
-  SubEventTypeEnum,
-} from "@badman/utils";
+import { SubEventTypeEnum } from "@badman/utils";
 import { Op } from "sequelize";
 import { IndexCalculationService } from "./index-calculation.service";
 import { IndexCalculationInput } from "./index-calculation.types";
@@ -32,7 +28,7 @@ const stubPlace = (
   single?: number,
   double_?: number,
   mix?: number,
-  rankingDate = new Date(`${SEASON}-05-15`)
+  rankingDate = new Date(SEASON, 4, 15) // May 15 of season — within validator cutoff
 ): RankingPlace =>
   ({
     playerId,
@@ -41,21 +37,20 @@ const stubPlace = (
     double: double_,
     mix,
     rankingDate,
-    updatePossible: true,
   }) as unknown as RankingPlace;
 
 const stubPlayer = (id: string, gender: "M" | "F" = "M"): Player =>
   ({ id, gender }) as unknown as Player;
 
 const stubSubEvent = (
+  type: SubEventTypeEnum = SubEventTypeEnum.M,
   ecOverrides?: Partial<EventCompetition>
 ): SubEventCompetition =>
   ({
     id: SUB_EVENT_ID,
+    eventType: type,
     eventCompetition: {
       season: SEASON,
-      usedRankingUnit: "months",
-      usedRankingAmount: 4,
       ...ecOverrides,
     } as unknown as EventCompetition,
   }) as unknown as SubEventCompetition;
@@ -81,62 +76,7 @@ describe("IndexCalculationService", () => {
   afterEach(() => jest.restoreAllMocks());
 
   // -------------------------------------------------------------------------
-  // T015: Fixture parity loop
-  // -------------------------------------------------------------------------
-  describe("parity with getIndexFromPlayers (INDEX_CALCULATION_FIXTURES)", () => {
-    for (const fixture of INDEX_CALCULATION_FIXTURES) {
-      // Skip fixtures where any player has no gender — without gender in the
-      // DB row those players would trigger PLAYER_NOT_FOUND at the service level.
-      const hasUngenderedPlayers = fixture.players.some(
-        (p) => !("gender" in p) || p.gender === undefined
-      );
-      if (hasUngenderedPlayers) {
-        test.skip(`${fixture.name} (skipped: un-gendered player)`, () => {});
-        continue;
-      }
-
-      test(fixture.name, async () => {
-        jest.spyOn(RankingSystem, "findOne").mockResolvedValue(
-          stubSystem({ amountOfLevels: fixture.defaultRanking ?? 12 })
-        );
-
-        const playerIds = fixture.players.map((_, idx) => `player-${idx}`);
-
-        // Gender always comes from the Player table.
-        jest.spyOn(Player, "findAll").mockResolvedValue(
-          fixture.players.map((p, idx) =>
-            stubPlayer(playerIds[idx], p.gender as "M" | "F")
-          )
-        );
-
-        const placeRows = fixture.players.map((p, idx) =>
-          stubPlace(playerIds[idx], p.single, p.double, p.mix)
-        );
-        jest.spyOn(RankingPlace, "findAll").mockResolvedValue(placeRows);
-
-        const result = await service.calculateOne({
-          key: "test-key",
-          type: fixture.type,
-          season: SEASON,
-          players: playerIds.map((id) => ({ id })),
-        });
-
-        expect(result._tag).toBe("success");
-        if (result._tag === "success") {
-          const helperExpected = getIndexFromPlayers(
-            fixture.type,
-            fixture.players,
-            fixture.defaultRanking
-          );
-          expect(result.index).toBe(helperExpected);
-          expect(result.index).toBe(fixture.expected);
-        }
-      });
-    }
-  });
-
-  // -------------------------------------------------------------------------
-  // calculate — top-level orchestration
+  // Top-level orchestration
   // -------------------------------------------------------------------------
   describe("calculate", () => {
     it("returns [] immediately without any DB call when inputs is empty", async () => {
@@ -146,8 +86,12 @@ describe("IndexCalculationService", () => {
       expect(findOneSpy).not.toHaveBeenCalled();
     });
 
-    it("returns RANKING_SYSTEM_NOT_FOUND for every input when primary system does not exist", async () => {
+    it("returns RANKING_SYSTEM_NOT_FOUND for every input when neither primary nor explicit system resolves", async () => {
       jest.spyOn(RankingSystem, "findOne").mockResolvedValue(null);
+      jest.spyOn(Player, "findAll").mockResolvedValue([
+        stubPlayer("player-k1"),
+        stubPlayer("player-k2"),
+      ]);
 
       const results = await service.calculate([minimalInput("k1"), minimalInput("k2")]);
 
@@ -168,8 +112,8 @@ describe("IndexCalculationService", () => {
       ]);
       jest.spyOn(RankingPlace, "findAll").mockResolvedValue([]);
 
-      const origCompute = (service as any).computeResult.bind(service);
-      jest.spyOn(service as any, "computeResult").mockImplementation(
+      const origCompute = (service as unknown as { computeResult: (...a: unknown[]) => unknown }).computeResult.bind(service);
+      jest.spyOn(service as unknown as { computeResult: jest.Mock }, "computeResult").mockImplementation(
         (...args: unknown[]) => {
           const input = args[0] as IndexCalculationInput;
           if (input.key === "boom") throw new Error("Simulated crash");
@@ -212,38 +156,247 @@ describe("IndexCalculationService", () => {
   });
 
   // -------------------------------------------------------------------------
-  // T016: Partial failure — missing player does not fail the batch
+  // Validator's cutoff rule: rankingDate <= June 10 of season
   // -------------------------------------------------------------------------
-  describe("partial failure does not fail the batch", () => {
-    it("returns Success for input[0] and PLAYER_NOT_FOUND for input[1]", async () => {
-      const goodId = "player-good-0000-0000-0000-000000000000";
-      const badId  = "player-bad--0000-0000-0000-000000000000";
-
+  describe("ranking-date cutoff", () => {
+    it("queries RankingPlace with rankingDate <= June 10 of season (validator's rule)", async () => {
       jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      // Only goodId is in the DB — badId is absent.
-      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer(goodId)]);
-      jest.spyOn(RankingPlace, "findAll").mockResolvedValue([stubPlace(goodId, 8, 8, 8)]);
+      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
+      const spy = jest.spyOn(RankingPlace, "findAll").mockResolvedValue([]);
 
-      const results = await service.calculate([
-        { key: "good", type: SubEventTypeEnum.M, season: SEASON, players: [{ id: goodId }] },
-        { key: "bad",  type: SubEventTypeEnum.M, season: SEASON, players: [{ id: badId }] },
+      await service.calculate([
+        { key: "k", type: SubEventTypeEnum.M, season: 2024, players: [{ id: "p1" }] },
       ]);
 
-      expect(results).toHaveLength(2);
-      expect(results[0]._tag).toBe("success");
-      expect(results[1]._tag).toBe("failure");
-      if (results[1]._tag === "failure") {
-        expect(results[1].error.code).toBe("PLAYER_NOT_FOUND");
-        expect(results[1].error.playerIds).toContain(badId);
+      expect(spy).toHaveBeenCalledTimes(1);
+      const args = spy.mock.calls[0][0] as {
+        where: { rankingDate: Record<symbol, Date> };
+      };
+      const lteSym = Object.getOwnPropertySymbols(args.where.rankingDate).find(
+        (s) => s === Op.lte
+      )!;
+      expect(lteSym).toBeDefined();
+      const cutoff = args.where.rankingDate[lteSym];
+      expect(cutoff.getFullYear()).toBe(2024);
+      expect(cutoff.getMonth()).toBe(5); // June (0-indexed)
+      expect(cutoff.getDate()).toBe(10);
+    });
+
+    it("does NOT filter by updatePossible (validator does not either)", async () => {
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
+      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
+      const spy = jest.spyOn(RankingPlace, "findAll").mockResolvedValue([]);
+
+      await service.calculate([
+        { key: "k", type: SubEventTypeEnum.M, season: SEASON, players: [{ id: "p1" }] },
+      ]);
+
+      const args = spy.mock.calls[0][0] as { where: Record<string, unknown> };
+      expect(args.where).not.toHaveProperty("updatePossible");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // min+2 fallback (validator parity)
+  // -------------------------------------------------------------------------
+  describe("validator-parity per-discipline fallback (min+2)", () => {
+    it("defaults all components to amountOfLevels+2 when no RankingPlace row exists", async () => {
+      const playerId = "player-norate-0000-0000-0000-000000000000";
+
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(
+        stubSystem({ amountOfLevels: 10 })
+      );
+      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer(playerId)]);
+      jest.spyOn(RankingPlace, "findAll").mockResolvedValue([]);
+
+      const result = await service.calculateOne({
+        key: "k",
+        type: SubEventTypeEnum.M,
+        season: SEASON,
+        players: [{ id: playerId }],
+      });
+
+      expect(result._tag).toBe("success");
+      if (result._tag === "success") {
+        // min(10,10,10)+2 = 12 per discipline
+        expect(result.contributingPlayers[0].single).toBe(12);
+        expect(result.contributingPlayers[0].double).toBe(12);
+        expect(result.contributingPlayers[0].mix).toBe(12);
+      }
+    });
+
+    it("fills missing components with min(s,d,m)+2 when at least one component is rated", async () => {
+      const playerId = "p1";
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
+      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer(playerId)]);
+      jest.spyOn(RankingPlace, "findAll").mockResolvedValue([
+        // single=4 only; double / mix missing
+        stubPlace(playerId, 4, undefined, undefined),
+      ]);
+
+      const result = await service.calculateOne({
+        key: "k",
+        type: SubEventTypeEnum.M,
+        season: SEASON,
+        players: [{ id: playerId }],
+      });
+
+      expect(result._tag).toBe("success");
+      if (result._tag === "success") {
+        // min(4, 12, 12) + 2 = 6 → double and mix become 6
+        expect(result.contributingPlayers[0].single).toBe(4);
+        expect(result.contributingPlayers[0].double).toBe(6);
+        expect(result.contributingPlayers[0].mix).toBe(6);
       }
     });
   });
 
   // -------------------------------------------------------------------------
-  // T017: Snapshot dedupe — one RankingPlace.findAll per season
+  // Sub-event derivation
+  // -------------------------------------------------------------------------
+  describe("type / season derivation from sub-event", () => {
+    it("derives type and season from SubEventCompetition when caller omits them", async () => {
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
+      jest.spyOn(SubEventCompetition, "findAll").mockResolvedValue([
+        stubSubEvent(SubEventTypeEnum.MX, { season: 2024 }),
+      ]);
+      jest.spyOn(Player, "findAll").mockResolvedValue([
+        stubPlayer("p1", "M"),
+        stubPlayer("p2", "F"),
+      ]);
+      const placeSpy = jest.spyOn(RankingPlace, "findAll").mockResolvedValue([
+        stubPlace("p1", 6, 6, 6),
+        stubPlace("p2", 6, 6, 6),
+      ]);
+
+      const result = await service.calculateOne({
+        key: "k",
+        subEventCompetitionId: SUB_EVENT_ID,
+        players: [{ id: "p1" }, { id: "p2" }],
+        // type + season intentionally omitted
+      });
+
+      expect(result._tag).toBe("success");
+      // Cutoff on June 10 2024 — derived from sub-event's EventCompetition.season
+      const args = placeSpy.mock.calls[0][0] as {
+        where: { rankingDate: Record<symbol, Date> };
+      };
+      const lteSym = Object.getOwnPropertySymbols(args.where.rankingDate).find(
+        (s) => s === Op.lte
+      )!;
+      const cutoff = args.where.rankingDate[lteSym];
+      expect(cutoff.getFullYear()).toBe(2024);
+      expect(cutoff.getMonth()).toBe(5);
+      expect(cutoff.getDate()).toBe(10);
+    });
+
+    it("returns SUB_EVENT_NOT_FOUND when subEventCompetitionId does not resolve", async () => {
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
+      jest.spyOn(SubEventCompetition, "findAll").mockResolvedValue([]);
+      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
+
+      const result = await service.calculateOne({
+        key: "k",
+        subEventCompetitionId: SUB_EVENT_ID,
+        players: [{ id: "p1" }],
+      });
+
+      expect(result._tag).toBe("failure");
+      if (result._tag === "failure") {
+        expect(result.error.code).toBe("SUB_EVENT_NOT_FOUND");
+      }
+    });
+
+    it("returns MISSING_TYPE_OR_SEASON when caller omits both AND no sub-event provided", async () => {
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
+      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
+
+      const result = await service.calculateOne({
+        key: "k",
+        players: [{ id: "p1" }],
+      });
+
+      expect(result._tag).toBe("failure");
+      if (result._tag === "failure") {
+        expect(result.error.code).toBe("MISSING_TYPE_OR_SEASON");
+      }
+    });
+
+    it("explicit type/season override the sub-event-derived values", async () => {
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
+      jest.spyOn(SubEventCompetition, "findAll").mockResolvedValue([
+        stubSubEvent(SubEventTypeEnum.M, { season: 2020 }),
+      ]);
+      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
+      const placeSpy = jest.spyOn(RankingPlace, "findAll").mockResolvedValue([]);
+
+      await service.calculateOne({
+        key: "k",
+        type: SubEventTypeEnum.MX,
+        season: 2024,
+        subEventCompetitionId: SUB_EVENT_ID,
+        players: [{ id: "p1" }],
+      });
+
+      const args = placeSpy.mock.calls[0][0] as {
+        where: { rankingDate: Record<symbol, Date> };
+      };
+      const lteSym = Object.getOwnPropertySymbols(args.where.rankingDate).find(
+        (s) => s === Op.lte
+      )!;
+      // explicit season = 2024 wins, not sub-event's 2020
+      expect(args.where.rankingDate[lteSym].getFullYear()).toBe(2024);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // System resolution
+  // -------------------------------------------------------------------------
+  describe("ranking system resolution", () => {
+    it("uses primary system when input.systemId is omitted", async () => {
+      const findOneSpy = jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
+      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
+      const placeSpy = jest.spyOn(RankingPlace, "findAll").mockResolvedValue([]);
+
+      await service.calculateOne({
+        key: "k",
+        type: SubEventTypeEnum.M,
+        season: SEASON,
+        players: [{ id: "p1" }],
+      });
+
+      expect(findOneSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { primary: true } })
+      );
+      const args = placeSpy.mock.calls[0][0] as { where: { systemId: string } };
+      expect(args.where.systemId).toBe(SYSTEM_ID);
+    });
+
+    it("honors caller-supplied input.systemId, falling back to primary if not found", async () => {
+      const otherSystem = stubSystem({ id: "other-system", primary: false });
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem()); // primary
+      jest.spyOn(RankingSystem, "findAll").mockResolvedValue([otherSystem]);
+      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
+      const placeSpy = jest.spyOn(RankingPlace, "findAll").mockResolvedValue([]);
+
+      await service.calculateOne({
+        key: "k",
+        type: SubEventTypeEnum.M,
+        season: SEASON,
+        systemId: "other-system",
+        players: [{ id: "p1" }],
+      });
+
+      const args = placeSpy.mock.calls[0][0] as { where: { systemId: string } };
+      expect(args.where.systemId).toBe("other-system");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Snapshot dedupe
   // -------------------------------------------------------------------------
   describe("snapshot dedupe", () => {
-    it("calls RankingPlace.findAll once when three inputs share the same season", async () => {
+    it("calls RankingPlace.findAll once when three inputs share the same (system, season)", async () => {
       jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
       jest.spyOn(Player, "findAll").mockResolvedValue([
         stubPlayer("p1"), stubPlayer("p2"), stubPlayer("p3"),
@@ -276,35 +429,6 @@ describe("IndexCalculationService", () => {
   });
 
   // -------------------------------------------------------------------------
-  // buildBroadWindow — date boundaries verified via findAll call args
-  // -------------------------------------------------------------------------
-  describe("buildBroadWindow", () => {
-    it("uses Jan 1 as start and Dec 31 as end of the given season", async () => {
-      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
-      const spy = jest.spyOn(RankingPlace, "findAll").mockResolvedValue([]);
-
-      await service.calculate([
-        { key: "k", type: SubEventTypeEnum.M, season: 2024, players: [{ id: "p1" }] },
-      ]);
-
-      expect(spy).toHaveBeenCalledTimes(1);
-      const args = spy.mock.calls[0][0] as {
-        where: { rankingDate: Record<symbol, [Date, Date]> };
-      };
-      const [start, end] = args.where.rankingDate[Op.between];
-
-      expect(start.getFullYear()).toBe(2024);
-      expect(start.getMonth()).toBe(0);  // January
-      expect(start.getDate()).toBe(1);
-
-      expect(end.getFullYear()).toBe(2024);
-      expect(end.getMonth()).toBe(11); // December
-      expect(end.getDate()).toBe(31);
-    });
-  });
-
-  // -------------------------------------------------------------------------
   // fetchPlaceMap dedup: most-recent row per player kept
   // -------------------------------------------------------------------------
   describe("fetchPlaceMap dedup", () => {
@@ -314,8 +438,8 @@ describe("IndexCalculationService", () => {
       jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
       jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer(playerId)]);
 
-      const newer = stubPlace(playerId, 4, 4, 4, new Date(`${SEASON}-06-01`));
-      const older = stubPlace(playerId, 8, 8, 8, new Date(`${SEASON}-03-01`));
+      const newer = stubPlace(playerId, 4, 4, 4, new Date(SEASON, 5, 5)); // June 5
+      const older = stubPlace(playerId, 8, 8, 8, new Date(SEASON, 2, 1)); // March 1
       jest.spyOn(RankingPlace, "findAll").mockResolvedValue([newer, older]);
 
       const result = await service.calculateOne({
@@ -334,8 +458,33 @@ describe("IndexCalculationService", () => {
   });
 
   // -------------------------------------------------------------------------
-  // resolveGenders
+  // PLAYER_NOT_FOUND
   // -------------------------------------------------------------------------
+  describe("partial failure does not fail the batch", () => {
+    it("returns Success for input[0] and PLAYER_NOT_FOUND for input[1]", async () => {
+      const goodId = "player-good-0000-0000-0000-000000000000";
+      const badId  = "player-bad--0000-0000-0000-000000000000";
+
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
+      // Only goodId is in the DB — badId is absent.
+      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer(goodId)]);
+      jest.spyOn(RankingPlace, "findAll").mockResolvedValue([stubPlace(goodId, 8, 8, 8)]);
+
+      const results = await service.calculate([
+        { key: "good", type: SubEventTypeEnum.M, season: SEASON, players: [{ id: goodId }] },
+        { key: "bad",  type: SubEventTypeEnum.M, season: SEASON, players: [{ id: badId }] },
+      ]);
+
+      expect(results).toHaveLength(2);
+      expect(results[0]._tag).toBe("success");
+      expect(results[1]._tag).toBe("failure");
+      if (results[1]._tag === "failure") {
+        expect(results[1].error.code).toBe("PLAYER_NOT_FOUND");
+        expect(results[1].error.playerIds).toContain(badId);
+      }
+    });
+  });
+
   describe("resolveGenders", () => {
     it("does not call Player.findAll when the input player list is empty", async () => {
       jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
@@ -370,52 +519,12 @@ describe("IndexCalculationService", () => {
         expect(result.error.code).toBe("PLAYER_NOT_FOUND");
       }
     });
-
-    it("returns PLAYER_NOT_FOUND when a player is entirely absent from the DB", async () => {
-      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(Player, "findAll").mockResolvedValue([]);
-      jest.spyOn(RankingPlace, "findAll").mockResolvedValue([]);
-
-      const result = await service.calculateOne({
-        key: "k",
-        type: SubEventTypeEnum.M,
-        season: SEASON,
-        players: [{ id: "ghost-player-id" }],
-      });
-
-      expect(result._tag).toBe("failure");
-      if (result._tag === "failure") {
-        expect(result.error.code).toBe("PLAYER_NOT_FOUND");
-      }
-    });
   });
 
   // -------------------------------------------------------------------------
-  // computeResult — per-player default fill
+  // missingPlayerCount
   // -------------------------------------------------------------------------
-  describe("computeResult — default fill", () => {
-    it("defaults all components to amountOfLevels when no RankingPlace row exists for a player", async () => {
-      const playerId = "player-norate-0000-0000-000000000000";
-
-      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem({ amountOfLevels: 10 }));
-      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer(playerId)]);
-      jest.spyOn(RankingPlace, "findAll").mockResolvedValue([]);
-
-      const result = await service.calculateOne({
-        key: "k",
-        type: SubEventTypeEnum.M,
-        season: SEASON,
-        players: [{ id: playerId }],
-      });
-
-      expect(result._tag).toBe("success");
-      if (result._tag === "success") {
-        expect(result.contributingPlayers[0].single).toBe(10);
-        expect(result.contributingPlayers[0].double).toBe(10);
-        expect(result.contributingPlayers[0].mix).toBe(10);
-      }
-    });
-
+  describe("computeResult — missing-player count", () => {
     it("sets missingPlayerCount to max(0, 4 − contributingPlayers.length)", async () => {
       jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
       jest.spyOn(Player, "findAll").mockResolvedValue([
@@ -442,235 +551,13 @@ describe("IndexCalculationService", () => {
   });
 
   // -------------------------------------------------------------------------
-  // fetchSubEventWindow — all branches
+  // RankingPlace fetch failure tolerance
   // -------------------------------------------------------------------------
-  describe("fetchSubEventWindow (via subEventCompetitionId)", () => {
-    it("returns SUB_EVENT_NOT_FOUND when SubEventCompetition does not exist", async () => {
-      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
-      jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(null);
-
-      const result = await service.calculateOne({
-        key: "k",
-        type: SubEventTypeEnum.M,
-        season: SEASON,
-        subEventCompetitionId: SUB_EVENT_ID,
-        players: [{ id: "p1" }],
-      });
-
-      expect(result._tag).toBe("failure");
-      if (result._tag === "failure") {
-        expect(result.error.code).toBe("SUB_EVENT_NOT_FOUND");
-      }
-    });
-
-    it("returns SUB_EVENT_NOT_FOUND when SubEventCompetition has no linked EventCompetition", async () => {
-      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
-      jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(
-        { id: SUB_EVENT_ID, eventCompetition: null } as unknown as SubEventCompetition
+  describe("RankingPlace fetch error", () => {
+    it("falls back to default-fill (amountOfLevels+2) when RankingPlace.findAll throws", async () => {
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(
+        stubSystem({ amountOfLevels: 12 })
       );
-
-      const result = await service.calculateOne({
-        key: "k",
-        type: SubEventTypeEnum.M,
-        season: SEASON,
-        subEventCompetitionId: SUB_EVENT_ID,
-        players: [{ id: "p1" }],
-      });
-
-      expect(result._tag).toBe("failure");
-      if (result._tag === "failure") {
-        expect(result.error.code).toBe("SUB_EVENT_NOT_FOUND");
-      }
-    });
-
-    it("returns INTERNAL_ERROR when EventCompetition is missing usedRankingUnit", async () => {
-      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
-      jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(
-        stubSubEvent({ usedRankingUnit: undefined as unknown as "months" })
-      );
-
-      const result = await service.calculateOne({
-        key: "k",
-        type: SubEventTypeEnum.M,
-        season: SEASON,
-        subEventCompetitionId: SUB_EVENT_ID,
-        players: [{ id: "p1" }],
-      });
-
-      expect(result._tag).toBe("failure");
-      if (result._tag === "failure") {
-        expect(result.error.code).toBe("INTERNAL_ERROR");
-      }
-    });
-
-    it("returns INTERNAL_ERROR when EventCompetition is missing usedRankingAmount", async () => {
-      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
-      jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(
-        stubSubEvent({ usedRankingAmount: null as unknown as number })
-      );
-
-      const result = await service.calculateOne({
-        key: "k",
-        type: SubEventTypeEnum.M,
-        season: SEASON,
-        subEventCompetitionId: SUB_EVENT_ID,
-        players: [{ id: "p1" }],
-      });
-
-      expect(result._tag).toBe("failure");
-      if (result._tag === "failure") {
-        expect(result.error.code).toBe("INTERNAL_ERROR");
-      }
-    });
-
-    it("returns RANKING_FETCH_FAILED when RankingPlace.findAll throws in the sub-event path", async () => {
-      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
-      jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(stubSubEvent());
-      jest.spyOn(RankingPlace, "findAll").mockRejectedValue(new Error("DB error"));
-
-      const result = await service.calculateOne({
-        key: "k",
-        type: SubEventTypeEnum.M,
-        season: SEASON,
-        subEventCompetitionId: SUB_EVENT_ID,
-        players: [{ id: "p1" }],
-      });
-
-      expect(result._tag).toBe("failure");
-      if (result._tag === "failure") {
-        expect(result.error.code).toBe("RANKING_FETCH_FAILED");
-      }
-    });
-
-    it("uses the precise snapshot window from EventCompetition when subEventCompetitionId is supplied (months unit)", async () => {
-      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
-      // usedRankingUnit="months", usedRankingAmount=4 → May 2024
-      jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(
-        stubSubEvent({ season: 2024, usedRankingUnit: "months", usedRankingAmount: 4 })
-      );
-      const spy = jest.spyOn(RankingPlace, "findAll").mockResolvedValue([]);
-
-      await service.calculateOne({
-        key: "k",
-        type: SubEventTypeEnum.M,
-        season: SEASON,
-        subEventCompetitionId: SUB_EVENT_ID,
-        players: [{ id: "p1" }],
-      });
-
-      expect(spy).toHaveBeenCalledTimes(1);
-      const args = spy.mock.calls[0][0] as {
-        where: { rankingDate: Record<symbol, [Date, Date]> };
-      };
-      const [start, end] = args.where.rankingDate[Op.between];
-
-      // start widened 1 year back: startOfMonth(May 2023)
-      expect(start.getFullYear()).toBe(2023);
-      expect(start.getMonth()).toBe(4); // May
-      expect(start.getDate()).toBe(1);
-
-      // end = last day of May 2024
-      expect(end.getFullYear()).toBe(2024);
-      expect(end.getMonth()).toBe(4); // May
-      expect(end.getDate()).toBe(31);
-    });
-
-    it("builds a weeks-based window when usedRankingUnit is 'weeks'", async () => {
-      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
-      // week 20 of 2024 falls in May
-      jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(
-        stubSubEvent({ season: 2024, usedRankingUnit: "weeks", usedRankingAmount: 20 })
-      );
-      const spy = jest.spyOn(RankingPlace, "findAll").mockResolvedValue([]);
-
-      await service.calculateOne({
-        key: "k",
-        type: SubEventTypeEnum.M,
-        season: SEASON,
-        subEventCompetitionId: SUB_EVENT_ID,
-        players: [{ id: "p1" }],
-      });
-
-      const args = spy.mock.calls[0][0] as {
-        where: { rankingDate: Record<symbol, [Date, Date]> };
-      };
-      const [start, end] = args.where.rankingDate[Op.between];
-
-      // week 20 of 2024 is in May → window widened to [May 1 2023, May 31 2024]
-      expect(start.getFullYear()).toBe(2023);
-      expect(start.getMonth()).toBe(4); // May
-      expect(start.getDate()).toBe(1);
-      expect(end.getFullYear()).toBe(2024);
-      expect(end.getMonth()).toBe(4); // May
-      expect(end.getDate()).toBe(31);
-    });
-
-    it("falls back to the prior-year snapshot when the precise month has no rows", async () => {
-      const playerId = "p1";
-      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer(playerId)]);
-      // Upcoming season 2026, May target — no May 2026 rows yet, only May 2025.
-      jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(
-        stubSubEvent({ season: 2026, usedRankingUnit: "months", usedRankingAmount: 4 })
-      );
-      const priorYearPlace = stubPlace(playerId, 7, 7, 12);
-      // Make rankingDate explicit so the test pins the prior-year semantics.
-      (priorYearPlace as unknown as { rankingDate: Date }).rankingDate = new Date(2025, 4, 5);
-      jest.spyOn(RankingPlace, "findAll").mockResolvedValue([priorYearPlace]);
-
-      const result = await service.calculateOne({
-        key: "k",
-        type: SubEventTypeEnum.M,
-        season: 2026,
-        subEventCompetitionId: SUB_EVENT_ID,
-        players: [{ id: playerId }],
-      });
-
-      expect(result._tag).toBe("success");
-      if (result._tag === "success") {
-        expect(result.contributingPlayers[0].single).toBe(7);
-        expect(result.contributingPlayers[0].double).toBe(7);
-      }
-    });
-
-    it("returns a successful result using the precise window", async () => {
-      const playerId = "p1";
-      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer(playerId)]);
-      jest.spyOn(SubEventCompetition, "findByPk").mockResolvedValue(stubSubEvent());
-      jest.spyOn(RankingPlace, "findAll").mockResolvedValue([
-        stubPlace(playerId, 6, 6, 12),
-      ]);
-
-      const result = await service.calculateOne({
-        key: "k",
-        type: SubEventTypeEnum.M,
-        season: SEASON,
-        subEventCompetitionId: SUB_EVENT_ID,
-        players: [{ id: playerId }],
-      });
-
-      expect(result._tag).toBe("success");
-      if (result._tag === "success") {
-        expect(result.contributingPlayers[0].single).toBe(6);
-        expect(result.contributingPlayers[0].double).toBe(6);
-      }
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // fetchBroadPlaceMaps — DB error path
-  // -------------------------------------------------------------------------
-  describe("fetchBroadPlaceMaps DB error", () => {
-    it("falls back to default-fill (amountOfLevels) when RankingPlace.findAll throws", async () => {
-      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem({ amountOfLevels: 12 }));
       jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
       jest.spyOn(RankingPlace, "findAll").mockRejectedValue(new Error("DB timeout"));
 
@@ -681,10 +568,67 @@ describe("IndexCalculationService", () => {
         players: [{ id: "p1" }],
       });
 
-      // No crash — all components default to amountOfLevels = 12.
+      // No crash — all components default to amountOfLevels+2 = 14.
       expect(result._tag).toBe("success");
       if (result._tag === "success") {
-        expect(result.contributingPlayers[0].single).toBe(12);
+        expect(result.contributingPlayers[0].single).toBe(14);
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // End-to-end parity with validator on a representative case
+  // -------------------------------------------------------------------------
+  describe("validator parity", () => {
+    it("M team, 4 ranked players: matches validator's baseIndex computation", async () => {
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
+      jest.spyOn(Player, "findAll").mockResolvedValue([
+        stubPlayer("p1"), stubPlayer("p2"), stubPlayer("p3"), stubPlayer("p4"),
+      ]);
+      jest.spyOn(RankingPlace, "findAll").mockResolvedValue([
+        stubPlace("p1", 5, 5, 7),
+        stubPlace("p2", 6, 6, 8),
+        stubPlace("p3", 7, 7, 9),
+        stubPlace("p4", 8, 8, 10),
+      ]);
+
+      const result = await service.calculateOne({
+        key: "k",
+        type: SubEventTypeEnum.M,
+        season: SEASON,
+        players: [{ id: "p1" }, { id: "p2" }, { id: "p3" }, { id: "p4" }],
+      });
+
+      expect(result._tag).toBe("success");
+      // (5+5)+(6+6)+(7+7)+(8+8) = 52 — same as the validator's M-team baseIndex test.
+      if (result._tag === "success") {
+        expect(result.index).toBe(52);
+      }
+    });
+
+    it("M team, one unranked player: matches validator's min+2 fallback", async () => {
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
+      jest.spyOn(Player, "findAll").mockResolvedValue([
+        stubPlayer("p1"), stubPlayer("p2"), stubPlayer("p3"), stubPlayer("p4"),
+      ]);
+      jest.spyOn(RankingPlace, "findAll").mockResolvedValue([
+        stubPlace("p1", 5, 5, 7),
+        stubPlace("p2", 6, 6, 8),
+        stubPlace("p3", 7, 7, 9),
+        // p4: no row
+      ]);
+
+      const result = await service.calculateOne({
+        key: "k",
+        type: SubEventTypeEnum.M,
+        season: SEASON,
+        players: [{ id: "p1" }, { id: "p2" }, { id: "p3" }, { id: "p4" }],
+      });
+
+      expect(result._tag).toBe("success");
+      if (result._tag === "success") {
+        // Same setup as validator's "Player without RankingPlace falls back…" test → 64
+        expect(result.index).toBe(64);
       }
     });
   });

--- a/libs/backend/competition/enrollment/src/services/index-calculation/index-calculation.service.ts
+++ b/libs/backend/competition/enrollment/src/services/index-calculation/index-calculation.service.ts
@@ -1,13 +1,17 @@
 import {
-  EventCompetition,
   Player,
   RankingPlace,
   RankingSystem,
   SubEventCompetition,
 } from "@badman/backend-database";
-import { getBestPlayersFromTeam, getIndexFromPlayers, IndexPlayer } from "@badman/utils";
+import {
+  getBestPlayersFromTeam,
+  getIndexFromPlayers,
+  IndexPlayer,
+  SubEventTypeEnum,
+} from "@badman/utils";
 import { Injectable, Logger } from "@nestjs/common";
-import { endOfMonth, setDay, setMonth, setWeek, startOfMonth, subYears } from "date-fns";
+import moment from "moment";
 import { Op, Transaction } from "sequelize";
 import {
   IndexCalculationContributingPlayer,
@@ -17,6 +21,24 @@ import {
   IndexCalculationSuccess,
 } from "./index-calculation.types";
 
+/**
+ * Resolves a team's strength index using the EnrollmentValidationService's
+ * canonical rule:
+ *
+ *   • RankingPlace.rankingDate <= moment([season, 5, 10]).toDate()
+ *     (June 10 of season; moment month is 0-indexed)
+ *   • ORDER BY rankingDate DESC, keep the first row per player
+ *   • No `updatePossible` filter — both confirmed and in-progress rows count,
+ *     same as the validator.
+ *   • Missing per-discipline values fall back to
+ *     `min(single, double, mix) + 2` (validator's "min+2" penalty).
+ *     A player with no RankingPlace at all therefore gets
+ *     `amountOfLevels + 2` per discipline.
+ *
+ * `subEventCompetitionId` does NOT influence the cutoff — it is consulted only
+ * to derive `type` (M / F / MX / NATIONAL) and/or `season` when the caller
+ * does not pass them.
+ */
 @Injectable()
 export class IndexCalculationService {
   private readonly logger = new Logger(IndexCalculationService.name);
@@ -34,58 +56,204 @@ export class IndexCalculationService {
       return [];
     }
 
-    // Step 1: Resolve the primary ranking system (shared across all inputs).
-    const sys = await this.resolvePrimarySystem(options?.transaction);
-    if (!sys) {
-      return inputs.map((i) =>
-        failure(i.key, "RANKING_SYSTEM_NOT_FOUND", "Primary ranking system not configured.")
-      );
+    // Step 1: Derive missing type/season from sub-events (one batched lookup).
+    const subEventIds = [
+      ...new Set(
+        inputs
+          .map((i) => i.subEventCompetitionId)
+          .filter((id): id is string => !!id)
+      ),
+    ];
+    let subEventMap = new Map<
+      string,
+      { eventType: SubEventTypeEnum; season: number }
+    >();
+    if (subEventIds.length > 0) {
+      try {
+        const subEvents = await SubEventCompetition.findAll({
+          where: { id: subEventIds },
+          attributes: ["id", "eventType"],
+          include: [{ association: "eventCompetition", attributes: ["season"] }],
+          transaction: options?.transaction,
+        });
+        for (const se of subEvents) {
+          const season = se.eventCompetition?.season;
+          if (se.eventType && season != null) {
+            subEventMap.set(se.id, { eventType: se.eventType, season });
+          }
+        }
+      } catch (err) {
+        this.logger.error(
+          { subEventIds },
+          err instanceof Error ? err.stack : String(err)
+        );
+        // Fall through; per-input failure surfaces below.
+      }
     }
 
-    // Step 2: Batch-resolve gender for all players across all inputs.
-    const allPlayerIds = [...new Set(inputs.flatMap((i) => i.players.map((p) => p.id)))];
+    // Step 2: Resolve per-input metadata (type, season, systemId).
+    interface ResolvedInput {
+      input: IndexCalculationInput;
+      type: SubEventTypeEnum;
+      season: number;
+      systemId?: string;
+    }
+    const resolved: (ResolvedInput | IndexCalculationFailure)[] = inputs.map(
+      (input) => {
+        let type = input.type;
+        let season = input.season;
+        if (input.subEventCompetitionId) {
+          const se = subEventMap.get(input.subEventCompetitionId);
+          if (!se) {
+            return failure(
+              input.key,
+              "SUB_EVENT_NOT_FOUND",
+              `SubEventCompetition not found or has no linked EventCompetition: ${input.subEventCompetitionId}`
+            );
+          }
+          type = type ?? se.eventType;
+          season = season ?? se.season;
+        }
+        if (!type || season == null) {
+          return failure(
+            input.key,
+            "MISSING_TYPE_OR_SEASON",
+            "Input is missing `type` and/or `season`. Provide them directly or via `subEventCompetitionId`."
+          );
+        }
+        return { input, type, season, systemId: input.systemId };
+      }
+    );
+
+    // Step 3: Resolve ranking systems (caller-supplied or primary).
+    const systemIds = [
+      ...new Set(
+        resolved
+          .filter((r): r is ResolvedInput => !("_tag" in r))
+          .map((r) => r.systemId)
+          .filter((id): id is string => !!id)
+      ),
+    ];
+    let primarySystem: RankingSystem | null = null;
+    const systemById = new Map<string, RankingSystem>();
+    try {
+      // Always need primary as a fallback for inputs that did not specify a system.
+      primarySystem = await RankingSystem.findOne({
+        where: { primary: true },
+        transaction: options?.transaction,
+      });
+      if (primarySystem) systemById.set(primarySystem.id, primarySystem);
+
+      if (systemIds.length > 0) {
+        const explicit = await RankingSystem.findAll({
+          where: { id: systemIds },
+          transaction: options?.transaction,
+        });
+        for (const s of explicit) systemById.set(s.id, s);
+      }
+    } catch (err) {
+      this.logger.error(err instanceof Error ? err.stack : String(err));
+    }
+
+    // Step 4: Batch-resolve gender for all players across all inputs.
+    const allPlayerIds = [
+      ...new Set(inputs.flatMap((i) => i.players.map((p) => p.id))),
+    ];
     const { genderMap, notFoundIds } = await this.resolveGenders(
       allPlayerIds,
       options?.transaction
     );
 
-    // Step 3: Batch-fetch RankingPlace rows for inputs that don't specify a sub-event.
-    //         Group by season so we issue one DB query per unique season.
-    const broadPlaceMaps = await this.fetchBroadPlaceMaps(
-      inputs.filter((i) => !i.subEventCompetitionId),
-      sys.id,
-      options?.transaction
-    );
-
-    // Step 4: Process each input.
-    const results: IndexCalculationResult[] = [];
-
-    for (const input of inputs) {
+    // Step 5: Group RankingPlace fetches by (systemId, season). One DB call per group.
+    interface FetchKey {
+      systemId: string;
+      season: number;
+    }
+    const fetchKeyOf = (k: FetchKey) => `${k.systemId}::${k.season}`;
+    const groups = new Map<
+      string,
+      { key: FetchKey; playerIds: Set<string> }
+    >();
+    const inputSystemId = new Map<string, string>(); // input.key -> systemId chosen
+    for (const r of resolved) {
+      if ("_tag" in r) continue;
+      const sys =
+        (r.systemId ? systemById.get(r.systemId) : null) ?? primarySystem;
+      if (!sys) continue; // failure handled below
+      inputSystemId.set(r.input.key, sys.id);
+      const k = fetchKeyOf({ systemId: sys.id, season: r.season });
+      const g = groups.get(k);
+      if (g) {
+        for (const p of r.input.players) g.playerIds.add(p.id);
+      } else {
+        groups.set(k, {
+          key: { systemId: sys.id, season: r.season },
+          playerIds: new Set(r.input.players.map((p) => p.id)),
+        });
+      }
+    }
+    const placeMaps = new Map<string, Map<string, RankingPlace>>();
+    for (const [k, g] of groups) {
       try {
-        let placeMap: Map<string, RankingPlace>;
-
-        if (input.subEventCompetitionId) {
-          const windowResult = await this.fetchSubEventWindow(
-            input.subEventCompetitionId,
-            input.players.map((p) => p.id),
-            sys.id,
+        placeMaps.set(
+          k,
+          await this.fetchPlaceMap(
+            [...g.playerIds],
+            g.key.systemId,
+            g.key.season,
             options?.transaction
-          );
-          if ("_tag" in windowResult && windowResult._tag === "failure") {
-            results.push(windowResult as IndexCalculationFailure);
-            continue;
-          }
-          placeMap = windowResult as Map<string, RankingPlace>;
-        } else {
-          placeMap = broadPlaceMaps.get(input.season) ?? new Map();
-        }
-
-        results.push(
-          this.computeResult(input, placeMap, genderMap, notFoundIds, sys.amountOfLevels ?? 12)
+          )
         );
       } catch (err) {
-        this.logger.error({ key: input.key }, err instanceof Error ? err.stack : String(err));
-        results.push(failure(input.key, "INTERNAL_ERROR", "Unexpected error processing input."));
+        this.logger.error(
+          { systemId: g.key.systemId, season: g.key.season },
+          err instanceof Error ? err.stack : String(err)
+        );
+        placeMaps.set(k, new Map()); // fall through to default-fill
+      }
+    }
+
+    // Step 6: Process each input.
+    const results: IndexCalculationResult[] = [];
+    for (const r of resolved) {
+      if ("_tag" in r) {
+        results.push(r);
+        continue;
+      }
+      const sysId = inputSystemId.get(r.input.key);
+      const sys = sysId ? systemById.get(sysId) : null;
+      if (!sys) {
+        results.push(
+          failure(
+            r.input.key,
+            "RANKING_SYSTEM_NOT_FOUND",
+            "No primary ranking system configured and no explicit systemId resolved."
+          )
+        );
+        continue;
+      }
+      const placeMap =
+        placeMaps.get(fetchKeyOf({ systemId: sys.id, season: r.season })) ??
+        new Map<string, RankingPlace>();
+      try {
+        results.push(
+          this.computeResult(
+            r.input,
+            r.type,
+            placeMap,
+            genderMap,
+            notFoundIds,
+            sys.amountOfLevels ?? 12
+          )
+        );
+      } catch (err) {
+        this.logger.error(
+          { key: r.input.key },
+          err instanceof Error ? err.stack : String(err)
+        );
+        results.push(
+          failure(r.input.key, "INTERNAL_ERROR", "Unexpected error processing input.")
+        );
       }
     }
 
@@ -105,75 +273,29 @@ export class IndexCalculationService {
   // Private helpers
   // ---------------------------------------------------------------------------
 
-  private async resolvePrimarySystem(transaction?: Transaction): Promise<RankingSystem | null> {
-    return RankingSystem.findOne({
-      where: { primary: true },
-      transaction,
-    });
-  }
-
-  /** Calendar-year broad window: Jan 1 → Dec 31 of the given season. */
-  private buildBroadWindow(season: number): { start: Date; end: Date } {
-    const start = new Date(season, 0, 1);
-    const end = endOfMonth(new Date(season, 11, 1));
-    return { start, end };
-  }
-
   /**
-   * Derives the precise snapshot window from an EventCompetition, mirroring
-   * the logic in entry.model.ts (recalculateCompetitionIndex).
+   * Validator's exact rule: most-recent RankingPlace per player whose
+   * `rankingDate` is <= June 10 of `season`.
    */
-  private buildPreciseWindow(ec: {
-    season: number;
-    usedRankingUnit: string;
-    usedRankingAmount: number;
-  }): { start: Date; end: Date } {
-    // Mirror assembly.service.ts: moment().set("year", season).set(unit, amount).startOf/endOfMonth
-    let refDate = new Date(ec.season, 0, 1);
-    switch (ec.usedRankingUnit) {
-      case "months":
-        refDate = setMonth(refDate, ec.usedRankingAmount);
-        break;
-      case "weeks":
-        refDate = setWeek(refDate, ec.usedRankingAmount);
-        break;
-      case "days":
-        refDate = setDay(refDate, ec.usedRankingAmount);
-        break;
-      default:
-        refDate = setMonth(refDate, ec.usedRankingAmount);
-    }
-    const end = endOfMonth(refDate);
-    // Widen 1 year back so an upcoming-season enrollment can fall through to
-    // last season's snapshot when this season's federation snapshot has not
-    // yet been published. fetchPlaceMap orders DESC and keeps the most recent
-    // row per player — fresher data wins automatically when it exists.
-    const start = startOfMonth(subYears(refDate, 1));
-    return { start, end };
-  }
-
   private async fetchPlaceMap(
     playerIds: string[],
     systemId: string,
-    window: { start: Date; end: Date },
+    season: number,
     transaction?: Transaction
   ): Promise<Map<string, RankingPlace>> {
     if (playerIds.length === 0) return new Map();
 
+    const cutoff = moment([season, 5, 10]).toDate();
     const rows = await RankingPlace.findAll({
       where: {
         playerId: playerIds,
         systemId,
-        rankingDate: { [Op.between]: [window.start, window.end] },
-        // updatePossible: true means the row is confirmed/final (not an in-progress
-        // recalculation). Only confirmed rows are valid as ranking snapshots.
-        updatePossible: true,
+        rankingDate: { [Op.lte]: cutoff },
       },
       order: [["rankingDate", "DESC"]],
       transaction,
     });
 
-    // Keep most-recent row per player (DESC order gives first hit per player).
     const map = new Map<string, RankingPlace>();
     for (const row of rows) {
       if (row.playerId && !map.has(row.playerId)) {
@@ -181,123 +303,6 @@ export class IndexCalculationService {
       }
     }
     return map;
-  }
-
-  /** Batch-fetch broad place maps, one DB call per unique season. */
-  private async fetchBroadPlaceMaps(
-    inputs: IndexCalculationInput[],
-    systemId: string,
-    transaction?: Transaction
-  ): Promise<Map<number, Map<string, RankingPlace>>> {
-    const bySeasonResult = new Map<number, Map<string, RankingPlace>>();
-
-    const seasonToPlayerIds = new Map<number, string[]>();
-    for (const input of inputs) {
-      if (!seasonToPlayerIds.has(input.season)) {
-        seasonToPlayerIds.set(input.season, []);
-      }
-      for (const p of input.players) {
-        seasonToPlayerIds.get(input.season)!.push(p.id);
-      }
-    }
-
-    for (const [season, rawIds] of seasonToPlayerIds) {
-      const playerIds = [...new Set(rawIds)];
-      const window = this.buildBroadWindow(season);
-      try {
-        bySeasonResult.set(
-          season,
-          await this.fetchPlaceMap(playerIds, systemId, window, transaction)
-        );
-      } catch (err) {
-        this.logger.error({ season, systemId }, err instanceof Error ? err.stack : String(err));
-        bySeasonResult.set(season, new Map());
-      }
-    }
-
-    return bySeasonResult;
-  }
-
-  /**
-   * Resolves the precise snapshot window for a sub-event and fetches the
-   * matching RankingPlace rows. Returns a place map on success or an
-   * IndexCalculationFailure on error.
-   */
-  private async fetchSubEventWindow(
-    subEventCompetitionId: string,
-    playerIds: string[],
-    systemId: string,
-    transaction?: Transaction
-  ): Promise<Map<string, RankingPlace> | IndexCalculationFailure> {
-    const subEvent = await SubEventCompetition.findByPk(subEventCompetitionId, {
-      attributes: [],
-      include: [
-        {
-          model: EventCompetition,
-          attributes: ["season", "usedRankingUnit", "usedRankingAmount"],
-        },
-      ],
-      transaction,
-    });
-
-    if (!subEvent) {
-      return failure(
-        subEventCompetitionId,
-        "SUB_EVENT_NOT_FOUND",
-        `SubEventCompetition not found: ${subEventCompetitionId}`
-      );
-    }
-
-    const ec = subEvent.eventCompetition;
-    if (!ec) {
-      return failure(
-        subEventCompetitionId,
-        "SUB_EVENT_NOT_FOUND",
-        `SubEventCompetition ${subEventCompetitionId} has no linked EventCompetition`
-      );
-    }
-
-    if (!ec.usedRankingUnit || ec.usedRankingAmount == null) {
-      return failure(
-        subEventCompetitionId,
-        "INTERNAL_ERROR",
-        `EventCompetition for sub-event ${subEventCompetitionId} is missing usedRankingUnit / usedRankingAmount`
-      );
-    }
-
-    const window = this.buildPreciseWindow({
-      season: ec.season,
-      usedRankingUnit: ec.usedRankingUnit,
-      usedRankingAmount: ec.usedRankingAmount,
-    });
-
-    this.logger.debug({
-      subEventCompetitionId,
-      season: ec.season,
-      usedRankingUnit: ec.usedRankingUnit,
-      usedRankingAmount: ec.usedRankingAmount,
-      window: { start: window.start.toISOString(), end: window.end.toISOString() },
-    });
-
-    try {
-      const placeMap = await this.fetchPlaceMap(playerIds, systemId, window, transaction);
-      if (placeMap.size === 0) {
-        this.logger.warn({
-          subEventCompetitionId,
-          systemId,
-          playerIds,
-          window: { start: window.start.toISOString(), end: window.end.toISOString() },
-        }, "No RankingPlace rows found in window — all players will fall back to amountOfLevels");
-      }
-      return placeMap;
-    } catch (err) {
-      this.logger.error({ subEventCompetitionId }, err instanceof Error ? err.stack : String(err));
-      return failure(
-        subEventCompetitionId,
-        "RANKING_FETCH_FAILED",
-        `RankingPlace fetch failed for sub-event ${subEventCompetitionId}`
-      );
-    }
   }
 
   /** Batch-resolve player gender from the Player table. */
@@ -331,15 +336,23 @@ export class IndexCalculationService {
     return { genderMap, notFoundIds };
   }
 
-  /** Compute a single IndexCalculationResult given pre-fetched data. */
+  /**
+   * Compute a single IndexCalculationResult given pre-fetched data.
+   * Mirrors `EnrollmentValidationService.getPlayers` per-discipline fallback:
+   *   bestRankingMin2 = min(s, d, m) + 2  (each component defaults to amountOfLevels first)
+   *   missing components default to bestRankingMin2.
+   */
   private computeResult(
     input: IndexCalculationInput,
+    type: SubEventTypeEnum,
     placeMap: Map<string, RankingPlace>,
     genderMap: Map<string, "M" | "F">,
     notFoundIds: Set<string>,
     amountOfLevels: number
   ): IndexCalculationResult {
-    const missingPlayerIds = input.players.filter((p) => notFoundIds.has(p.id)).map((p) => p.id);
+    const missingPlayerIds = input.players
+      .filter((p) => notFoundIds.has(p.id))
+      .map((p) => p.id);
 
     if (missingPlayerIds.length > 0) {
       return failure(
@@ -350,17 +363,28 @@ export class IndexCalculationService {
       );
     }
 
-    const resolvedPlayers: IndexCalculationContributingPlayer[] = input.players.map((p) => {
-      const place = placeMap.get(p.id);
-      const gender = genderMap.get(p.id) as "M" | "F";
-      return {
-        id: p.id,
-        gender,
-        single: place?.single ?? amountOfLevels,
-        double: place?.double ?? amountOfLevels,
-        mix: place?.mix ?? amountOfLevels,
-      };
-    });
+    const resolvedPlayers: IndexCalculationContributingPlayer[] = input.players.map(
+      (p) => {
+        const place = placeMap.get(p.id);
+        const gender = genderMap.get(p.id) as "M" | "F";
+        const rawSingle = place?.single;
+        const rawDouble = place?.double;
+        const rawMix = place?.mix;
+        const bestRankingMin2 =
+          Math.min(
+            rawSingle ?? amountOfLevels,
+            rawDouble ?? amountOfLevels,
+            rawMix ?? amountOfLevels
+          ) + 2;
+        return {
+          id: p.id,
+          gender,
+          single: rawSingle ?? bestRankingMin2,
+          double: rawDouble ?? bestRankingMin2,
+          mix: rawMix ?? bestRankingMin2,
+        };
+      }
+    );
 
     const indexPlayers: Partial<IndexPlayer>[] = resolvedPlayers.map((p) => ({
       id: p.id,
@@ -370,16 +394,18 @@ export class IndexCalculationService {
       mix: p.mix,
     }));
 
-    const index = getIndexFromPlayers(input.type, indexPlayers, amountOfLevels);
-    const bestResult = getBestPlayersFromTeam(input.type, indexPlayers, amountOfLevels);
+    const index = getIndexFromPlayers(type, indexPlayers, amountOfLevels);
+    const bestResult = getBestPlayersFromTeam(type, indexPlayers, amountOfLevels);
     const contributingIds = new Set(bestResult.players.map((p) => p.id));
 
-    const contributingPlayers = resolvedPlayers.filter((p) => contributingIds.has(p.id));
+    const contributingPlayers = resolvedPlayers.filter((p) =>
+      contributingIds.has(p.id)
+    );
     const missingPlayerCount = Math.max(0, 4 - contributingPlayers.length);
 
     this.logger.debug({
       key: input.key,
-      type: input.type,
+      type,
       playerIds: input.players.map((p) => p.id),
       resolvedPerPlayer: resolvedPlayers.map(({ id, single, double, mix }) => ({
         id,

--- a/libs/backend/competition/enrollment/src/services/index-calculation/index-calculation.types.ts
+++ b/libs/backend/competition/enrollment/src/services/index-calculation/index-calculation.types.ts
@@ -8,15 +8,27 @@ export interface IndexCalculationPlayerInput {
 export interface IndexCalculationInput {
   /** Caller-supplied correlation key (typically the team UUID) */
   key: string;
-  /** Team type — drives the canonical formula branch (non-MX vs MX) */
-  type: SubEventTypeEnum;
-  /** Season year */
-  season: number;
   /**
-   * Optional sub-event competition UUID.
-   * When present, the service derives the ranking snapshot window from the linked
-   * EventCompetition (parity with the entry-model hook).
-   * When absent, the service uses a broad calendar-year window for the given season.
+   * Team type — drives the canonical formula branch (non-MX vs MX).
+   * Optional only when `subEventCompetitionId` is provided; the service then
+   * derives the type from `SubEventCompetition.eventType`.
+   */
+  type?: SubEventTypeEnum;
+  /**
+   * Season year. Optional only when `subEventCompetitionId` is provided; the
+   * service then derives the season from the linked `EventCompetition`.
+   */
+  season?: number;
+  /**
+   * Optional ranking system override. When omitted, the primary system is used.
+   * Mirrors the validator, which honors a caller-supplied `systemId` and falls
+   * back to primary.
+   */
+  systemId?: string;
+  /**
+   * Optional sub-event competition UUID. Used to derive `type` and/or `season`
+   * when the caller does not supply them. Does NOT influence the ranking-date
+   * cutoff — that is always `<= June 10 of season` (validator's rule).
    */
   subEventCompetitionId?: string;
   /** Player inputs. Empty array is valid — produces only the missing-player penalty. */
@@ -56,6 +68,7 @@ export type IndexCalculationErrorCode =
   | "PLAYER_NOT_FOUND"
   | "RANKING_SYSTEM_NOT_FOUND"
   | "SUB_EVENT_NOT_FOUND"
+  | "MISSING_TYPE_OR_SEASON"
   | "RANKING_FETCH_FAILED"
   | "INTERNAL_ERROR";
 

--- a/libs/backend/competition/enrollment/src/services/validate/enrollment.service.spec.ts
+++ b/libs/backend/competition/enrollment/src/services/validate/enrollment.service.spec.ts
@@ -1,49 +1,19 @@
-// import {
-//   DatabaseModule,
-//   SystemGroupBuilder,
-//   SystemBuilder,
-//   RankingSystem,
-//   PlayerBuilder,
-//   TeamBuilder,
-//   EventCompetitionEntryBuilder,
-//   DrawCompetition,
-//   DrawCompetitionBuilder,
-//   EncounterCompetitionBuilder,
-//   SubEventCompetitionBuilder,
-//   EventCompetitionBuilder,
-//   SubEventCompetition,
-//   ClubBuilder,
-//   Player,
-//   Team,
-//   EncounterCompetition,
-// } from '@badman/backend-database';
-// import { Sequelize } from 'sequelize-typescript';
-import { Test, TestingModule } from "@nestjs/testing";
-// import { ConfigModule } from '@nestjs/config';
 
-// import {
-//   TeamBaseIndexRule,
-//   CompetitionStatusRule,
-//   PlayerMinLevelRule,
-//   PlayerOrderRule,
-//   TeamSubeventIndexRule,
-//   PlayerMaxGamesRule,
-//   PlayerGenderRule,
-//   TeamClubBaseRule,
-//   SubTeamIndexRule,
-// } from './rules';
-// import { RankingSystems, SubEventTypeEnum } from '@badman/utils';
+import { Test, TestingModule } from "@nestjs/testing";
 import {
   Club,
   DatabaseModule,
   Player,
+  RankingPlace,
   RankingSystem,
   SubEventCompetition,
   Team,
 } from "@badman/backend-database";
 import { SubEventTypeEnum } from "@badman/utils";
 import { ConfigModule } from "@nestjs/config";
+import { Op } from "sequelize";
 import { EnrollmentValidationService } from "./enrollment.service";
+import { IndexCalculationService } from "../index-calculation/index-calculation.service";
 import { TeamContinuityRule } from "./rules";
 
 describe("EnrollmentValidationService", () => {
@@ -56,7 +26,7 @@ describe("EnrollmentValidationService", () => {
 
   beforeEach(async () => {
     module = await Test.createTestingModule({
-      providers: [EnrollmentValidationService],
+      providers: [EnrollmentValidationService, IndexCalculationService],
       imports: [
         DatabaseModule,
         ConfigModule.forRoot({
@@ -109,7 +79,7 @@ describe("EnrollmentValidationService", () => {
 
   test("reused continuity id finds previous season team", async () => {
     const system = { id: "system-1", amountOfLevels: 12 } as RankingSystem;
-    const club = new Club({ id: "club-1" });
+    const club = new Club({ id: "club-1", name: "Club 1" });
     const previousSeasonTeam = new Team({
       id: "team-prev",
       link: "continuity-1",
@@ -148,7 +118,7 @@ describe("EnrollmentValidationService", () => {
 
   test("missing continuity id warns when previous season match exists", async () => {
     const system = { id: "system-1", amountOfLevels: 12 } as RankingSystem;
-    const club = new Club({ id: "club-1" });
+    const club = new Club({ id: "club-1", name: "Club 1" });
     const previousSeasonTeam = new Team({
       id: "team-prev",
       link: "continuity-1",
@@ -160,9 +130,10 @@ describe("EnrollmentValidationService", () => {
 
     jest.spyOn(RankingSystem, "findByPk").mockResolvedValue(system);
     jest.spyOn(Club, "findByPk").mockResolvedValue(club);
-    const teamFindAllMock = jest.spyOn(Team, "findAll");
-    teamFindAllMock.mockResolvedValueOnce([]);
-    teamFindAllMock.mockResolvedValueOnce([previousSeasonTeam]);
+    // No continuity link on the team → the first conditional Team.findAll
+    // (previousSeasonTeams) is skipped. Only the previousSeasonClubTeams
+    // call runs, and that's the one that should return the candidate match.
+    jest.spyOn(Team, "findAll").mockResolvedValue([previousSeasonTeam]);
     jest.spyOn(SubEventCompetition, "findAll").mockResolvedValue([]);
     jest.spyOn(Player, "findAll").mockResolvedValue([]);
 
@@ -188,6 +159,290 @@ describe("EnrollmentValidationService", () => {
     expect(warningMessages).toContain(
       "all.v1.entryTeamDrawer.validation.warnings.missing-continuity-link"
     );
+  });
+
+  describe("getValidationData index calculations", () => {
+    const SYSTEM_ID = "system-1";
+    const SEASON = 2024;
+    const RANKING_DATE_BEFORE_CUTOFF = new Date(SEASON, 4, 15); // May 15 SEASON
+    const RANKING_DATE_AFTER_CUTOFF = new Date(SEASON, 5, 20); // June 20 SEASON
+
+    const stubSystem = (amountOfLevels = 12): RankingSystem =>
+      ({ id: SYSTEM_ID, amountOfLevels, primary: true }) as unknown as RankingSystem;
+
+    const stubPlayerWithRanking = (
+      id: string,
+      gender: "M" | "F",
+      single?: number,
+      double?: number,
+      mix?: number,
+      rankingDate: Date = RANKING_DATE_BEFORE_CUTOFF
+    ): Player => {
+      const player = new Player({
+        id,
+        gender,
+        firstName: id,
+        lastName: id,
+        competitionPlayer: true,
+      });
+      const place = new RankingPlace({
+        playerId: id,
+        systemId: SYSTEM_ID,
+        single,
+        double,
+        mix,
+        rankingDate,
+      });
+      (player as unknown as { rankingPlaces: RankingPlace[] }).rankingPlaces = [place];
+      return player;
+    };
+
+    const stubPlayerWithoutRanking = (id: string, gender: "M" | "F"): Player => {
+      const player = new Player({
+        id,
+        gender,
+        firstName: id,
+        lastName: id,
+        competitionPlayer: true,
+      });
+      (player as unknown as { rankingPlaces: RankingPlace[] }).rankingPlaces = [];
+      return player;
+    };
+
+    const arrange = (players: Player[]) => {
+      jest.spyOn(RankingSystem, "findByPk").mockResolvedValue(stubSystem());
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
+      jest.spyOn(RankingSystem, "findAll").mockResolvedValue([stubSystem()]);
+      jest.spyOn(Club, "findByPk").mockResolvedValue(new Club({ id: "club-1", name: "Club 1" }));
+      jest.spyOn(Team, "findAll").mockResolvedValue([]);
+      jest.spyOn(SubEventCompetition, "findAll").mockResolvedValue([]);
+      // Player.findAll is called both by the validator (gender + names) and by
+      // IndexCalculationService (gender). Same return is fine for both.
+      jest.spyOn(Player, "findAll").mockResolvedValue(players);
+      // The service's RankingPlace.findAll consults `rankingDate <= June 10 of season`.
+      // Filter the in-memory rows by that predicate so the cutoff still drives the result.
+      jest.spyOn(RankingPlace, "findAll").mockImplementation((opts) => {
+        const cutoff = (opts as { where: { rankingDate: Record<symbol, Date> } }).where.rankingDate[Op.lte];
+        const allPlaces = players.flatMap(
+          (p) => (p as unknown as { rankingPlaces?: RankingPlace[] }).rankingPlaces ?? []
+        );
+        return Promise.resolve(allPlaces.filter((rp) => rp.rankingDate && rp.rankingDate <= cutoff));
+      });
+    };
+
+    test("M team: baseIndex sums single+double of 4 base players", async () => {
+      const players = [
+        stubPlayerWithRanking("p1", "M", 5, 5, 7),
+        stubPlayerWithRanking("p2", "M", 6, 6, 8),
+        stubPlayerWithRanking("p3", "M", 7, 7, 9),
+        stubPlayerWithRanking("p4", "M", 8, 8, 10),
+      ];
+      arrange(players);
+
+      const data = await service.getValidationData({
+        clubId: "club-1",
+        systemId: SYSTEM_ID,
+        season: SEASON,
+        teams: [
+          {
+            id: "team-1",
+            name: "Team A",
+            type: SubEventTypeEnum.M,
+            teamNumber: 1,
+            basePlayers: ["p1", "p2", "p3", "p4"],
+          },
+        ],
+      });
+
+      // (5+5)+(6+6)+(7+7)+(8+8) = 52
+      expect(data.teams[0].baseIndex).toBe(52);
+      expect(data.teams[0].basePlayers).toHaveLength(4);
+    });
+
+    test("F team: 3 base players adds (4-3)*24 penalty", async () => {
+      const players = [
+        stubPlayerWithRanking("p1", "F", 4, 4, 6),
+        stubPlayerWithRanking("p2", "F", 5, 5, 7),
+        stubPlayerWithRanking("p3", "F", 6, 6, 8),
+      ];
+      arrange(players);
+
+      const data = await service.getValidationData({
+        clubId: "club-1",
+        systemId: SYSTEM_ID,
+        season: SEASON,
+        teams: [
+          {
+            id: "team-1",
+            name: "Team A",
+            type: SubEventTypeEnum.F,
+            teamNumber: 1,
+            basePlayers: ["p1", "p2", "p3"],
+          },
+        ],
+      });
+
+      // (4+4)+(5+5)+(6+6) + 1*24 = 30 + 24 = 54
+      expect(data.teams[0].baseIndex).toBe(54);
+    });
+
+    test("MX team: 2M + 2F sums single+double+mix, no penalty", async () => {
+      const players = [
+        stubPlayerWithRanking("p1", "M", 5, 5, 7),
+        stubPlayerWithRanking("p2", "M", 6, 6, 8),
+        stubPlayerWithRanking("p3", "F", 4, 4, 6),
+        stubPlayerWithRanking("p4", "F", 5, 5, 7),
+      ];
+      arrange(players);
+
+      const data = await service.getValidationData({
+        clubId: "club-1",
+        systemId: SYSTEM_ID,
+        season: SEASON,
+        teams: [
+          {
+            id: "team-1",
+            name: "Team A",
+            type: SubEventTypeEnum.MX,
+            teamNumber: 1,
+            basePlayers: ["p1", "p2", "p3", "p4"],
+          },
+        ],
+      });
+
+      // (5+5+7)+(6+6+8)+(4+4+6)+(5+5+7) = 17+20+14+17 = 68
+      expect(data.teams[0].baseIndex).toBe(68);
+    });
+
+    test("MX team: 2M + 1F adds (4-3)*36 penalty", async () => {
+      const players = [
+        stubPlayerWithRanking("p1", "M", 5, 5, 7),
+        stubPlayerWithRanking("p2", "M", 6, 6, 8),
+        stubPlayerWithRanking("p3", "F", 4, 4, 6),
+      ];
+      arrange(players);
+
+      const data = await service.getValidationData({
+        clubId: "club-1",
+        systemId: SYSTEM_ID,
+        season: SEASON,
+        teams: [
+          {
+            id: "team-1",
+            name: "Team A",
+            type: SubEventTypeEnum.MX,
+            teamNumber: 1,
+            basePlayers: ["p1", "p2", "p3"],
+          },
+        ],
+      });
+
+      // (5+5+7)+(6+6+8)+(4+4+6) + 1*36 = 17+20+14+36 = 87
+      expect(data.teams[0].baseIndex).toBe(87);
+    });
+
+    test("Player without RankingPlace falls back to min(s,d,m)+2 = amountOfLevels+2 per discipline", async () => {
+      const players = [
+        stubPlayerWithRanking("p1", "M", 5, 5, 7),
+        stubPlayerWithRanking("p2", "M", 6, 6, 8),
+        stubPlayerWithRanking("p3", "M", 7, 7, 9),
+        stubPlayerWithoutRanking("p4", "M"),
+      ];
+      arrange(players);
+
+      const data = await service.getValidationData({
+        clubId: "club-1",
+        systemId: SYSTEM_ID,
+        season: SEASON,
+        teams: [
+          {
+            id: "team-1",
+            name: "Team A",
+            type: SubEventTypeEnum.M,
+            teamNumber: 1,
+            basePlayers: ["p1", "p2", "p3", "p4"],
+          },
+        ],
+      });
+
+      // Three rated players + one unrated. Unrated: min(12,12,12)+2 = 14 per discipline → single+double = 28.
+      // (5+5)+(6+6)+(7+7)+14+14 = 10+12+14+28 = 64
+      expect(data.teams[0].baseIndex).toBe(64);
+    });
+
+    test("Cutoff: a RankingPlace dated after June 10 of season is ignored; players fall back to amountOfLevels+2", async () => {
+      // p1-p3 have rows BEFORE cutoff. p4 has only an AFTER-cutoff row → service ignores it
+      // and falls back to min(12,12,12)+2 = 14 per discipline.
+      const players = [
+        stubPlayerWithRanking("p1", "M", 5, 5, 7, RANKING_DATE_BEFORE_CUTOFF),
+        stubPlayerWithRanking("p2", "M", 6, 6, 8, RANKING_DATE_BEFORE_CUTOFF),
+        stubPlayerWithRanking("p3", "M", 7, 7, 9, RANKING_DATE_BEFORE_CUTOFF),
+        stubPlayerWithRanking("p4", "M", 1, 1, 1, RANKING_DATE_AFTER_CUTOFF),
+      ];
+      arrange(players);
+
+      const data = await service.getValidationData({
+        clubId: "club-1",
+        systemId: SYSTEM_ID,
+        season: SEASON,
+        teams: [
+          {
+            id: "team-1",
+            name: "Team A",
+            type: SubEventTypeEnum.M,
+            teamNumber: 1,
+            basePlayers: ["p1", "p2", "p3", "p4"],
+          },
+        ],
+      });
+
+      // Verify the service was queried with the validator's June 10 cutoff.
+      const rankingPlaceCalls = (RankingPlace.findAll as unknown as jest.SpyInstance).mock.calls;
+      expect(rankingPlaceCalls.length).toBeGreaterThan(0);
+      const args = rankingPlaceCalls[0][0] as { where: { rankingDate: Record<symbol, Date> } };
+      const cutoff = args.where.rankingDate[Op.lte];
+      expect(cutoff.getFullYear()).toBe(SEASON);
+      expect(cutoff.getMonth()).toBe(5); // June (0-indexed)
+      expect(cutoff.getDate()).toBe(10);
+      expect(RANKING_DATE_AFTER_CUTOFF.getTime()).toBeGreaterThan(cutoff.getTime());
+
+      // p4's stronger after-cutoff row is excluded; min+2 fallback yields 14+14=28 for that player.
+      // (5+5)+(6+6)+(7+7)+14+14 = 64
+      expect(data.teams[0].baseIndex).toBe(64);
+    });
+
+    test("Enrollment-only flow: only basePlayers populated; teamIndex defaults to 4-player penalty", async () => {
+      // Current enrollment input does not populate t.players. The validator therefore feeds
+      // an empty list into teamIndex, which yields the 4*24 penalty (96) for non-MX teams.
+      // baseIndex still reflects the actual base roster.
+      const players = [
+        stubPlayerWithRanking("p1", "M", 5, 5, 7),
+        stubPlayerWithRanking("p2", "M", 6, 6, 8),
+        stubPlayerWithRanking("p3", "M", 7, 7, 9),
+        stubPlayerWithRanking("p4", "M", 8, 8, 10),
+      ];
+      arrange(players);
+
+      const data = await service.getValidationData({
+        clubId: "club-1",
+        systemId: SYSTEM_ID,
+        season: SEASON,
+        teams: [
+          {
+            id: "team-1",
+            name: "Team A",
+            type: SubEventTypeEnum.M,
+            teamNumber: 2,
+            basePlayers: ["p1", "p2", "p3", "p4"],
+            // players + backupPlayers omitted — current enrollment shape
+          },
+        ],
+      });
+
+      expect(data.teams[0].baseIndex).toBe(52);
+      expect(data.teams[0].teamIndex).toBe(96); // 4 * 24 penalty for empty teamPlayers
+      // teamIndex >= baseIndex satisfies team-base-index.rule for non-#1 teams (rule guards against teamIndex < baseIndex).
+    });
   });
 
   // describe('Doubles Male team checks', () => {

--- a/libs/backend/competition/enrollment/src/services/validate/enrollment.service.ts
+++ b/libs/backend/competition/enrollment/src/services/validate/enrollment.service.ts
@@ -40,6 +40,7 @@ import { IndexCalculationService } from "../index-calculation/index-calculation.
 import {
   IndexCalculationContributingPlayer,
   IndexCalculationInput,
+  isFailure,
   isSuccess,
 } from "../index-calculation/index-calculation.types";
 
@@ -294,7 +295,7 @@ export class EnrollmentValidationService {
         // issue (missing gender, missing player, …).
         if (baseRes && isSuccess(baseRes)) {
           this.hydrateRanks(sk.basePlayers, baseRes.resolvedPlayers);
-        } else if (baseRes) {
+        } else if (baseRes && isFailure(baseRes)) {
           this._logger.warn(
             `Index calc failed for team ${sk.teamId} base: ${baseRes.error.code} ${baseRes.error.message}`
           );

--- a/libs/backend/competition/enrollment/src/services/validate/enrollment.service.ts
+++ b/libs/backend/competition/enrollment/src/services/validate/enrollment.service.ts
@@ -4,13 +4,12 @@ import {
   EventCompetition,
   EventEntry,
   Player,
-  RankingPlace,
   RankingSystem,
   Standing,
   SubEventCompetition,
   Team,
 } from "@badman/backend-database";
-import { getSeason, getIndexFromPlayers } from "@badman/utils";
+import { getSeason } from "@badman/utils";
 import { Injectable, Logger } from "@nestjs/common";
 import {
   EnrollmentOutput,
@@ -33,16 +32,22 @@ import {
   TeamMaxBasePlayersRule,
   TeamContinuityRule,
 } from "./rules";
-import moment from "moment";
-import { Op } from "sequelize";
 import { PartialType, PickType } from "@nestjs/graphql";
 import { PlayerClubRule } from "./rules/player-club.rule";
 import { TeamBaseGenderRule } from "./rules/team-base-gender.rule";
 import { Md5 } from "ts-md5";
+import { IndexCalculationService } from "../index-calculation/index-calculation.service";
+import {
+  IndexCalculationContributingPlayer,
+  IndexCalculationInput,
+  isSuccess,
+} from "../index-calculation/index-calculation.types";
 
 @Injectable()
 export class EnrollmentValidationService {
   private readonly _logger = new Logger(EnrollmentValidationService.name);
+
+  constructor(private readonly indexCalculationService: IndexCalculationService) {}
 
   async getValidationData({
     clubId,
@@ -138,19 +143,7 @@ export class EnrollmentValidationService {
         where: {
           id: stringPlayerIds,
         },
-        include: [
-          {
-            model: RankingPlace,
-            where: {
-              systemId: system?.id,
-              rankingDate: {
-                [Op.lte]: moment([season, 5, 10]).toDate(),
-              },
-            },
-            order: [["rankingDate", "DESC"]],
-            limit: 1,
-          },
-        ],
+        // RankingPlace lookup is now delegated to IndexCalculationService below.
       }),
       Player.findAll({
         attributes: ["id", "gender", "competitionPlayer", "firstName", "lastName"],
@@ -166,95 +159,194 @@ export class EnrollmentValidationService {
       }),
     ]);
 
+    // Pass 1: build per-team skeletons (player rosters + metadata) without
+    // computed indices. Ranks on `EntryCompetitionPlayer` are hydrated in
+    // pass 2 from `IndexCalculationService.resolvedPlayers`.
+    const skeletons = teams.map((t) => {
+      if (!t.type) {
+        throw new Error("No type found");
+      }
+      if (!t.id) {
+        throw new Error("No team id found");
+      }
+
+      const playersForTeam = this.getPlayers(
+        [t.players ?? [], t.backupPlayers ?? [], t.basePlayers ?? []]?.flat(1),
+        dbPlayers,
+        dbPlayersEntry
+      );
+
+      const basePlayers = playersForTeam.filter((p) =>
+        t.basePlayers?.map((p) => (instanceOfEntryCompetitionPlayer(p) ? p.id : p)).includes(p.id)
+      );
+
+      // find if there are any exceptions requested
+      for (const exception of t.exceptions ?? []) {
+        const playerIndex = basePlayers.findIndex((p) => p.id === exception);
+        if (playerIndex === -1) {
+          throw new Error(`Player with id ${exception} not found`);
+        }
+        basePlayers[playerIndex].levelExceptionRequested = true;
+      }
+
+      const teamPlayers = playersForTeam.filter((p) =>
+        t.players?.map((p) => (instanceOfEntryCompetitionPlayer(p) ? p.id : p)).includes(p.id)
+      );
+
+      const backupPlayers = playersForTeam.filter((p) =>
+        t.backupPlayers
+          ?.map((p) => (instanceOfEntryCompetitionPlayer(p) ? p.id : p))
+          .includes(p.id)
+      );
+
+      const previousSeasonTeam = previousSeasonTeams.find((p) => p.link === t.link);
+      const missingContinuityId = !t.link;
+      const possibleOldTeamTeam = missingContinuityId
+        ? previousSeasonClubTeams.find(
+            (team) =>
+              (team.type === t.type && team.teamNumber === t.teamNumber) ||
+              (!!t.name && team.name === t.name)
+          )
+        : undefined;
+
+      if (missingContinuityId && possibleOldTeamTeam) {
+        this._logger.warn(
+          `Team continuity id missing for ${t.name ?? t.id}; previous season match exists.`
+        );
+      }
+
+      return {
+        teamId: t.id,
+        teamType: t.type,
+        team: new Team({
+          id: t.id,
+          type: t.type,
+          name: t.name,
+          teamNumber: t.teamNumber,
+          link: previousSeasonTeam?.link,
+        }),
+        previousSeasonTeam,
+        possibleOldTeamTeam,
+        isNewTeam: !t.link,
+        possibleOldTeam: !!possibleOldTeamTeam,
+        basePlayers,
+        teamPlayers,
+        backupPlayers,
+        subEvent: subEvents.find((s) => s.id === t.subEventId),
+      };
+    });
+
+    // Pass 2: single batched call to IndexCalculationService. Per team we
+    // submit three inputs:
+    //   `${id}:base`   → drives baseIndex AND hydrates basePlayers ranks
+    //   `${id}:team`   → drives teamIndex AND hydrates teamPlayers ranks
+    //   `${id}:backup` → only hydrates backupPlayers ranks (index discarded)
+    // The service deduplicates RankingPlace fetches to one DB query per
+    // (systemId, season).
+    const indexInputs: IndexCalculationInput[] = [];
+    for (const sk of skeletons) {
+      const baseIds = sk.basePlayers.map((p) => p.id!).filter((id) => !!id);
+      const teamIds = sk.teamPlayers.map((p) => p.id!).filter((id) => !!id);
+      const backupIds = sk.backupPlayers.map((p) => p.id!).filter((id) => !!id);
+      const common = {
+        type: sk.teamType,
+        season,
+        systemId: system.id,
+      };
+      indexInputs.push({
+        ...common,
+        key: `${sk.teamId}:base`,
+        players: baseIds.map((id) => ({ id })),
+      });
+      indexInputs.push({
+        ...common,
+        key: `${sk.teamId}:team`,
+        players: teamIds.map((id) => ({ id })),
+      });
+      if (backupIds.length > 0) {
+        indexInputs.push({
+          ...common,
+          key: `${sk.teamId}:backup`,
+          players: backupIds.map((id) => ({ id })),
+        });
+      }
+    }
+
+    const indexResults =
+      indexInputs.length > 0
+        ? await this.indexCalculationService.calculate(indexInputs)
+        : [];
+    const resultsByKey = new Map(indexResults.map((r) => [r.key, r]));
+
     return {
       club,
       season,
       loans: loans ?? [],
       transfers: transfers ?? [],
-      teams: teams?.map((t) => {
-        if (!t.type) {
-          throw new Error("No type found");
-        }
+      teams: skeletons.map((sk) => {
+        const baseRes = resultsByKey.get(`${sk.teamId}:base`);
+        const teamRes = resultsByKey.get(`${sk.teamId}:team`);
+        const backupRes = resultsByKey.get(`${sk.teamId}:backup`);
 
-        const playersForTeam = this.getPlayers(
-          [t.players ?? [], t.backupPlayers ?? [], t.basePlayers ?? []]?.flat(1),
-          dbPlayers,
-          dbPlayersEntry,
-          system
-        );
-
-        const basePlayers = playersForTeam.filter((p) =>
-          t.basePlayers?.map((p) => (instanceOfEntryCompetitionPlayer(p) ? p.id : p)).includes(p.id)
-        );
-
-        // find if there are any exceptions requested
-        for (const exception of t.exceptions ?? []) {
-          const playerIndex = basePlayers.findIndex((p) => p.id === exception);
-          if (playerIndex === -1) {
-            throw new Error(`Player with id ${exception} not found`);
-          }
-
-          basePlayers[playerIndex].levelExceptionRequested = true;
-        }
-
-        const teamPlayers = playersForTeam.filter((p) =>
-          t.players?.map((p) => (instanceOfEntryCompetitionPlayer(p) ? p.id : p)).includes(p.id)
-        );
-
-        const backupPlayers = playersForTeam.filter((p) =>
-          t.backupPlayers
-            ?.map((p) => (instanceOfEntryCompetitionPlayer(p) ? p.id : p))
-            .includes(p.id)
-        );
-
-        const teamIndex = getIndexFromPlayers(t.type, teamPlayers, system.amountOfLevels);
-        const baseIndex = getIndexFromPlayers(t.type, basePlayers, system.amountOfLevels);
-
-        const previousSeasonTeam = previousSeasonTeams.find((p) => p.link === t.link);
-        const missingContinuityId = !t.link;
-        const possibleOldTeamTeam = missingContinuityId
-          ? previousSeasonClubTeams.find(
-              (team) =>
-                (team.type === t.type && team.teamNumber === t.teamNumber) ||
-                (!!t.name && team.name === t.name)
-            )
-          : undefined;
-
-        if (missingContinuityId && possibleOldTeamTeam) {
+        // Hydrate per-player ranks from each respective response. Failures
+        // are tolerated: players keep their default-undefined ranks and
+        // downstream rules (PlayerGenderRule etc.) surface the underlying
+        // issue (missing gender, missing player, …).
+        if (baseRes && isSuccess(baseRes)) {
+          this.hydrateRanks(sk.basePlayers, baseRes.resolvedPlayers);
+        } else if (baseRes) {
           this._logger.warn(
-            `Team continuity id missing for ${t.name ?? t.id}; previous season match exists.`
+            `Index calc failed for team ${sk.teamId} base: ${baseRes.error.code} ${baseRes.error.message}`
           );
         }
-
-        if (!t.id) {
-          throw new Error("No team id found");
+        if (teamRes && isSuccess(teamRes)) {
+          this.hydrateRanks(sk.teamPlayers, teamRes.resolvedPlayers);
+        }
+        if (backupRes && isSuccess(backupRes)) {
+          this.hydrateRanks(sk.backupPlayers, backupRes.resolvedPlayers);
         }
 
+        const baseIndex = baseRes && isSuccess(baseRes) ? baseRes.index : undefined;
+        const teamIndex = teamRes && isSuccess(teamRes) ? teamRes.index : undefined;
+
         return {
-          team: new Team({
-            id: t.id,
-            type: t.type,
-            name: t.name,
-            teamNumber: t.teamNumber,
-            link: previousSeasonTeam?.link,
-          }),
-          previousSeasonTeam,
-          possibleOldTeamTeam,
-          isNewTeam: !t.link,
-          possibleOldTeam: !!possibleOldTeamTeam,
-          id: t.id,
-          basePlayers,
-          teamPlayers,
-          backupPlayers,
+          team: sk.team,
+          previousSeasonTeam: sk.previousSeasonTeam,
+          possibleOldTeamTeam: sk.possibleOldTeamTeam,
+          isNewTeam: sk.isNewTeam,
+          possibleOldTeam: sk.possibleOldTeam,
+          id: sk.teamId,
+          basePlayers: sk.basePlayers,
+          teamPlayers: sk.teamPlayers,
+          backupPlayers: sk.backupPlayers,
           system,
 
           baseIndex,
           teamIndex,
 
-          subEvent: subEvents.find((s) => s.id === t.subEventId),
+          subEvent: sk.subEvent,
         };
       }),
     };
+  }
+
+  /**
+   * Copy `single` / `double` / `mix` from the index-calculation service's
+   * resolved per-player ranks onto the `EntryCompetitionPlayer` objects that
+   * downstream rules consume. Idempotent.
+   */
+  private hydrateRanks(
+    players: EntryCompetitionPlayer[],
+    resolved: IndexCalculationContributingPlayer[]
+  ): void {
+    const byId = new Map(resolved.map((r) => [r.id, r]));
+    for (const p of players) {
+      const r = p.id ? byId.get(p.id) : undefined;
+      if (!r) continue;
+      p.single = r.single;
+      p.double = r.double;
+      p.mix = r.mix;
+    }
   }
 
   /**
@@ -358,80 +450,50 @@ export class EnrollmentValidationService {
     ];
   }
 
+  /**
+   * Build the per-team `EntryCompetitionPlayer[]` skeleton (id, gender, dbPlayer
+   * association) without populating ranks. Ranks are filled later by
+   * `hydrateRanks` from `IndexCalculationService.resolvedPlayers`, which is the
+   * canonical source for the cutoff + min+2 fallback semantics.
+   */
   private getPlayers(
     players: (string | EntryCompetitionPlayer)[],
-    withRanking: Player[],
-    withoutRanking: Player[],
-    system?: RankingSystem
+    withDbPlayer: Player[],
+    existingDbPlayers: Player[]
   ): EntryCompetitionPlayer[] {
-    if (!system) {
-      throw new Error("No ranking system provided");
-    }
-
     const stringPlayerIds = players.filter((p) => !instanceOfEntryCompetitionPlayer(p)) as string[];
-    const eixistingPlayerIds = players.filter((p) =>
+    const existingPlayers = players.filter((p) =>
       instanceOfEntryCompetitionPlayer(p)
     ) as EntryCompetitionPlayer[];
 
-    const addedPlayes: EntryCompetitionPlayer[] = [];
+    const addedPlayers: EntryCompetitionPlayer[] = [];
 
-    for (const player of eixistingPlayerIds) {
-      if (!player?.id) {
-        continue;
-      }
+    for (const player of existingPlayers) {
+      if (!player?.id) continue;
+      if (addedPlayers.find((p) => p.id === player.id)) continue;
 
-      // check if player is already added
-      if (addedPlayes.find((p) => p.id === player.id)) {
-        continue;
-      }
-
-      const dbPlayer = withoutRanking.find((p) => p.id === player?.id);
+      const dbPlayer = existingDbPlayers.find((p) => p.id === player.id);
       player.player = dbPlayer;
-
-      addedPlayes.push(player);
+      addedPlayers.push(player);
     }
 
     for (const id of stringPlayerIds) {
-      // check if player is already added
-      if (addedPlayes.find((p) => p.id === id)) {
-        continue;
-      }
+      if (addedPlayers.find((p) => p.id === id)) continue;
 
-      const dbPlayer = withRanking.find((p) => p.id === id);
+      const dbPlayer = withDbPlayer.find((p) => p.id === id);
       if (!dbPlayer) {
         throw new Error(`Player with id ${id} not found`);
       }
 
-      const ranking =
-        dbPlayer?.rankingPlaces?.[0] ??
-        new RankingPlace({
-          playerId: dbPlayer.id,
-          systemId: system?.id,
-        });
-
-      const bestRankingMin2 =
-        Math.min(
-          ranking?.single ?? system.amountOfLevels,
-          ranking?.double ?? system.amountOfLevels,
-          ranking?.mix ?? system.amountOfLevels
-        ) + 2;
-
-      // if the player has a missing rankingplace, we set the lowest possible ranking
-      ranking.single = ranking?.single ?? bestRankingMin2;
-      ranking.double = ranking?.double ?? bestRankingMin2;
-      ranking.mix = ranking?.mix ?? bestRankingMin2;
-
-      addedPlayes.push({
+      addedPlayers.push({
         id,
         player: dbPlayer,
-        single: ranking.single,
-        double: ranking.double,
-        mix: ranking.mix,
         gender: dbPlayer.gender,
+        // single / double / mix populated by hydrateRanks
       });
     }
 
-    return addedPlayes;
+    return addedPlayers;
   }
 }
 

--- a/libs/backend/database/src/models/event/entry.model.spec.ts
+++ b/libs/backend/database/src/models/event/entry.model.spec.ts
@@ -109,7 +109,8 @@ describe("EventEntry.recalculateCompetitionIndex", () => {
       {
         key: ENTRY_UUID,
         type: "M",
-        season: 0,
+        // `season` intentionally omitted — the service derives it from
+        // SubEventCompetition.eventCompetition when subEventCompetitionId is set.
         subEventCompetitionId: SUBEVENT_UUID,
         players: [{ id: PLAYER_UUID }],
       },

--- a/libs/backend/database/src/models/event/entry.model.ts
+++ b/libs/backend/database/src/models/event/entry.model.ts
@@ -42,8 +42,9 @@ interface IIndexCalculationService {
   calculateOne(
     input: {
       key: string;
-      type: string;
-      season: number;
+      type?: string;
+      season?: number;
+      systemId?: string;
       subEventCompetitionId?: string;
       players: { id: string }[];
     },
@@ -243,9 +244,8 @@ export class EventEntry extends Model<
       {
         key: instance.id!,
         type: team.type!,
-        // season is ignored when subEventCompetitionId is provided;
-        // the service derives it from the linked EventCompetition.
-        season: 0,
+        // `season` intentionally omitted: the service derives it from the
+        // sub-event's linked EventCompetition when subEventCompetitionId is set.
         subEventCompetitionId: instance.subEventId ?? undefined,
         players: (instance.meta.competition.players ?? []).map((p) => ({ id: p.id! })),
       },

--- a/libs/backend/graphql/src/resolvers/event/competition/calculate-index/calculate-index.input.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/calculate-index/calculate-index.input.ts
@@ -25,8 +25,9 @@ export class CalculateIndexInput {
 
   /**
    * Optional sub-event competition UUID.
-   * When present, the service derives the ranking snapshot window from the linked
-   * EventCompetition (parity with the entry-model hook).
+   * Used only as a fallback to derive `type` and/or `season` when the caller
+   * omits them. Does NOT influence the ranking-date cutoff — that is always
+   * `<= June 10 of season` (validator's rule).
    */
   @Field(() => ID, { nullable: true })
   @IsOptional()

--- a/libs/backend/graphql/src/resolvers/event/competition/calculate-index/calculate-index.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/calculate-index/calculate-index.resolver.ts
@@ -120,7 +120,13 @@ export class CalculateIndexResolver {
 }
 
 function mapErrorCode(
-  serviceCode: "PLAYER_NOT_FOUND" | "RANKING_SYSTEM_NOT_FOUND" | "SUB_EVENT_NOT_FOUND" | "RANKING_FETCH_FAILED" | "INTERNAL_ERROR"
+  serviceCode:
+    | "PLAYER_NOT_FOUND"
+    | "RANKING_SYSTEM_NOT_FOUND"
+    | "SUB_EVENT_NOT_FOUND"
+    | "MISSING_TYPE_OR_SEASON"
+    | "RANKING_FETCH_FAILED"
+    | "INTERNAL_ERROR"
 ): string {
   switch (serviceCode) {
     case "PLAYER_NOT_FOUND":
@@ -129,6 +135,7 @@ function mapErrorCode(
       return ErrorCode.RANKING_SYSTEM_NOT_FOUND;
     case "SUB_EVENT_NOT_FOUND":
       return ErrorCode.SUB_EVENT_NOT_FOUND;
+    case "MISSING_TYPE_OR_SEASON":
     case "RANKING_FETCH_FAILED":
     case "INTERNAL_ERROR":
     default:

--- a/libs/backend/graphql/src/resolvers/team/team.module.ts
+++ b/libs/backend/graphql/src/resolvers/team/team.module.ts
@@ -1,10 +1,11 @@
 import { DatabaseModule } from "@badman/backend-database";
+import { EnrollmentModule } from "@badman/backend-enrollment";
 import { Module } from "@nestjs/common";
 import { TeamPlayerResolver, TeamsResolver } from "./team.resolver";
 import { TeamWriteService } from "./team-write.service";
 
 @Module({
-  imports: [DatabaseModule],
+  imports: [DatabaseModule, EnrollmentModule],
   providers: [TeamsResolver, TeamPlayerResolver, TeamWriteService],
   exports: [TeamWriteService],
 })

--- a/libs/backend/graphql/src/resolvers/team/team.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/team/team.resolver.spec.ts
@@ -12,6 +12,7 @@ import {
   TeamNewInput,
   TeamUpdateInput,
 } from "@badman/backend-database";
+import { IndexCalculationService } from "@badman/backend-enrollment";
 import { SubEventTypeEnum } from "@badman/utils";
 import { TeamsResolver } from "./team.resolver";
 
@@ -61,6 +62,20 @@ describe("TeamsResolver.createTeam", () => {
         {
           provide: Sequelize,
           useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+        },
+        {
+          provide: IndexCalculationService,
+          useValue: {
+            calculate: jest.fn().mockResolvedValue([]),
+            calculateOne: jest.fn().mockResolvedValue({
+              _tag: "success",
+              key: "team-key",
+              index: 0,
+              contributingPlayers: [],
+              missingPlayerCount: 0,
+              resolvedPlayers: [],
+            }),
+          },
         },
       ],
     }).compile();
@@ -194,7 +209,7 @@ describe("TeamsResolver.createTeam", () => {
     expect(mockTransaction.rollback).toHaveBeenCalled();
   });
 
-  it("returns RANKING_NOT_FOUND when a base-lineup player has no ranking", async () => {
+  it("propagates PLAYER_NOT_FOUND from IndexCalculationService", async () => {
     const user = userWithPermission(true);
     const dbClub = stubClub();
     const created = stubCreatedTeam();
@@ -204,14 +219,29 @@ describe("TeamsResolver.createTeam", () => {
     jest
       .spyOn(EventEntry, "findOrCreate")
       .mockResolvedValue([
-        { meta: {}, save: jest.fn().mockResolvedValue(undefined) } as never,
+        { id: "entry-uuid", meta: {}, save: jest.fn().mockResolvedValue(undefined) } as never,
         true,
       ]);
-    jest.spyOn(RankingSystem, "findOne").mockResolvedValue({ id: "ranking-system-uuid" } as never);
     jest
       .spyOn(Player, "findAll")
       .mockResolvedValue([{ id: "player-1", gender: "M" } as unknown as Player]);
-    jest.spyOn(RankingLastPlace, "findAll").mockResolvedValue([]); // no rankings
+
+    // Override the service mock for this test: simulate PLAYER_NOT_FOUND.
+    // The resolver should map this to ErrorCode.PLAYER_NOT_FOUND and roll back.
+    const calculateOneMock = (
+      resolver as unknown as {
+        indexCalculationService: { calculateOne: jest.Mock };
+      }
+    ).indexCalculationService.calculateOne;
+    calculateOneMock.mockResolvedValueOnce({
+      _tag: "failure",
+      key: "entry-uuid",
+      error: {
+        code: "PLAYER_NOT_FOUND",
+        message: "Players not found: player-1",
+        playerIds: ["player-1"],
+      },
+    });
 
     const input = baseInput({
       entry: {
@@ -230,8 +260,8 @@ describe("TeamsResolver.createTeam", () => {
       fail("expected throw");
     } catch (err) {
       const e = err as GraphQLError;
-      expect(e.extensions["code"]).toBe("RANKING_NOT_FOUND");
-      expect(e.extensions["playerId"]).toBe("player-1");
+      expect(e.extensions["code"]).toBe("PLAYER_NOT_FOUND");
+      expect(e.extensions["playerIds"]).toContain("player-1");
     }
 
     expect(mockTransaction.rollback).toHaveBeenCalled();
@@ -274,6 +304,20 @@ describe("TeamsResolver.createTeams", () => {
         {
           provide: Sequelize,
           useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+        },
+        {
+          provide: IndexCalculationService,
+          useValue: {
+            calculate: jest.fn().mockResolvedValue([]),
+            calculateOne: jest.fn().mockResolvedValue({
+              _tag: "success",
+              key: "team-key",
+              index: 0,
+              contributingPlayers: [],
+              missingPlayerCount: 0,
+              resolvedPlayers: [],
+            }),
+          },
         },
       ],
     }).compile();
@@ -372,6 +416,20 @@ describe("TeamsResolver.updateTeam", () => {
         {
           provide: Sequelize,
           useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+        },
+        {
+          provide: IndexCalculationService,
+          useValue: {
+            calculate: jest.fn().mockResolvedValue([]),
+            calculateOne: jest.fn().mockResolvedValue({
+              _tag: "success",
+              key: "team-key",
+              index: 0,
+              contributingPlayers: [],
+              missingPlayerCount: 0,
+              resolvedPlayers: [],
+            }),
+          },
         },
       ],
     }).compile();

--- a/libs/backend/graphql/src/resolvers/team/team.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/team/team.resolver.ts
@@ -7,8 +7,6 @@ import {
   Location,
   Player,
   PlayerWithTeamMembershipType,
-  RankingLastPlace,
-  RankingSystem,
   Team,
   TeamNewInput,
   TeamPlayerMembership,
@@ -16,10 +14,13 @@ import {
   TeamWithPlayerMembershipType,
 } from "@badman/backend-database";
 import {
+  IndexCalculationService,
+  isFailure,
+} from "@badman/backend-enrollment";
+import {
   IsUUID,
   SubEventTypeEnum,
   TeamMembershipType,
-  getIndexFromPlayers,
   getLetterForRegion,
 } from "@badman/utils";
 import {
@@ -39,7 +40,10 @@ import { TeamResult } from "./team-result.object";
 export class TeamsResolver {
   private readonly logger = new Logger(TeamsResolver.name);
 
-  constructor(private _sequelize: Sequelize) {}
+  constructor(
+    private _sequelize: Sequelize,
+    private readonly indexCalculationService: IndexCalculationService
+  ) {}
 
   @Query(() => Team)
   async team(@Args("id", { type: () => ID }) id: string): Promise<Team> {
@@ -290,74 +294,60 @@ export class TeamsResolver {
         });
 
         if (entry?.meta?.competition?.players) {
-          const system = await RankingSystem.findOne({
-            where: { primary: true },
-            transaction,
-          });
-          if (!system) {
-            this.logger.error({
-              code: ErrorCode.INTERNAL_ERROR,
-              reason: "primary ranking system missing",
+          // Delegate to IndexCalculationService for the canonical rank lookup
+          // (validator's June 10 cutoff + min+2 fallback) and index math.
+          const playerIds = (entry.meta.competition.players?.map((p) => p.id) || []) as string[];
+          const result = await this.indexCalculationService.calculateOne(
+            {
+              key: dbEntry.id!,
+              type: teamDb.type,
+              subEventCompetitionId: entry.subEventId,
+              players: playerIds.map((id) => ({ id })),
+            },
+            { transaction }
+          );
+          if (isFailure(result)) {
+            this.logger.warn({
+              code: result.error.code,
               clubId: dbClub.id,
               userId,
-            });
-            throw new GraphQLError("Primary ranking system not configured.", {
-              extensions: { code: ErrorCode.INTERNAL_ERROR },
-            });
-          }
-
-          const competitionPlayers: EntryCompetitionPlayer[] = [];
-          const playerIds = (entry.meta.competition.players?.map((p) => p.id) || []) as string[];
-          const rankings = await RankingLastPlace.findAll({
-            where: { playerId: { [Op.in]: playerIds }, systemId: system.id },
-            transaction,
-          });
-          const dbBasePlayers = await Player.findAll({
-            where: { id: { [Op.in]: playerIds } },
-            transaction,
-          });
-
-          for (const p of entry.meta.competition.players) {
-            const player = dbBasePlayers.find((dbPlayer) => dbPlayer.id === p.id);
-            if (!player) {
-              this.logger.warn({
-                code: ErrorCode.PLAYER_NOT_FOUND,
-                playerId: p.id,
-                clubId: dbClub.id,
-                userId,
-              });
-              throw new GraphQLError(`Player not found: ${p.id}`, {
-                extensions: { code: ErrorCode.PLAYER_NOT_FOUND, playerId: p.id },
-              });
-            }
-            const ranking = rankings.find((r) => r.playerId === p.id);
-            if (!ranking) {
-              this.logger.warn({
-                code: ErrorCode.RANKING_NOT_FOUND,
-                playerId: p.id,
-                clubId: dbClub.id,
-                userId,
-              });
-              throw new GraphQLError(`Ranking for player ${p.id} not found`, {
-                extensions: { code: ErrorCode.RANKING_NOT_FOUND, playerId: p.id },
-              });
-            }
-            competitionPlayers.push({
-              id: player.id,
-              gender: player.gender,
-              single: ranking.single,
-              double: ranking.double,
-              mix: ranking.mix,
-              levelException: p.levelException,
-              levelExceptionReason: p.levelExceptionReason,
-              levelExceptionRequested: p.levelExceptionRequested,
+            }, result.error.message);
+            const code =
+              result.error.code === "PLAYER_NOT_FOUND"
+                ? ErrorCode.PLAYER_NOT_FOUND
+                : result.error.code === "RANKING_SYSTEM_NOT_FOUND"
+                ? ErrorCode.INTERNAL_ERROR
+                : ErrorCode.INTERNAL_ERROR;
+            throw new GraphQLError(result.error.message, {
+              extensions: {
+                code,
+                ...(result.error.playerIds ? { playerIds: result.error.playerIds } : {}),
+              },
             });
           }
 
-          const index = getIndexFromPlayers(teamDb.type, competitionPlayers);
+          const origById = new Map(
+            entry.meta.competition.players.map((p) => [p.id, p])
+          );
+          const competitionPlayers: EntryCompetitionPlayer[] = result.resolvedPlayers.map(
+            (rp) => {
+              const orig = origById.get(rp.id);
+              return {
+                id: rp.id,
+                gender: rp.gender,
+                single: rp.single,
+                double: rp.double,
+                mix: rp.mix,
+                levelException: orig?.levelException,
+                levelExceptionReason: orig?.levelExceptionReason,
+                levelExceptionRequested: orig?.levelExceptionRequested,
+              };
+            }
+          );
+
           dbEntry.meta = {
             ...dbEntry.meta,
-            competition: { teamIndex: index, players: competitionPlayers },
+            competition: { teamIndex: result.index, players: competitionPlayers },
           };
           await dbEntry.save({ transaction, hooks: false });
         }


### PR DESCRIPTION
## Summary
- IndexCalculationService and the validator computed baseIndex with different ranking-snapshot windows; client confirmed validator's result is correct.
- Service rewritten to validator's rule: `rankingDate <= moment([season, 5, 10])` (June 10 cutoff), no `updatePossible` filter, per-discipline fallback `min(s,d,m) + 2`. `subEventCompetitionId` now only derives `type` / `season`.
- All entrypoints (validator, `calculateIndex` resolver, EventEntry hook, `team.resolver` `createTeam`) route through `IndexCalculationService` so FE preview, API, DB hook, and validation always agree.

## Test plan
- [ ] `npx jest --config libs/backend/competition/enrollment/jest.config.ts` — 34/34
- [ ] `npx jest --config libs/backend/database/jest.config.ts` — 16/16
- [ ] `npx jest --config libs/backend/graphql/jest.config.ts` — 200/200 (1 pre-existing skip)
- [ ] FE preview (`calculateIndex` query) and `validateEnrollment` return identical baseIndex for the team that triggered this report
- [ ] `EventEntry` save hook writes the same `meta.competition.teamIndex`
- [ ] Spot-check an MX team and a team with <4 players for penalty math

🤖 Generated with [Claude Code](https://claude.com/claude-code)