### PR TITLE
fix(team-resolver): coerce nullable gender to undefined in finishCreateTeams

### DIFF
--- a/libs/backend/graphql/src/resolvers/team/team.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/team/team.resolver.ts
@@ -363,7 +363,7 @@ export class TeamsResolver {
               const orig = origById.get(rp.id);
               return {
                 id: rp.id,
-                gender: rp.gender,
+                gender: rp.gender ?? undefined,
                 single: rp.single,
                 double: rp.double,
                 mix: rp.mix,


### PR DESCRIPTION
## Summary
- 1-line TS fix at [team.resolver.ts:366](libs/backend/graphql/src/resolvers/team/team.resolver.ts#L366): coerce `rp.gender ?? undefined` when mapping `resolvedPlayers` → `EntryCompetitionPlayer[]`.
- Source `Player.gender` is `"M" | "F" | null | undefined`; target type is `"M" | "F" | undefined`. The `null` arm was a TS2322 error that blocked `team.resolver.spec.ts` from compiling on develop.
- Behavior unchanged at runtime — downstream code already treats falsy gender the same way.

## Test plan
- [x] `npx jest --config libs/backend/graphql/jest.config.ts --testPathPattern team.resolver` → 17/17 pass, suite now compiles.
- [ ] Verify CI lint/typecheck on `develop` rebase.

## Merge order
Recommended after #900 (clears develop's pre-existing lint debt) and before `chore/remove-team-renumber-spec-008` (depends on `team.resolver.ts` compiling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)