### PR TITLE
refactor(ranking-sync): emit per-pub progress, drop hook noise

### DIFF
--- a/apps/worker/sync/src/app/processors/sync-ranking/ranking-sync.ts
+++ b/apps/worker/sync/src/app/processors/sync-ranking/ranking-sync.ts
@@ -263,27 +263,25 @@ export class RankingSyncer {
         (!ranking.stopDate || isBefore(publication.date, ranking.stopDate))
     );
 
+    const totalPublications = publicationsToProcess.length;
+    const runStart = Date.now();
     this.logger.log(
-      `Processing ${publicationsToProcess.length} publications with separate transactions`
+      `Processing ${totalPublications} publications with separate transactions`
     );
 
     for (const [index, publication] of publicationsToProcess.entries()) {
       // Create a separate transaction for each publication
       const publicationTransaction = await this._sequelize.transaction();
+      const pubStart = Date.now();
 
       try {
+        const progressPct = Math.round(((index + 1) / totalPublications) * 100);
         this.logger.log(
-          `Processing publication ${publication.name} (${format(publication.date, "yyyy-MM-dd")}) - ${index + 1}/${publicationsToProcess.length}`
+          `[${index + 1}/${totalPublications}] (${progressPct}%) Processing publication ${publication.name} (${format(publication.date, "yyyy-MM-dd")})${publication.usedForUpdate ? " — UPDATE" : ""}`
         );
 
-        if (publication.usedForUpdate) {
-          this.logger.log(
-            `This publication will update rankings: ${publication.date.toLocaleString()}`
-          );
-        }
-
         // Process this single publication with its own transaction
-        await this.processSinglePublication(
+        const pubStats = await this.processSinglePublication(
           publication,
           categories,
           ranking,
@@ -292,7 +290,11 @@ export class RankingSyncer {
 
         // Commit the transaction for this publication
         await publicationTransaction.commit();
-        this.logger.debug(`Committed transaction for publication ${publication.name}`);
+        const pubElapsedS = ((Date.now() - pubStart) / 1000).toFixed(1);
+        const runElapsedS = ((Date.now() - runStart) / 1000).toFixed(1);
+        this.logger.log(
+          `[${index + 1}/${totalPublications}] Done in ${pubElapsedS}s — ${pubStats.places} places, ${pubStats.newPlayers} new players (run total ${runElapsedS}s)`
+        );
 
         // Force garbage collection after each publication
         if (global.gc) {
@@ -314,7 +316,7 @@ export class RankingSyncer {
     categories: CategoriesStepData[],
     ranking: RankingStepData,
     transaction: Transaction
-  ) {
+  ): Promise<{ places: number; newPlayers: number }> {
     const rankingPlaces = new Map<string, RankingPlace>();
     const newPlayers = new Map<string, Player>();
 
@@ -466,8 +468,9 @@ export class RankingSyncer {
     }
 
     // Create new players first
-    this.logger.debug(`Creating ${newPlayers.size} new players`);
-    if (newPlayers.size > 0) {
+    const newPlayerCount = newPlayers.size;
+    if (newPlayerCount > 0) {
+      this.logger.log(`Creating ${newPlayerCount} new players`);
       const newPlayersMap = Array.from(newPlayers).map(([, player]) => player.toJSON());
       await Player.bulkCreate(newPlayersMap, {
         ignoreDuplicates: true,
@@ -478,15 +481,21 @@ export class RankingSyncer {
 
     // Process ranking places in very small chunks
     const instances = Array.from(rankingPlaces).map(([, place]) => place.toJSON());
-    this.logger.debug(`Creating/updating ${instances.length} ranking places`);
-
+    const placeCount = instances.length;
     const chunkSize = 500; // Ultra small chunks to prevent lock exhaustion
+    const totalChunks = Math.ceil(placeCount / chunkSize);
+    this.logger.log(`Creating/updating ${placeCount} ranking places in ${totalChunks} chunks`);
+
     for (let i = 0; i < instances.length; i += chunkSize) {
       const chunk = instances.slice(i, i + chunkSize);
+      const chunkNum = Math.floor(i / chunkSize) + 1;
 
-      this.logger.verbose(
-        `Processing batch ${Math.floor(i / chunkSize) + 1}/${Math.ceil(instances.length / chunkSize)} (${chunk.length} records)`
-      );
+      // Only log every 5th chunk (or first/last) to avoid noise on big publications
+      if (chunkNum === 1 || chunkNum === totalChunks || chunkNum % 5 === 0) {
+        this.logger.log(
+          `  chunk ${chunkNum}/${totalChunks} (${chunk.length} records)`
+        );
+      }
 
       await RankingPlace.bulkCreate(chunk, {
         updateOnDuplicate: [
@@ -511,13 +520,11 @@ export class RankingSyncer {
       }
     }
 
-    this.logger.verbose(
-      `Finished processing ${instances.length} ranking places for ${publication.name}`
-    );
-
     // Clear memory immediately
     rankingPlaces.clear();
     newPlayers.clear();
+
+    return { places: placeCount, newPlayers: newPlayerCount };
   }
 
   protected queueMissingRankingPlayers(): ProcessStep {

--- a/libs/backend/database/src/models/ranking/ranking-place.model.ts
+++ b/libs/backend/database/src/models/ranking/ranking-place.model.ts
@@ -257,7 +257,6 @@ export class RankingPlace extends Model {
     instances: RankingPlace[] | RankingPlace,
     options: SaveOptions
   ) {
-    console.log("updateLatestRankingsCreate called");
     if (!Array.isArray(instances)) {
       instances = [instances];
     }


### PR DESCRIPTION
## Summary

- Remove per-row `console.log("updateLatestRankingsCreate called")` in `RankingPlace.updateLatestRankingsCreate` hook. Fired on every `@AfterCreate` / `@AfterUpsert` / `@AfterBulkCreate` — drowned worker-sync logs with tens of thousands of lines per sync run.
- Per-publication loop now logs `[index/total] (percent%)` header, elapsed time per pub, and a final summary with place + new-player counts threaded from the inner step.
- Chunk progress throttled (first, last, every 5th) and promoted to info level so default Nest log level shows it.

## Sample new output

```
[3/15] (20%) Processing publication 2026-05-04 (2026-05-04) — UPDATE
Creating 12 new players
Creating/updating 4823 ranking places in 10 chunks
  chunk 1/10 (500 records)
  chunk 5/10 (500 records)
  chunk 10/10 (323 records)
[3/15] Done in 47.2s — 4823 places, 12 new players (run total 142.8s)
```

## Test plan

- [ ] Restart `worker-sync` on staging, enqueue `Sync.SyncRanking` with an explicit window, confirm new log format appears and `updateLatestRankingsCreate called` no longer printed
- [ ] Verify `RankingLastPlace` hook still fires (per-batch summary, not per-row) by checking a player's `RankingLastPlace.rankingDate` matches latest `RankingPlace`