### PR TITLE
fix(graphql): enable introspection in production

### DIFF
--- a/libs/backend/graphql/src/grapqhl.module.ts
+++ b/libs/backend/graphql/src/grapqhl.module.ts
@@ -64,6 +64,7 @@ import { ServiceResolverModule } from "./resolvers/services/serice.module";
             origin: "*",
           },
           playground: false,
+          introspection: true,
           debug: true,
           autoSchemaFile: join(process.cwd(), "schema.gql"),
           buildSchemaOptions: {


### PR DESCRIPTION
## Summary
- Enable Apollo Server introspection in all environments so GraphQL Code Generator and other schema-consuming tools can load the schema from `https://api.badman.app/graphql`.

## Problem
Apollo Server blocks introspection by default in production, causing:
```
Failed to load schema from https://api.badman.app/graphql:
GraphQL introspection is not allowed by Apollo Server, but the query contained __schema or __type.
To enable introspection, pass introspection: true to ApolloServer in production
```

## Fix
Add `introspection: true` to the `GraphQLModule` config in `libs/backend/graphql/src/grapqhl.module.ts`.

## Test plan
- [ ] Deploy and run codegen against production endpoint
- [ ] Verify introspection query returns schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)