### PR TITLE
chore(enrollment): enrich SEASON_MISMATCH diagnostics

### DIFF
--- a/libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts
@@ -90,16 +90,35 @@ export class EnrollmentEntryService {
 
     const competitionSeason = subEvent.eventCompetition?.season;
     if (team.season !== competitionSeason) {
-      this.logger.warn({
+      const diagnostic = {
         code: ErrorCode.SEASON_MISMATCH,
-        teamId,
-        subEventCompetitionId: subEventId,
         userId,
+        teamId,
+        teamName: team.name,
+        teamClubId: team.clubId,
+        teamType: team.type,
         teamSeason: team.season,
-        competitionSeason,
-      });
+        subEventCompetitionId: subEventId,
+        subEventName: subEvent.name,
+        subEventType: subEvent.eventType,
+        eventCompetitionId: subEvent.eventCompetition?.id ?? null,
+        eventCompetitionName: subEvent.eventCompetition?.name ?? null,
+        competitionSeason: competitionSeason ?? null,
+        basePlayersCount: basePlayers?.length ?? 0,
+      };
+      this.logger.error(
+        `SEASON_MISMATCH: team ${teamId} (season=${team.season}) vs competition ${subEvent.eventCompetition?.id} (season=${competitionSeason})`,
+        diagnostic
+      );
       throw new GraphQLError("Team season does not match competition season.", {
-        extensions: { code: ErrorCode.SEASON_MISMATCH, teamSeason: team.season, competitionSeason },
+        extensions: {
+          code: ErrorCode.SEASON_MISMATCH,
+          teamId,
+          teamSeason: team.season,
+          subEventCompetitionId: subEventId,
+          eventCompetitionId: subEvent.eventCompetition?.id ?? null,
+          competitionSeason,
+        },
       });
     }
 


### PR DESCRIPTION
## Summary
- Triggered by Sentry issue 119666374 (`GraphQLError: Team season does not match competition season.`) where the existing log only carried `teamId`, `subEventId`, and the two season numbers — not enough to root-cause from Sentry alone.
- Promotes the season-mismatch log from `warn` to `error` (so it surfaces in Sentry consistently) and enriches it with team name/club/type, sub-event name/type, and event-competition id/name.
- Mirrors the key identifiers into the `GraphQLError` extensions so the frontend / API consumers can self-diagnose without a backend log dive.

## Test plan
- [x] `npx jest --config libs/backend/graphql/jest.config.ts --testPathPattern enrollment-entry` — 12/12 pass.
- [ ] Next production occurrence of `SEASON_MISMATCH` carries the new fields in Sentry breadcrumbs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)