### PR TITLE
fix(sync-events): keep job running on per-tournament failure

### DIFF
--- a/apps/worker/sync/src/app/processors/sync-events/__tests__/sync-events.processor.spec.ts
+++ b/apps/worker/sync/src/app/processors/sync-events/__tests__/sync-events.processor.spec.ts
@@ -4,11 +4,21 @@ import { VisualService, XmlTournamentTypeID } from "@badman/backend-visual";
 import { PointsService } from "@badman/backend-ranking";
 import { EncounterGamesGenerationService } from "@badman/backend-encounter-games";
 import { Test, TestingModule } from "@nestjs/testing";
+import * as Sentry from "@sentry/nestjs";
 import { SyncEventsProcessor } from "../sync-events.processor";
 import { CompetitionSyncer } from "../competition-sync";
 import { TournamentSyncer } from "../tournament-sync";
 import { Sync, SyncQueue } from "@badman/backend-queue";
 import { Sequelize } from "sequelize-typescript";
+
+jest.mock("@sentry/nestjs", () => ({
+  __esModule: true,
+  withScope: jest.fn((cb: (scope: any) => void) => {
+    cb({ setLevel: jest.fn(), setTag: jest.fn(), setContext: jest.fn(), setFingerprint: jest.fn() });
+  }),
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -242,18 +252,36 @@ describe("SyncEventsProcessor", () => {
       expect(sequelize._mockTransaction.rollback).not.toHaveBeenCalled();
     });
 
-    it("rolls back transaction on syncer error", async () => {
+    it("rolls back transaction on syncer error, reports to Sentry, and does not throw", async () => {
       const event = makeXmlEvent();
       visualService.getChangeEvents.mockResolvedValue([event] as any);
       competitionSyncSpy.mockRejectedValue(new Error("Sync failed"));
 
       const job = makeJob();
-      await expect(processor.syncEvents(job as any)).rejects.toThrow("Sync failed");
+      await expect(processor.syncEvents(job as any)).resolves.toBeUndefined();
 
       expect(sequelize._mockTransaction.rollback).toHaveBeenCalled();
       expect(sequelize._mockTransaction.commit).not.toHaveBeenCalled();
+      expect(Sentry.captureException).toHaveBeenCalledWith(expect.objectContaining({ message: "Sync failed" }));
     });
 
+    it("continues with next tournament after a prior one fails (Sentry #104397491 resilience)", async () => {
+      (Sentry.captureException as jest.Mock).mockClear();
+      const event1 = makeXmlEvent({ Name: "Bad Event", ID: "event-1" });
+      const event2 = makeXmlEvent({ Name: "Good Event", ID: "event-2" });
+      visualService.getChangeEvents.mockResolvedValue([event1, event2] as any);
+      competitionSyncSpy
+        .mockRejectedValueOnce(new Error("Visual API returned a malformed Player payload"))
+        .mockResolvedValueOnce({ event: { id: "comp-good" } } as any);
+
+      const job = makeJob();
+      await expect(processor.syncEvents(job as any)).resolves.toBeUndefined();
+
+      expect(competitionSyncSpy).toHaveBeenCalledTimes(2);
+      expect(sequelize._mockTransaction.rollback).toHaveBeenCalledTimes(1);
+      expect(sequelize._mockTransaction.commit).toHaveBeenCalledTimes(1);
+      expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("notifications", () => {
@@ -270,13 +298,13 @@ describe("SyncEventsProcessor", () => {
       });
     });
 
-    it("notifies user of failed sync", async () => {
+    it("notifies user of failed sync without aborting the job", async () => {
       const event = makeXmlEvent();
       visualService.getChangeEvents.mockResolvedValue([event] as any);
       competitionSyncSpy.mockRejectedValue(new Error("Sync failed"));
 
       const job = makeJob({ userId: "user-1" });
-      await expect(processor.syncEvents(job as any)).rejects.toThrow();
+      await expect(processor.syncEvents(job as any)).resolves.toBeUndefined();
 
       expect(notificationService.notifySyncFinished).toHaveBeenCalledWith("user-1", {
         event: expect.objectContaining({ name: event.Name }),

--- a/apps/worker/sync/src/app/processors/sync-events/sync-events.processor.ts
+++ b/apps/worker/sync/src/app/processors/sync-events/sync-events.processor.ts
@@ -5,6 +5,7 @@ import { VisualService, XmlTournament, XmlTournamentTypeID } from "@badman/backe
 import { Process, Processor } from "@nestjs/bull";
 import { Logger } from "@nestjs/common";
 import { Job } from "bull";
+import * as Sentry from "@sentry/nestjs";
 import { Sequelize } from "sequelize-typescript";
 import { CompetitionSyncer } from "./competition-sync";
 import { TournamentSyncer } from "./tournament-sync";
@@ -199,8 +200,25 @@ export class SyncEventsProcessor {
             }
           }
         } catch (e) {
-          this.logger.error("Rollback", e);
+          this.logger.error(`Rollback for ${xmlTournament?.Name}`, e);
           await transaction.rollback();
+
+          // Report to Sentry but DO NOT re-throw — one bad tournament must
+          // not abort the whole run. The outer catch still handles non-loop
+          // failures (e.g. searchEvents itself throwing). See Sentry
+          // #104397491 for the originating incident.
+          Sentry.withScope((scope) => {
+            scope.setTag("queue", SyncQueue);
+            scope.setTag("job_name", Sync.SyncEvents);
+            scope.setContext("tournament", {
+              code: xmlTournament?.Code,
+              name: xmlTournament?.Name,
+              typeId: xmlTournament?.TypeID,
+              index: i,
+              total: toProcess,
+            });
+            Sentry.captureException(e);
+          });
 
           if (job.data?.userId) {
             const userIds = Array.isArray(job.data?.userId) ? job.data?.userId : [job.data?.userId];
@@ -214,7 +232,7 @@ export class SyncEventsProcessor {
               });
             }
           }
-          throw e;
+          continue;
         }
       }
     } catch (e) {

--- a/libs/backend/visual/package.json
+++ b/libs/backend/visual/package.json
@@ -14,7 +14,8 @@
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.47",
     "cache-manager": "^5.7.6",
-    "@nestjs/cache-manager": "^2.3.0"
+    "@nestjs/cache-manager": "^2.3.0",
+    "@sentry/nestjs": "^10.43.0"
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/libs/backend/visual/src/services/__tests__/visual.service.spec.ts
+++ b/libs/backend/visual/src/services/__tests__/visual.service.spec.ts
@@ -2,8 +2,18 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { ConfigService } from "@nestjs/config";
 import { CACHE_MANAGER } from "@nestjs/cache-manager";
 import { VisualService } from "../visual.service";
+import * as Sentry from "@sentry/nestjs";
 import axios from "axios";
 import { formatInTimeZone } from "date-fns-tz";
+
+jest.mock("@sentry/nestjs", () => ({
+  __esModule: true,
+  withScope: jest.fn((cb: (scope: any) => void) => {
+    cb({ setLevel: jest.fn(), setTag: jest.fn(), setContext: jest.fn(), setFingerprint: jest.fn() });
+  }),
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
 
 jest.mock("axios", () => {
   const mockAxios: any = jest.fn().mockResolvedValue({ data: "" });
@@ -470,6 +480,67 @@ describe("VisualService", () => {
       await expect(service.getPoints(RANKING_ID, "PUB1", "CAT1", false)).rejects.toThrow(
         /Invalid RankingPublicationPoints response/
       );
+    });
+  });
+
+  describe("getPlayers", () => {
+    const TOURNEY_ID = "T-LOSSY-1";
+
+    it("returns the validated player list", async () => {
+      httpGet.mockResolvedValueOnce({
+        data: JSON.stringify({
+          Player: [
+            { MemberID: "M001", Firstname: "Alice", Lastname: "A" },
+            { MemberID: 12345, Firstname: "Bob", Lastname: "B" },
+          ],
+        }),
+      });
+
+      const result = await service.getPlayers(TOURNEY_ID, false);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].MemberID).toBe("M001");
+      expect(result[1].MemberID).toBe("12345");
+    });
+
+    // Regression: Sentry #104397491 — Visual API sporadically returns Player
+    // rows without a MemberID. Strict validation killed the whole SyncEvents
+    // job; lossy validation must drop the bad rows, keep the good ones, and
+    // report each drop to Sentry as a warning (fingerprinted per field path
+    // so all rows with the same defect collapse into one issue).
+    it("drops Player entries missing MemberID instead of throwing", async () => {
+      const warnSpy = jest.spyOn((service as any).logger, "warn").mockImplementation(() => undefined);
+      (Sentry.captureMessage as jest.Mock).mockClear();
+      (Sentry.withScope as jest.Mock).mockClear();
+
+      httpGet.mockResolvedValueOnce({
+        data: JSON.stringify({
+          Player: [
+            { Firstname: "NoID" },
+            { MemberID: "M001", Firstname: "Alice" },
+            { Firstname: "AlsoNoID" },
+            { MemberID: "M002", Firstname: "Bob" },
+          ],
+        }),
+      });
+
+      const result = await service.getPlayers(TOURNEY_ID, false);
+
+      expect(result).toHaveLength(2);
+      expect(result.map((p) => p.MemberID)).toEqual(["M001", "M002"]);
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/dropping invalid Player entry at index 0/);
+      expect(warnSpy.mock.calls[1][0]).toMatch(/dropping invalid Player entry at index 2/);
+      expect(Sentry.captureMessage).toHaveBeenCalledTimes(2);
+      expect(Sentry.captureMessage).toHaveBeenCalledWith(
+        expect.stringMatching(/Visual API Player entry dropped.*MemberID/)
+      );
+    });
+
+    it("returns empty array when the API has no players", async () => {
+      httpGet.mockResolvedValueOnce({ data: `<?xml version="1.0"?><Result></Result>` });
+
+      expect(await service.getPlayers(TOURNEY_ID, false)).toEqual([]);
     });
   });
 

--- a/libs/backend/visual/src/services/visual.service.ts
+++ b/libs/backend/visual/src/services/visual.service.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosInstance } from "axios";
 import axiosRetry from "axios-retry";
 import { XMLParser } from "fast-xml-parser";
+import * as Sentry from "@sentry/nestjs";
 
 import { Inject, Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
@@ -38,6 +39,7 @@ import {
   XmlTournamentSchema,
   parseResponse,
   validateMany,
+  validateManyLossy,
   validateOne,
 } from "../utils";
 import { z } from "zod";
@@ -74,11 +76,40 @@ export class VisualService {
   }
 
   async getPlayers(tourneyId: string, useCache = true): Promise<XmlPlayer[]> {
-    return this._fetchMany<XmlPlayer>(
-      `${this._vr()}/Tournament/${tourneyId}/Player`,
-      "Player",
+    // Lossy validation: Visual API sporadically returns Player rows without
+    // a MemberID (Sentry #104397491). Such rows are useless downstream
+    // (cannot be matched to a member record) so we drop them with a warn
+    // log + a Sentry breadcrumb instead of killing the whole SyncEvents job.
+    const url = `${this._vr()}/Tournament/${tourneyId}/Player`;
+    const result = await this._getFromApi(url, useCache);
+    const parsed = parseResponse(result, this._parser, this.logger) as XmlResult;
+    return validateManyLossy<XmlPlayer>(
+      parsed.Player,
       XmlPlayerSchema,
-      useCache
+      "Player",
+      this.logger,
+      ({ index, payloadKey, error }) => {
+        Sentry.withScope((scope) => {
+          scope.setLevel("warning");
+          scope.setTag("payload_key", payloadKey);
+          scope.setTag("tournament_id", tourneyId);
+          // Fingerprint by field path so all rows missing the same field
+          // collapse to one Sentry issue across runs. validateManyLossy
+          // validates each element separately, so issue.path already starts
+          // at the field name (no array index to strip).
+          const firstIssue = error.errors[0];
+          const fieldPath = firstIssue?.path.join(".") || "unknown";
+          scope.setFingerprint(["visual-lossy-drop", payloadKey, fieldPath]);
+          scope.setContext("zodError", {
+            index,
+            fieldPath,
+            message: error.message,
+          });
+          Sentry.captureMessage(
+            `Visual API ${payloadKey} entry dropped: missing/invalid ${fieldPath}`
+          );
+        });
+      }
     );
   }
 

--- a/libs/backend/visual/src/utils/visual-parsing.ts
+++ b/libs/backend/visual/src/utils/visual-parsing.ts
@@ -149,6 +149,61 @@ export function validateMany<TOut>(
 }
 
 /**
+ * Same shape as `validateMany`, but drops individual entries that fail the
+ * schema instead of throwing for the whole list. Use this only when one
+ * bad row should not poison a whole sync run — i.e. the dataset is a flat
+ * list of independently-useful records and a missing-field entry is
+ * cosmetically broken upstream rather than a contract violation.
+ *
+ * Each dropped entry is logged with its index and the Zod error so we keep
+ * visibility into upstream rot.
+ *
+ * Reference: Sentry #104397491 (SyncEvents) — the Visual API `Player` list
+ * sporadically contains rows without `MemberID`, which the strict
+ * `validateMany` rejects, killing the whole job.
+ */
+export interface LossyDropInfo {
+  index: number;
+  payloadKey: string;
+  error: z.ZodError;
+  value: unknown;
+}
+
+export function validateManyLossy<TOut>(
+  value: unknown,
+  schema: z.ZodTypeAny,
+  payloadKey: string,
+  logger: Logger,
+  onDrop?: (info: LossyDropInfo) => void
+): TOut[] {
+  if (value == null) return [];
+  const candidates = asArray(value);
+  const out: TOut[] = [];
+  for (let i = 0; i < candidates.length; i++) {
+    const result = schema.safeParse(candidates[i]);
+    if (result.success) {
+      out.push(result.data as TOut);
+    } else {
+      logger.warn(
+        `[visual] dropping invalid ${payloadKey} entry at index ${i}: ${result.error.message}`
+      );
+      if (onDrop) {
+        try {
+          onDrop({ index: i, payloadKey, error: result.error, value: candidates[i] });
+        } catch (cbErr) {
+          // Never let a reporting hook fail the sync — log and continue.
+          logger.error(
+            `[visual] onDrop callback threw while reporting ${payloadKey} drop:`,
+            cbErr
+          );
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/**
  * Validate a single-object payload from the API. Returns undefined when
  * the payload is missing; throws a clear error on shape mismatch.
  *


### PR DESCRIPTION
## Summary

A single tournament whose Visual API payload fails Zod validation (Sentry [#104397491](https://badminton-apps.sentry.io/issues/104397491/) — sporadic `Player` rows without `MemberID`) used to throw out of the per-tournament try/catch and abort the entire `SyncEvents` run, skipping every later tournament in the batch.

Two-layer fix:

- **Row-level**: `validateManyLossy` gains an optional `onDrop` callback. `VisualService.getPlayers` wires it to `Sentry.captureMessage` (warning level), fingerprinted by field path so all rows with the same defect collapse into a single Sentry issue across runs. Good rows still flow through; bad rows are dropped with a `logger.warn` + Sentry report.
- **Tournament-level**: the `SyncEvents` per-tournament catch now reports to `Sentry.captureException` and `continue`s instead of rethrowing. The outer catch is preserved, so genuine job-wide failures (e.g. `searchEvents` itself throwing) still surface as a failed Bull job.

## Files

- `libs/backend/visual/src/utils/visual-parsing.ts` — `onDrop` callback on `validateManyLossy`
- `libs/backend/visual/src/services/visual.service.ts` — wire Sentry into `getPlayers`
- `libs/backend/visual/package.json` — add `@sentry/nestjs` dep
- `apps/worker/sync/src/app/processors/sync-events/sync-events.processor.ts` — Sentry + `continue` in per-tournament catch

## Test plan

- [x] `nx test backend-visual` — 74/74 (3 new `getPlayers` tests covering happy path, lossy drop with Sentry assert, empty payload)
- [x] `nx test worker-sync --testPathPattern=sync-events.processor` — 25/25 (2 updated tests + 1 new "continues with next tournament after a prior one fails")
- [x] `nx build backend-visual` clean
- [x] `nx build worker-sync` clean
- [ ] Watch Sentry #104397491 after deploy — expect the issue to stop reopening as a job-fatal error and instead surface dropped Player rows as a warning-level issue grouped by field path

🤖 Generated with [Claude Code](https://claude.com/claude-code)