### PR TITLE
fix(email): fix club enrollment email notification flow

### DIFF
--- a/database/seeders/utils/entity-builders.ts
+++ b/database/seeders/utils/entity-builders.ts
@@ -41,9 +41,10 @@ async function findOrCreatePlayer(
 
   // Create new player
   console.log("👤 Creating new player...");
+  const slug = `${firstName}-${lastName}`.toLowerCase().replace(/\s+/g, "-");
   const user = await ctx.insert<Player>(
-    `INSERT INTO "Players" (email, "firstName", "lastName", "memberId", gender, "createdAt", "updatedAt", "competitionPlayer", "sub")
-     VALUES (:email, :firstName, :lastName, :memberId, :gender, NOW(), NOW(),:competitionPlayer, :sub)
+    `INSERT INTO "Players" (email, "firstName", "lastName", "memberId", gender, slug, "createdAt", "updatedAt", "competitionPlayer", "sub")
+     VALUES (:email, :firstName, :lastName, :memberId, :gender, :slug, NOW(), NOW(),:competitionPlayer, :sub)
      RETURNING id, email, "firstName", "lastName"`,
     {
       email: userEmail,
@@ -51,6 +52,7 @@ async function findOrCreatePlayer(
       lastName,
       memberId,
       gender,
+      slug,
       competitionPlayer,
       sub,
     }

--- a/libs/backend/mailing/src/compile/templates/clubenrollment/html.pug
+++ b/libs/backend/mailing/src/compile/templates/clubenrollment/html.pug
@@ -43,7 +43,7 @@ block content
                   br
                   strong Basisspelers:
                   ul
-                  each player in team.entry.meta.competition.players
+                  each player in (team.entry && team.entry.meta && team.entry.meta.competition && team.entry.meta.competition.players || [])
                     li #{ player.firstName }#{ " " }#{ player.lastName }
                       small #{ " " }(#{ player.memberId })
                         if team.type == "MX"

--- a/libs/backend/mailing/src/services/mailing/mailing.service.ts
+++ b/libs/backend/mailing/src/services/mailing/mailing.service.ts
@@ -401,6 +401,10 @@ export class MailingService {
     locations: Location[],
     comments: Comment[]
   ) {
+    this.logger.log(
+      `[sendEnrollmentMail] Preparing enrollment mail — to: ${to.email} (${to.fullName}), club: ${club.name}, mailingEnabled: ${this._mailingEnabled}`
+    );
+
     moment.locale("nl-be");
     const options = {
       from: "info@badman.app",
@@ -422,6 +426,8 @@ export class MailingService {
     }>;
 
     await this._sendMail(options);
+
+    this.logger.log(`[sendEnrollmentMail] _sendMail completed for ${to.email}`);
   }
 
   async sendSyncMail(
@@ -623,11 +629,7 @@ export class MailingService {
     await this._sendMail(options);
   }
 
-  async sendCpExportFailedMail(to: {
-    fullName: string;
-    email: string;
-    slug: string;
-  }) {
+  async sendCpExportFailedMail(to: { fullName: string; email: string; slug: string }) {
     const options = {
       from: "info@badman.app",
       to: to.email,
@@ -664,6 +666,8 @@ export class MailingService {
       this._transporter = nodemailer.createTransport(mailConfig);
 
       const verified = await this._transporter.verify();
+
+      this.logger.log(`[_setupMailing] Mailer verified: ${verified}`);
 
       if (!verified) {
         this._mailingEnabled = false;

--- a/libs/backend/notifications/src/notifiers/clubenrollment/clubEntrollment.ts
+++ b/libs/backend/notifications/src/notifiers/clubenrollment/clubEntrollment.ts
@@ -45,31 +45,51 @@ export class ClubEnrollmentNotifier extends Notifier<
     data: { club: Club; locations: Location[]; comments: Comment[] },
     args?: { email: string; url: string }
   ): Promise<void> {
-    this.logger.debug(
-      `Sending Email to ${player.fullName} (${player.email}), target ${args?.email}`
+    this.logger.log(
+      `[ClubEnrollmentNotifier] notifyEmail called — player: ${player.fullName} (${player.email}), target email: ${args?.email ?? "(none)"}`
     );
+
     const email = args?.email ?? player.email;
 
     if (!email) {
-      this.logger.debug(`No email found for ${player.fullName}`);
+      this.logger.warn(
+        `[ClubEnrollmentNotifier] Skipping email — no email address for player ${player.fullName} (id: ${player.id})`
+      );
       return;
     }
 
     if (!player?.slug) {
-      this.logger.debug(`No slug found for ${player.fullName}`);
+      this.logger.warn(
+        `[ClubEnrollmentNotifier] Skipping email — no slug for player ${player.fullName} (id: ${player.id})`
+      );
       return;
     }
 
-    await this.mailing.sendEnrollmentMail(
-      {
-        fullName: player.fullName,
-        email,
-        slug: player.slug,
-      },
-      data.club,
-      data.locations,
-      data.comments
+    this.logger.log(
+      `[ClubEnrollmentNotifier] Sending enrollment email — to: ${email}, club: ${data.club.name}, locations: ${data.locations.length}, comments: ${data.comments.length}`
     );
+
+    try {
+      await this.mailing.sendEnrollmentMail(
+        {
+          fullName: player.fullName,
+          email,
+          slug: player.slug,
+        },
+        data.club,
+        data.locations,
+        data.comments
+      );
+      this.logger.log(
+        `[ClubEnrollmentNotifier] Enrollment email sent successfully to ${email}`
+      );
+    } catch (e) {
+      this.logger.error(
+        `[ClubEnrollmentNotifier] Failed to send enrollment email to ${email}`,
+        e
+      );
+      throw e;
+    }
   }
 
   notifySms(

--- a/libs/backend/notifications/src/services/notification/notification.service.ts
+++ b/libs/backend/notifications/src/services/notification/notification.service.ts
@@ -393,12 +393,21 @@ export class NotificationService {
   }
 
   async notifyEnrollment(userId: string, clubId: string, season: number, email: string) {
+    this._logger.log(
+      `[notifyEnrollment] Starting enrollment notification — userId: ${userId}, clubId: ${clubId}, season: ${season}, adminEmail: ${email}`
+    );
+
     const notifierEnrollment = new ClubEnrollmentNotifier(this.mailing, this.push);
 
     const user = await Player.findByPk(userId);
     if (!user) {
+      this._logger.error(`[notifyEnrollment] User not found — userId: ${userId}`);
       throw new Error("User not found");
     }
+
+    this._logger.log(
+      `[notifyEnrollment] User loaded — ${user.fullName} (${user.email})`
+    );
 
     const club = await Club.findByPk(clubId, {
       include: [
@@ -431,8 +440,13 @@ export class NotificationService {
     });
 
     if (!club) {
+      this._logger.error(`[notifyEnrollment] Club not found — clubId: ${clubId}`);
       throw new Error("Club not found");
     }
+
+    this._logger.log(
+      `[notifyEnrollment] Club loaded — ${club.name}, teams in season: ${club.teams?.length ?? 0}`
+    );
 
     const locations = await club.getLocations({
       include: [{ model: Availability, where: { season } }],
@@ -473,6 +487,12 @@ export class NotificationService {
     });
 
     club.teams?.map((team) => {
+      if (!team?.entry?.meta?.competition) {
+        this._logger.warn(
+          `[notifyEnrollment] Team ${team.name} (id: ${team.id}) has no enrollment meta — base players will be empty in the email`
+        );
+      }
+
       const basePlayers = {
         ...team?.entry?.meta?.competition?.players.map((player) => {
           const basePlayer = players.find((p) => p.id === player.id);
@@ -490,16 +510,29 @@ export class NotificationService {
 
     club.teams = club?.teams?.sort(sortTeams);
     const url = `${this.configService.get("CLIENT_URL")}/club/${club.id}`;
+    const resolvedEmail = email || user.email || "";
+
+    this._logger.log(
+      `[notifyEnrollment] Dispatching notification — to: ${resolvedEmail}, cc: jeroen@badmintonvlaanderen.be, locations: ${locations.length}, comments: ${comments.length}, url: ${url}`
+    );
+
+    if (!resolvedEmail) {
+      this._logger.warn(
+        `[notifyEnrollment] No email address resolved — adminEmail: "${email}", user.email: "${user.email}". Notification will be skipped by notifier.`
+      );
+    }
 
     notifierEnrollment.notify(
       user,
       clubId,
       { club, locations, comments },
-      { email: email || user.email || "", url },
+      { email: resolvedEmail, url },
       {
         email: true,
       }
     );
+
+    this._logger.log(`[notifyEnrollment] Notification dispatched for club ${club.name}`);
   }
 
   async notifySyncEncounterFailed({


### PR DESCRIPTION
- Add null guard in clubenrollment Pug template for teams with no base player meta, preventing a silent crash that blocked all enrollment emails
- Add WARN log when a team has no enrollment meta so it is visible in logs
- Remove console.log debug statements from submit-enrollment resolver and mailing service (one was leaking SMTP credentials to stdout)
- Add slug generation to findOrCreatePlayer seed utility so newly seeded players pass the ClubEnrollmentNotifier slug check