### PR TITLE
fix(graphql): close GetClubPlayers/GetClubTeams N+1 + migrate RankingSystem fetches

### DIFF
--- a/libs/backend/graphql/src/resolvers/event/competition/assembly.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/assembly.resolver.ts
@@ -8,6 +8,7 @@ import {
   RankingPlace,
   RankingSystem,
 } from "@badman/backend-database";
+import { RankingSystemService } from "@badman/backend-ranking";
 import { getRankingProtected, sortPlayers } from "@badman/utils";
 import { Logger, NotFoundException } from "@nestjs/common";
 import { Args, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
@@ -15,7 +16,10 @@ import { Args, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/g
 @Resolver(() => AssemblyOutput)
 export class AssemblyResolver {
   private readonly logger = new Logger(AssemblyResolver.name);
-  constructor(private assemblyService: AssemblyValidationService) {}
+  constructor(
+    private assemblyService: AssemblyValidationService,
+    private readonly rankingSystemService: RankingSystemService
+  ) {}
 
   @Query(() => AssemblyOutput, {
     description: `Validate the assembly\n\r**note**: the levels are the ones from may!`,
@@ -40,7 +44,7 @@ export class AssemblyResolver {
       include: [RankingLastPlace],
     });
 
-    const system = await RankingSystem.findByPk(assembly.systemId);
+    const system = await this.rankingSystemService.getById(assembly.systemId);
 
     if (!system) {
       throw new NotFoundException(`${RankingSystem.name}: ${assembly.systemId}`);

--- a/libs/backend/graphql/src/resolvers/event/competition/draw.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/draw.resolver.ts
@@ -10,7 +10,7 @@ import {
   Standing,
   SubEventCompetition,
 } from "@badman/backend-database";
-import { PointsService } from "@badman/backend-ranking";
+import { PointsService, RankingSystemService } from "@badman/backend-ranking";
 import { sortStanding } from "@badman/utils";
 import { Logger, NotFoundException, UnauthorizedException } from "@nestjs/common";
 import { Args, ID, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
@@ -27,7 +27,8 @@ export class DrawCompetitionResolver {
   constructor(
     private _sequelize: Sequelize,
     private _pointService: PointsService,
-    @InjectQueue(SyncQueue) private _syncQueue: Queue
+    @InjectQueue(SyncQueue) private _syncQueue: Queue,
+    private readonly rankingSystemService: RankingSystemService
   ) {}
 
   @Query(() => DrawCompetition)
@@ -180,10 +181,9 @@ export class DrawCompetitionResolver {
     // Do transaction
     const transaction = await this._sequelize.transaction();
     try {
-      const where = systemId ? { id: systemId } : { primary: true };
-      const system = await RankingSystem.findOne({
-        where,
-      });
+      const system = systemId
+        ? await this.rankingSystemService.getById(systemId)
+        : await this.rankingSystemService.getPrimary();
 
       if (!system) {
         throw new NotFoundException(`${RankingSystem.name} not found for ${systemId || "primary"}`);

--- a/libs/backend/graphql/src/resolvers/event/competition/encounter.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/encounter.resolver.ts
@@ -19,7 +19,7 @@ import {
   updateTempTeamCaptainInput,
 } from "@badman/backend-database";
 import { getSyncJobOptions, Sync, SyncQueue } from "@badman/backend-queue";
-import { PointsService } from "@badman/backend-ranking";
+import { PointsService, RankingSystemService } from "@badman/backend-ranking";
 import { InjectQueue } from "@nestjs/bull";
 import { Logger, NotFoundException, UnauthorizedException } from "@nestjs/common";
 import {
@@ -65,7 +65,8 @@ export class EncounterCompetitionResolver {
     @InjectQueue(SyncQueue) private syncQueue: Queue,
     private _sequelize: Sequelize,
     private _pointService: PointsService,
-    private encounterValidationService: EncounterValidationService
+    private encounterValidationService: EncounterValidationService,
+    private readonly rankingSystemService: RankingSystemService
   ) {}
 
   @Query(() => EncounterCompetition)
@@ -518,10 +519,9 @@ export class EncounterCompetitionResolver {
     // Do transaction
     const transaction = await this._sequelize.transaction();
     try {
-      const where = systemId ? { id: systemId } : { primary: true };
-      const system = await RankingSystem.findOne({
-        where,
-      });
+      const system = systemId
+        ? await this.rankingSystemService.getById(systemId)
+        : await this.rankingSystemService.getPrimary();
 
       if (!system) {
         throw new NotFoundException(`${RankingSystem.name} not found for ${systemId || "primary"}`);

--- a/libs/backend/graphql/src/resolvers/event/competition/event.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/event.resolver.ts
@@ -16,7 +16,7 @@ import {
   EventEntry,
 } from "@badman/backend-database";
 import { Sync, SyncQueue } from "@badman/backend-queue";
-import { PointsService, StartVisualRankingDate } from "@badman/backend-ranking";
+import { PointsService, RankingSystemService, StartVisualRankingDate } from "@badman/backend-ranking";
 import { IsUUID } from "@badman/utils";
 import { InjectQueue } from "@nestjs/bull";
 import { Logger, NotFoundException, UnauthorizedException } from "@nestjs/common";
@@ -52,7 +52,8 @@ export class EventCompetitionResolver {
   constructor(
     private _sequelize: Sequelize,
     private _pointService: PointsService,
-    @InjectQueue(SyncQueue) private _syncQueue: Queue
+    @InjectQueue(SyncQueue) private _syncQueue: Queue,
+    private readonly rankingSystemService: RankingSystemService
   ) {}
 
   @Query(() => EventCompetition)
@@ -158,12 +159,7 @@ export class EventCompetitionResolver {
           });
 
           // getting the primary ranking system, in order to get the ranking groups, which will be added to each sub event
-          const ranking = await RankingSystem.findOne({
-            where: {
-              primary: true,
-            },
-            transaction,
-          });
+          const ranking = await this.rankingSystemService.getPrimary();
 
           if (!ranking) {
             throw new NotFoundException(`${RankingSystem.name}: primary system not found`);
@@ -501,10 +497,9 @@ export class EventCompetitionResolver {
     // Do transaction
     const transaction = await this._sequelize.transaction();
     try {
-      const where = systemId ? { id: systemId } : { primary: true };
-      const system = await RankingSystem.findOne({
-        where,
-      });
+      const system = systemId
+        ? await this.rankingSystemService.getById(systemId)
+        : await this.rankingSystemService.getPrimary();
 
       if (!system) {
         throw new NotFoundException(`${RankingSystem.name} not found for ${systemId || "primary"}`);

--- a/libs/backend/graphql/src/resolvers/event/competition/subevent.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/subevent.resolver.ts
@@ -15,7 +15,7 @@ import {
   SubEventCompetitionUpdateInput,
 } from "@badman/backend-database";
 import { Sync, SyncQueue } from "@badman/backend-queue";
-import { PointsService } from "@badman/backend-ranking";
+import { PointsService, RankingSystemService } from "@badman/backend-ranking";
 import { SubEventTypeEnum } from "@badman/utils";
 import { InjectQueue } from "@nestjs/bull";
 import { CACHE_MANAGER } from "@nestjs/cache-manager";
@@ -34,7 +34,8 @@ export class SubEventCompetitionResolver {
     @Inject(CACHE_MANAGER) private readonly _cacheManager: Cache,
     @InjectQueue(SyncQueue) private _syncQueue: Queue,
     private _sequelize: Sequelize,
-    private _pointService: PointsService
+    private _pointService: PointsService,
+    private readonly rankingSystemService: RankingSystemService
   ) {}
 
   @Query(() => SubEventCompetition)
@@ -136,11 +137,7 @@ export class SubEventCompetitionResolver {
     });
 
     // Get our ranking system
-    const primarySystem = await RankingSystem.findOne({
-      where: {
-        primary: true,
-      },
-    });
+    const primarySystem = await this.rankingSystemService.getPrimary();
 
     if (!primarySystem) {
       throw new NotFoundException(`${RankingSystem.name}: primary ranking system not found`);
@@ -321,10 +318,9 @@ export class SubEventCompetitionResolver {
     // Do transaction
     const transaction = await this._sequelize.transaction();
     try {
-      const where = systemId ? { id: systemId } : { primary: true };
-      const system = await RankingSystem.findOne({
-        where,
-      });
+      const system = systemId
+        ? await this.rankingSystemService.getById(systemId)
+        : await this.rankingSystemService.getPrimary();
 
       if (!system) {
         throw new NotFoundException(`${RankingSystem.name} not found for ${systemId || "primary"}`);

--- a/libs/backend/graphql/src/resolvers/event/tournament/draw.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/tournament/draw.resolver.ts
@@ -7,7 +7,7 @@ import {
   RankingSystem,
   SubEventTournament,
 } from "@badman/backend-database";
-import { PointsService } from "@badman/backend-ranking";
+import { PointsService, RankingSystemService } from "@badman/backend-ranking";
 import { Logger, NotFoundException, UnauthorizedException } from "@nestjs/common";
 import {
   Args,
@@ -51,7 +51,8 @@ export class DrawTournamentResolver {
   constructor(
     private readonly _sequelize: Sequelize,
     private readonly _pointService: PointsService,
-    @InjectQueue(SyncQueue) private readonly _syncQueue: Queue
+    @InjectQueue(SyncQueue) private readonly _syncQueue: Queue,
+    private readonly rankingSystemService: RankingSystemService
   ) {}
 
   @Query(() => DrawTournament)
@@ -97,10 +98,9 @@ export class DrawTournamentResolver {
     // Do transaction
     const transaction = await this._sequelize.transaction();
     try {
-      const where = systemId ? { id: systemId } : { primary: true };
-      const system = await RankingSystem.findOne({
-        where,
-      });
+      const system = systemId
+        ? await this.rankingSystemService.getById(systemId)
+        : await this.rankingSystemService.getPrimary();
 
       if (!system) {
         throw new NotFoundException(`${RankingSystem.name} not found for ${systemId || "primary"}`);

--- a/libs/backend/graphql/src/resolvers/event/tournament/event.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/tournament/event.resolver.ts
@@ -12,7 +12,7 @@ import {
   EventEntry,
 } from "@badman/backend-database";
 import { Sync, SyncQueue } from "@badman/backend-queue";
-import { PointsService, StartVisualRankingDate } from "@badman/backend-ranking";
+import { PointsService, RankingSystemService, StartVisualRankingDate } from "@badman/backend-ranking";
 import { IsUUID } from "@badman/utils";
 import { InjectQueue } from "@nestjs/bull";
 import { Logger, NotFoundException, UnauthorizedException } from "@nestjs/common";
@@ -63,7 +63,8 @@ export class EventTournamentResolver {
   constructor(
     private readonly _sequelize: Sequelize,
     private readonly _pointService: PointsService,
-    @InjectQueue(SyncQueue) private readonly _syncQueue: Queue
+    @InjectQueue(SyncQueue) private readonly _syncQueue: Queue,
+    private readonly rankingSystemService: RankingSystemService
   ) {}
 
   @Query(() => EventTournament)
@@ -117,12 +118,7 @@ export class EventTournamentResolver {
 
       if (eventTournamentDb.official !== updateEventTournamentData.official) {
         // we are making it official
-        const ranking = await RankingSystem.findOne({
-          where: {
-            primary: true,
-          },
-          transaction,
-        });
+        const ranking = await this.rankingSystemService.getPrimary();
 
         if (!ranking) {
           throw new NotFoundException(`${RankingSystem.name}: primary`);
@@ -364,10 +360,9 @@ export class EventTournamentResolver {
     // Do transaction
     const transaction = await this._sequelize.transaction();
     try {
-      const where = systemId ? { id: systemId } : { primary: true };
-      const system = await RankingSystem.findOne({
-        where,
-      });
+      const system = systemId
+        ? await this.rankingSystemService.getById(systemId)
+        : await this.rankingSystemService.getPrimary();
 
       if (!system) {
         throw new NotFoundException(`${RankingSystem.name} not found for ${systemId || "primary"}`);

--- a/libs/backend/graphql/src/resolvers/event/tournament/subevent.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/tournament/subevent.resolver.ts
@@ -21,7 +21,7 @@ import {
 } from "@nestjs/graphql";
 import { ListArgs } from "../../../utils";
 import { User } from "@badman/backend-authorization";
-import { PointsService } from "@badman/backend-ranking";
+import { PointsService, RankingSystemService } from "@badman/backend-ranking";
 import { Sequelize } from "sequelize-typescript";
 import { SyncQueue, Sync } from "@badman/backend-queue";
 import { InjectQueue } from "@nestjs/bull";
@@ -47,7 +47,8 @@ export class SubEventTournamentResolver {
   constructor(
     private readonly _sequelize: Sequelize,
     private readonly _pointService: PointsService,
-    @InjectQueue(SyncQueue) private readonly _syncQueue: Queue
+    @InjectQueue(SyncQueue) private readonly _syncQueue: Queue,
+    private readonly rankingSystemService: RankingSystemService
   ) {}
 
   @Query(() => SubEventTournament)
@@ -98,10 +99,9 @@ export class SubEventTournamentResolver {
     // Do transaction
     const transaction = await this._sequelize.transaction();
     try {
-      const where = systemId ? { id: systemId } : { primary: true };
-      const system = await RankingSystem.findOne({
-        where,
-      });
+      const system = systemId
+        ? await this.rankingSystemService.getById(systemId)
+        : await this.rankingSystemService.getPrimary();
 
       if (!system) {
         throw new NotFoundException(`${RankingSystem.name} not found for ${systemId || "primary"}`);

--- a/libs/backend/graphql/src/resolvers/game/game.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/game/game.resolver.ts
@@ -167,12 +167,8 @@ export class GamesResolver {
       );
 
       if (gameData.players) {
+        const system = await this.rankingSystemService.getPrimary();
         for (const player of gameData.players) {
-          const system = await RankingSystem.findOne({
-            where: {
-              primary: true,
-            },
-          });
           const ranking = await RankingLastPlace.findOne({
             where: {
               playerId: player.id,

--- a/libs/backend/graphql/src/resolvers/player/player.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/player/player.resolver.spec.ts
@@ -1,0 +1,143 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException } from "@nestjs/common";
+import {
+  Player,
+  RankingLastPlace,
+  RankingPlace,
+  RankingSystem,
+} from "@badman/backend-database";
+import { PointsService, RankingSystemService } from "@badman/backend-ranking";
+import { Sequelize } from "sequelize-typescript";
+import { ListArgs } from "../../utils";
+import { PlayersResolver, PlayerTeamResolver } from "./player.resolver";
+
+type SystemServiceMock = { getPrimary: jest.Mock; getById: jest.Mock };
+
+const systemFixture = (id: string): RankingSystem =>
+  ({ id, amountOfLevels: 12, maxDiffLevels: 4 }) as unknown as RankingSystem;
+
+const PRIMARY = systemFixture("primary-1");
+const SYS_A = systemFixture("sys-a");
+const SYS_B = systemFixture("sys-b");
+
+describe("PlayersResolver — RankingSystemService integration", () => {
+  let resolver: PlayersResolver;
+  let rankingSystemService: SystemServiceMock;
+
+  beforeEach(async () => {
+    rankingSystemService = {
+      getPrimary: jest.fn().mockResolvedValue(PRIMARY),
+      getById: jest.fn(async (id: string) => (id === SYS_A.id ? SYS_A : id === SYS_B.id ? SYS_B : null)),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PlayersResolver,
+        { provide: Sequelize, useValue: { transaction: jest.fn() } },
+        { provide: PointsService, useValue: {} },
+        { provide: RankingSystemService, useValue: rankingSystemService },
+      ],
+    }).compile();
+
+    resolver = module.get<PlayersResolver>(PlayersResolver);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("rankingPlaces: batches RankingSystem lookups by unique systemId", async () => {
+    const places = [
+      { systemId: SYS_A.id },
+      { systemId: SYS_A.id },
+      { systemId: SYS_B.id },
+    ] as RankingPlace[];
+    const player = {
+      getRankingPlaces: jest.fn().mockResolvedValue(places),
+    } as unknown as Player;
+
+    const result = await resolver.rankingPlaces(player, {} as ListArgs);
+
+    expect(result).toHaveLength(3);
+    // 2 unique system ids, regardless of place count
+    expect(rankingSystemService.getById).toHaveBeenCalledTimes(2);
+    expect(rankingSystemService.getById).toHaveBeenCalledWith(SYS_A.id);
+    expect(rankingSystemService.getById).toHaveBeenCalledWith(SYS_B.id);
+    expect(rankingSystemService.getPrimary).not.toHaveBeenCalled();
+  });
+
+  it("rankingLastPlaces: uses cached primary + batches systems", async () => {
+    const places = [{ systemId: SYS_A.id }, { systemId: SYS_A.id }] as RankingLastPlace[];
+    const player = {
+      getRankingLastPlaces: jest.fn().mockResolvedValue(places),
+    } as unknown as Player;
+
+    const result = await resolver.rankingLastPlaces(player, {} as ListArgs);
+
+    expect(result).toHaveLength(2);
+    expect(rankingSystemService.getPrimary).toHaveBeenCalledTimes(1);
+    expect(rankingSystemService.getById).toHaveBeenCalledTimes(1);
+    expect(rankingSystemService.getById).toHaveBeenCalledWith(SYS_A.id);
+  });
+
+  it("rankingPlaces: throws NotFoundException when system not in cache", async () => {
+    const places = [{ systemId: "missing" }] as RankingPlace[];
+    const player = {
+      getRankingPlaces: jest.fn().mockResolvedValue(places),
+    } as unknown as Player;
+
+    await expect(resolver.rankingPlaces(player, {} as ListArgs)).rejects.toThrow(NotFoundException);
+  });
+});
+
+describe("PlayerTeamResolver — RankingSystemService integration", () => {
+  let resolver: PlayerTeamResolver;
+  let rankingSystemService: SystemServiceMock;
+
+  beforeEach(async () => {
+    rankingSystemService = {
+      getPrimary: jest.fn().mockResolvedValue(PRIMARY),
+      getById: jest.fn(async (id: string) => (id === SYS_A.id ? SYS_A : null)),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PlayerTeamResolver,
+        { provide: Sequelize, useValue: { transaction: jest.fn() } },
+        { provide: PointsService, useValue: {} },
+        { provide: RankingSystemService, useValue: rankingSystemService },
+      ],
+    }).compile();
+
+    resolver = module.get<PlayerTeamResolver>(PlayerTeamResolver);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("override rankingLastPlaces: uses cached primary, batches systems by id", async () => {
+    jest
+      .spyOn(RankingLastPlace, "findAll")
+      .mockResolvedValue([{ systemId: SYS_A.id }, { systemId: SYS_A.id }] as RankingLastPlace[]);
+
+    const result = await resolver.rankingLastPlaces({ id: "p1" } as Player, {} as ListArgs);
+
+    expect(result).toHaveLength(2);
+    expect(rankingSystemService.getPrimary).toHaveBeenCalledTimes(1);
+    expect(rankingSystemService.getById).toHaveBeenCalledTimes(1);
+    expect(rankingSystemService.getById).toHaveBeenCalledWith(SYS_A.id);
+  });
+
+  it("override rankingPlaces: batches systems by unique id", async () => {
+    jest
+      .spyOn(RankingPlace, "findAll")
+      .mockResolvedValue([{ systemId: SYS_A.id }] as RankingPlace[]);
+
+    const result = await resolver.rankingPlaces({ id: "p1" } as Player, {} as ListArgs);
+
+    expect(result).toHaveLength(1);
+    expect(rankingSystemService.getById).toHaveBeenCalledTimes(1);
+    expect(rankingSystemService.getById).toHaveBeenCalledWith(SYS_A.id);
+  });
+});

--- a/libs/backend/graphql/src/resolvers/player/player.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/player/player.resolver.ts
@@ -32,7 +32,7 @@ import { Args, ID, Mutation, Parent, Query, ResolveField, Resolver } from "@nest
 import { Op } from "sequelize";
 import { Sequelize } from "sequelize-typescript";
 import { ListArgs, WhereArgs, queryFixer } from "../../utils";
-import { PointsService } from "@badman/backend-ranking";
+import { PointsService, RankingSystemService } from "@badman/backend-ranking";
 
 @Resolver(() => Player)
 export class PlayersResolver {
@@ -40,8 +40,24 @@ export class PlayersResolver {
 
   constructor(
     private _sequelize: Sequelize,
-    private pointService: PointsService
+    private pointService: PointsService,
+    protected readonly rankingSystemService: RankingSystemService
   ) {}
+
+  protected async loadSystemsByIds(
+    ids: (string | null | undefined)[]
+  ): Promise<(id: string | null | undefined) => RankingSystem | undefined> {
+    const uniqueIds = [...new Set(ids.filter((id): id is string => !!id))];
+    const systems = await Promise.all(uniqueIds.map((id) => this.rankingSystemService.getById(id)));
+    const map = new Map<string, RankingSystem>();
+    uniqueIds.forEach((id, idx) => {
+      const sys = systems[idx];
+      if (sys) {
+        map.set(id, sys);
+      }
+    });
+    return (id) => (id ? map.get(id) : undefined);
+  }
 
   private getPlayerFilters() {
     return {
@@ -157,17 +173,11 @@ export class PlayersResolver {
       ...ListArgs.toFindOptions(listArgs),
     });
 
-    // distinct systemIds
-    const systemIds = [...new Set(places.map((place) => place.systemId))];
-    const systems = await RankingSystem.findAll({
-      where: {
-        id: systemIds,
-      },
-    });
+    const findSystem = await this.loadSystemsByIds(places.map((place) => place.systemId));
 
     return (
       places?.map((place) => {
-        const system = systems.find((sys) => sys.id === place.systemId);
+        const system = findSystem(place.systemId);
 
         if (!system) {
           throw new NotFoundException(`${RankingSystem.name}: ${place.systemId}`);
@@ -186,24 +196,18 @@ export class PlayersResolver {
     @Args() listArgs: ListArgs
   ): Promise<RankingLastPlace[]> {
     const opts = ListArgs.toFindOptions(listArgs);
-    const primary = await RankingSystem.findOne({ where: { primary: true } });
+    const primary = await this.rankingSystemService.getPrimary();
     opts.where = { ...opts.where, systemId: primary?.id };
     const places = await player.getRankingLastPlaces({
       order: [["rankingDate", "DESC"]],
       ...opts,
     });
 
-    // distinct systemIds
-    const systemIds = [...new Set(places.map((place) => place.systemId))];
-    const systems = await RankingSystem.findAll({
-      where: {
-        id: systemIds,
-      },
-    });
+    const findSystem = await this.loadSystemsByIds(places.map((place) => place.systemId));
 
     return (
       places?.map((place) => {
-        const system = systems.find((sys) => sys.id === place.systemId);
+        const system = findSystem(place.systemId);
 
         if (!system) {
           throw new NotFoundException(`${RankingSystem.name}: ${place.systemId}`);
@@ -487,10 +491,9 @@ export class PlayersResolver {
     // Do transaction
     const transaction = await this._sequelize.transaction();
     try {
-      const where = systemId ? { id: systemId } : { primary: true };
-      const system = await RankingSystem.findOne({
-        where,
-      });
+      const system = systemId
+        ? await this.rankingSystemService.getById(systemId)
+        : await this.rankingSystemService.getPrimary();
 
       if (!system) {
         throw new NotFoundException(`No ranking system found for ${systemId || "primary"}`);
@@ -565,7 +568,7 @@ export class PlayerTeamResolver extends PlayersResolver {
   ): Promise<RankingLastPlace[]> {
     const args = ListArgs.toFindOptions(listArgs);
 
-    const primary = await RankingSystem.findOne({ where: { primary: true } });
+    const primary = await this.rankingSystemService.getPrimary();
     args.where = {
       ...args.where,
       systemId: primary?.id,
@@ -574,17 +577,11 @@ export class PlayerTeamResolver extends PlayersResolver {
 
     const places = await RankingLastPlace.findAll(args);
 
-    // distinct systemIds
-    const systemIds = [...new Set(places.map((place) => place.systemId))];
-    const systems = await RankingSystem.findAll({
-      where: {
-        id: systemIds,
-      },
-    });
+    const findSystem = await this.loadSystemsByIds(places.map((place) => place.systemId));
 
     return (
       places?.map((place) => {
-        const system = systems.find((sys) => sys.id === place.systemId);
+        const system = findSystem(place.systemId);
 
         if (!system) {
           throw new NotFoundException(`${RankingSystem.name}: ${place.systemId}`);
@@ -615,17 +612,11 @@ export class PlayerTeamResolver extends PlayersResolver {
 
     const places = await RankingPlace.findAll(args);
 
-    // distinct systemIds
-    const systemIds = [...new Set(places.map((place) => place.systemId))];
-    const systems = await RankingSystem.findAll({
-      where: {
-        id: systemIds,
-      },
-    });
+    const findSystem = await this.loadSystemsByIds(places.map((place) => place.systemId));
 
     return (
       places?.map((place) => {
-        const system = systems.find((sys) => sys.id === place.systemId);
+        const system = findSystem(place.systemId);
 
         if (!system) {
           throw new NotFoundException(`${RankingSystem.name}: ${place.systemId}`);

--- a/libs/backend/graphql/src/resolvers/ranking/rankingPoint.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/ranking/rankingPoint.resolver.ts
@@ -4,7 +4,7 @@ import { Args, ID, Mutation, Parent, Query, ResolveField, Resolver } from "@nest
 import { ListArgs } from "../../utils";
 import { User } from "@badman/backend-authorization";
 import { Sequelize } from "sequelize-typescript";
-import { PointsService } from "@badman/backend-ranking";
+import { PointsService, RankingSystemService } from "@badman/backend-ranking";
 
 @Resolver(() => RankingPoint)
 export class RankingPointResolver {
@@ -12,7 +12,8 @@ export class RankingPointResolver {
 
   constructor(
     private _sequelize: Sequelize,
-    private pointService: PointsService
+    private pointService: PointsService,
+    private readonly rankingSystemService: RankingSystemService
   ) {}
 
   @Query(() => RankingPoint)
@@ -45,7 +46,11 @@ export class RankingPointResolver {
 
   @ResolveField(() => RankingSystem)
   async system(@Parent() rankingPoint: RankingPoint): Promise<RankingSystem> {
-    return rankingPoint.getSystem();
+    const system = await this.rankingSystemService.getById(rankingPoint.systemId);
+    if (!system) {
+      throw new NotFoundException(`${RankingSystem.name}: ${rankingPoint.systemId}`);
+    }
+    return system;
   }
 
   @Mutation(() => Boolean)
@@ -61,10 +66,9 @@ export class RankingPointResolver {
     // Do transaction
     const transaction = await this._sequelize.transaction();
     try {
-      const where = systemId ? { id: systemId } : { primary: true };
-      const system = await RankingSystem.findOne({
-        where,
-      });
+      const system = systemId
+        ? await this.rankingSystemService.getById(systemId)
+        : await this.rankingSystemService.getPrimary();
 
       if (!system) {
         throw new NotFoundException(`No ranking system found for ${systemId || "primary"}`);

--- a/libs/backend/graphql/src/resolvers/team/team-association.service.spec.ts
+++ b/libs/backend/graphql/src/resolvers/team/team-association.service.spec.ts
@@ -1,0 +1,146 @@
+import {
+  Club,
+  EventEntry,
+  Location,
+  Player,
+  Team,
+  TeamPlayerMembership,
+} from "@badman/backend-database";
+import { TeamAssociationService } from "./team-association.service";
+
+describe("TeamAssociationService — request-scoped batching", () => {
+  let service: TeamAssociationService;
+
+  beforeEach(() => {
+    service = new TeamAssociationService();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("getCaptain: batches captainIds across teams into one Player.findAll", async () => {
+    const findAll = jest
+      .spyOn(Player, "findAll")
+      .mockResolvedValue([
+        { id: "p1" } as Player,
+        { id: "p2" } as Player,
+      ]);
+
+    const teams = [
+      { id: "t1", captainId: "p1" } as Team,
+      { id: "t2", captainId: "p2" } as Team,
+      { id: "t3", captainId: "p1" } as Team, // duplicate id
+    ];
+
+    const results = await Promise.all(teams.map((t) => service.getCaptain(t)));
+
+    expect(findAll).toHaveBeenCalledTimes(1);
+    expect(results.map((r) => r?.id)).toEqual(["p1", "p2", "p1"]);
+  });
+
+  it("getCaptain: returns null when captainId is missing without querying", async () => {
+    const findAll = jest.spyOn(Player, "findAll").mockResolvedValue([]);
+
+    const result = await service.getCaptain({ id: "t1", captainId: undefined } as Team);
+
+    expect(findAll).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it("getCaptain: caches resolved ids so a second tick does not re-query", async () => {
+    const findAll = jest
+      .spyOn(Player, "findAll")
+      .mockResolvedValue([{ id: "p1" } as Player]);
+
+    const team = { id: "t1", captainId: "p1" } as Team;
+
+    await service.getCaptain(team);
+    await service.getCaptain(team);
+
+    expect(findAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("getClub: batches by clubId", async () => {
+    const findAll = jest
+      .spyOn(Club, "findAll")
+      .mockResolvedValue([{ id: "c1" } as Club]);
+
+    const teams = [
+      { id: "t1", clubId: "c1" } as Team,
+      { id: "t2", clubId: "c1" } as Team,
+      { id: "t3", clubId: "c1" } as Team,
+    ];
+
+    const results = await Promise.all(teams.map((t) => service.getClub(t)));
+
+    expect(findAll).toHaveBeenCalledTimes(1);
+    expect(results.every((r) => r?.id === "c1")).toBe(true);
+  });
+
+  it("getPrefferedLocation: batches by prefferedLocationId", async () => {
+    const findAll = jest
+      .spyOn(Location, "findAll")
+      .mockResolvedValue([{ id: "l1" } as Location]);
+
+    const teams = [
+      { id: "t1", prefferedLocationId: "l1" } as Team,
+      { id: "t2", prefferedLocationId: "l1" } as Team,
+    ];
+
+    await Promise.all(teams.map((t) => service.getPrefferedLocation(t)));
+
+    expect(findAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("getEntry: batches by teamId and prefers entries with drawId", async () => {
+    const findAll = jest.spyOn(EventEntry, "findAll").mockResolvedValue([
+      { teamId: "t1", drawId: null, id: "e1-no-draw" } as unknown as EventEntry,
+      { teamId: "t1", drawId: "d1", id: "e1-with-draw" } as unknown as EventEntry,
+      { teamId: "t2", drawId: null, id: "e2-fallback" } as unknown as EventEntry,
+    ]);
+
+    const [entry1, entry2] = await Promise.all([
+      service.getEntry({ id: "t1" } as Team),
+      service.getEntry({ id: "t2" } as Team),
+    ]);
+
+    expect(findAll).toHaveBeenCalledTimes(1);
+    expect(entry1?.id).toBe("e1-with-draw");
+    expect(entry2?.id).toBe("e2-fallback");
+  });
+
+  it("getPlayers: batches via TeamPlayerMembership join and groups by teamId", async () => {
+    // Build mocks without back-references — the service mutates the player
+    // object to attach the membership, and a jest worker would choke on a
+    // circular `player <-> membership` graph during result serialization.
+    const m1: Partial<TeamPlayerMembership> & { Player: Partial<Player> } = {
+      teamId: "t1",
+      Player: { id: "p1" },
+    };
+    const m2: Partial<TeamPlayerMembership> & { Player: Partial<Player> } = {
+      teamId: "t1",
+      Player: { id: "p2" },
+    };
+    const m3: Partial<TeamPlayerMembership> & { Player: Partial<Player> } = {
+      teamId: "t2",
+      Player: { id: "p3" },
+    };
+    const findAll = jest
+      .spyOn(TeamPlayerMembership, "findAll")
+      .mockResolvedValue([m1, m2, m3] as unknown as TeamPlayerMembership[]);
+
+    const [t1Players, t2Players] = await Promise.all([
+      service.getPlayers({ id: "t1" } as Team),
+      service.getPlayers({ id: "t2" } as Team),
+    ]);
+
+    expect(findAll).toHaveBeenCalledTimes(1);
+    expect(t1Players.map((p) => p.id)).toEqual(["p1", "p2"]);
+    expect(t2Players.map((p) => p.id)).toEqual(["p3"]);
+    // Membership attached so player.TeamPlayerMembership keeps working
+    expect(
+      (t1Players[0] as Player & { TeamPlayerMembership: TeamPlayerMembership }).TeamPlayerMembership
+    ).toBe(m1);
+  });
+});

--- a/libs/backend/graphql/src/resolvers/team/team-association.service.ts
+++ b/libs/backend/graphql/src/resolvers/team/team-association.service.ts
@@ -1,0 +1,167 @@
+import {
+  Club,
+  EventEntry,
+  Location,
+  Player,
+  Team,
+  TeamPlayerMembership,
+} from "@badman/backend-database";
+import { Injectable, Logger, Scope } from "@nestjs/common";
+import { Op } from "sequelize";
+
+type Batch<K, V> = {
+  keys: Set<K>;
+  promise: Promise<Map<K, V>> | null;
+};
+
+type BatchState<K, V> = {
+  cache: Map<K, V | null>;
+  batch: Batch<K, V> | null;
+};
+
+/**
+ * Request-scoped batching for Team field resolvers.
+ *
+ * Each method collects all ids requested within one microtask tick, then
+ * issues a single `findAll({ id: Op.in })` and resolves every queued caller
+ * from the shared result. Subsequent ticks start a fresh batch but reuse
+ * the per-request cache built up so far.
+ *
+ * Lifecycle is bound to one GraphQL request (Scope.REQUEST). No TTL needed:
+ * the service instance is discarded when the request ends.
+ */
+@Injectable({ scope: Scope.REQUEST })
+export class TeamAssociationService {
+  private readonly logger = new Logger(TeamAssociationService.name);
+
+  private captainState: BatchState<string, Player> = { cache: new Map(), batch: null };
+  private locationState: BatchState<string, Location> = { cache: new Map(), batch: null };
+  private clubState: BatchState<string, Club> = { cache: new Map(), batch: null };
+  private entryState: BatchState<string, EventEntry> = { cache: new Map(), batch: null };
+  private playersState: BatchState<string, Player[]> = { cache: new Map(), batch: null };
+
+  async getCaptain(team: Team): Promise<Player | null> {
+    return this.loadOne(this.captainState, team.captainId, (ids) =>
+      this.loadPlayersByIds(ids)
+    );
+  }
+
+  async getPrefferedLocation(team: Team): Promise<Location | null> {
+    return this.loadOne(this.locationState, team.prefferedLocationId, (ids) =>
+      this.loadLocationsByIds(ids)
+    );
+  }
+
+  async getClub(team: Team): Promise<Club | null> {
+    return this.loadOne(this.clubState, team.clubId, (ids) => this.loadClubsByIds(ids));
+  }
+
+  async getEntry(team: Team): Promise<EventEntry | null> {
+    return this.loadOne(this.entryState, team.id, (ids) => this.loadEntriesByTeamIds(ids));
+  }
+
+  async getPlayers(team: Team): Promise<Player[]> {
+    const result = await this.loadOne(this.playersState, team.id, (ids) =>
+      this.loadPlayersByTeamIds(ids)
+    );
+    return result ?? [];
+  }
+
+  private loadOne<V>(
+    state: BatchState<string, V>,
+    key: string | null | undefined,
+    loader: (keys: string[]) => Promise<Map<string, V>>
+  ): Promise<V | null> {
+    if (!key) {
+      return Promise.resolve(null);
+    }
+    if (state.cache.has(key)) {
+      return Promise.resolve(state.cache.get(key) ?? null);
+    }
+
+    if (!state.batch) {
+      const batch: Batch<string, V> = { keys: new Set<string>(), promise: null };
+      state.batch = batch;
+      batch.promise = Promise.resolve().then(async () => {
+        state.batch = null;
+        const ids = [...batch.keys];
+        const result = await loader(ids);
+        for (const id of ids) {
+          state.cache.set(id, result.get(id) ?? null);
+        }
+        return result;
+      });
+    }
+
+    state.batch.keys.add(key);
+    return state.batch.promise!.then((m) => m.get(key) ?? null);
+  }
+
+  private async loadPlayersByIds(ids: string[]): Promise<Map<string, Player>> {
+    if (ids.length === 0) return new Map();
+    const players = await Player.findAll({ where: { id: { [Op.in]: ids } } });
+    return new Map(players.map((p) => [p.id, p]));
+  }
+
+  private async loadLocationsByIds(ids: string[]): Promise<Map<string, Location>> {
+    if (ids.length === 0) return new Map();
+    const locations = await Location.findAll({ where: { id: { [Op.in]: ids } } });
+    return new Map(locations.map((l) => [l.id, l]));
+  }
+
+  private async loadClubsByIds(ids: string[]): Promise<Map<string, Club>> {
+    if (ids.length === 0) return new Map();
+    const clubs = await Club.findAll({ where: { id: { [Op.in]: ids } } });
+    return new Map(clubs.map((c) => [c.id, c]));
+  }
+
+  private async loadEntriesByTeamIds(teamIds: string[]): Promise<Map<string, EventEntry>> {
+    if (teamIds.length === 0) return new Map();
+    const entries = await EventEntry.findAll({ where: { teamId: { [Op.in]: teamIds } } });
+
+    // Group by teamId; prefer the entry with a drawId (federation-sync has
+    // assigned a draw), otherwise fall back to any entry for the team.
+    // Mirrors the pre-existing logic at team.resolver.ts:323.
+    const byTeam = new Map<string, EventEntry[]>();
+    for (const entry of entries) {
+      if (!entry.teamId) continue;
+      const bucket = byTeam.get(entry.teamId) ?? [];
+      bucket.push(entry);
+      byTeam.set(entry.teamId, bucket);
+    }
+
+    const result = new Map<string, EventEntry>();
+    for (const [teamId, bucket] of byTeam) {
+      const winner = bucket.find((e) => e.drawId) ?? bucket[0];
+      if (winner) {
+        result.set(teamId, winner);
+      }
+    }
+    return result;
+  }
+
+  private async loadPlayersByTeamIds(teamIds: string[]): Promise<Map<string, Player[]>> {
+    if (teamIds.length === 0) return new Map();
+
+    // Fetch through TeamPlayerMembership so we can group rows back by teamId.
+    // Using a single query keeps this O(1) DB round trip regardless of team count.
+    const memberships = await TeamPlayerMembership.findAll({
+      where: { teamId: { [Op.in]: teamIds } },
+      include: [{ model: Player, required: true }],
+    });
+
+    const grouped = new Map<string, Player[]>();
+    for (const m of memberships as Array<TeamPlayerMembership & { Player?: Player }>) {
+      if (!m.teamId || !m.Player) continue;
+      const player = m.Player;
+      // Attach the membership row in the same shape Sequelize would produce
+      // through `team.getPlayers()` so downstream resolvers that read
+      // `player.TeamPlayerMembership` keep working.
+      (player as Player & { TeamPlayerMembership: TeamPlayerMembership }).TeamPlayerMembership = m;
+      const bucket = grouped.get(m.teamId) ?? [];
+      bucket.push(player);
+      grouped.set(m.teamId, bucket);
+    }
+    return grouped;
+  }
+}

--- a/libs/backend/graphql/src/resolvers/team/team.module.ts
+++ b/libs/backend/graphql/src/resolvers/team/team.module.ts
@@ -1,12 +1,13 @@
 import { DatabaseModule } from "@badman/backend-database";
 import { EnrollmentModule } from "@badman/backend-enrollment";
 import { Module } from "@nestjs/common";
+import { TeamAssociationService } from "./team-association.service";
 import { TeamPlayerResolver, TeamsResolver } from "./team.resolver";
 import { TeamWriteService } from "./team-write.service";
 
 @Module({
   imports: [DatabaseModule, EnrollmentModule],
-  providers: [TeamsResolver, TeamPlayerResolver, TeamWriteService],
+  providers: [TeamsResolver, TeamPlayerResolver, TeamWriteService, TeamAssociationService],
   exports: [TeamWriteService],
 })
 export class TeamResolverModule {}

--- a/libs/backend/graphql/src/resolvers/team/team.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/team/team.resolver.spec.ts
@@ -14,6 +14,15 @@ import {
   TeamUpdateInput,
 } from "@badman/backend-database";
 import { IndexCalculationInput, IndexCalculationService } from "@badman/backend-enrollment";
+import { TeamAssociationService } from "./team-association.service";
+
+const teamAssociationServiceStub = (): Partial<TeamAssociationService> => ({
+  getCaptain: jest.fn().mockResolvedValue(null),
+  getClub: jest.fn().mockResolvedValue(null),
+  getPrefferedLocation: jest.fn().mockResolvedValue(null),
+  getEntry: jest.fn().mockResolvedValue(null),
+  getPlayers: jest.fn().mockResolvedValue([]),
+});
 import { SubEventTypeEnum } from "@badman/utils";
 import { ErrorCode } from "../../utils";
 import { TeamsResolver } from "./team.resolver";
@@ -81,6 +90,10 @@ describe("TeamsResolver.createTeam", () => {
               resolvedPlayers: [],
             }),
           },
+        },
+        {
+          provide: TeamAssociationService,
+          useValue: teamAssociationServiceStub(),
         },
       ],
     }).compile();
@@ -325,6 +338,10 @@ describe("TeamsResolver.createTeams", () => {
               resolvedPlayers: [],
             }),
           },
+        },
+        {
+          provide: TeamAssociationService,
+          useValue: teamAssociationServiceStub(),
         },
       ],
     }).compile();
@@ -736,6 +753,10 @@ describe("TeamsResolver.updateTeam", () => {
               resolvedPlayers: [],
             }),
           },
+        },
+        {
+          provide: TeamAssociationService,
+          useValue: teamAssociationServiceStub(),
         },
       ],
     }).compile();

--- a/libs/backend/graphql/src/resolvers/team/team.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/team/team.resolver.ts
@@ -31,6 +31,7 @@ import { GraphQLError } from "graphql";
 import { Op, Transaction } from "sequelize";
 import { Sequelize } from "sequelize-typescript";
 import { ErrorCode, ListArgs } from "../../utils";
+import { TeamAssociationService } from "./team-association.service";
 import { TeamResult } from "./team-result.object";
 
 @Resolver(() => Team)
@@ -39,7 +40,8 @@ export class TeamsResolver {
 
   constructor(
     private _sequelize: Sequelize,
-    private readonly indexCalculationService: IndexCalculationService
+    private readonly indexCalculationService: IndexCalculationService,
+    private readonly teamAssociationService: TeamAssociationService
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -240,6 +242,14 @@ export class TeamsResolver {
 
   @ResolveField(() => [PlayerWithTeamMembershipType])
   async players(@Parent() team: Team, @Args() listArgs: ListArgs) {
+    // When no list args are supplied (the common GetClubTeams case) we batch
+    // all per-team Player lookups across the request into a single query via
+    // TeamAssociationService. When filters/pagination are supplied we fall
+    // back to the per-team association call so the args take effect.
+    const hasFilters = !!(listArgs.where || listArgs.take || listArgs.skip || listArgs.order);
+    if (!hasFilters) {
+      return this.teamAssociationService.getPlayers(team);
+    }
     return team.getPlayers(ListArgs.toFindOptions(listArgs));
   }
 
@@ -278,64 +288,30 @@ export class TeamsResolver {
 
   @ResolveField(() => EventEntry, { nullable: true })
   async entry(@Parent() team: Team): Promise<EventEntry | null> {
-    // Get all entries for the team
-    const entries = await EventEntry.findAll({
-      where: {
-        teamId: team.id,
-      },
-    });
-
-    // Prefer an entry that has been assigned to a draw: once the federation
-    // sync has run the draw assignment, the entry carries a `drawId` and that
-    // entry is the authoritative one (it pins the team to a specific draw
-    // within the subEvent, which is what the encounter/calendar views need).
-    //
-    // However, between team enrollment and the draw being made, entries
-    // exist with `drawId = NULL`. They still carry the `subEventId`, which
-    // is enough for the frontend to resolve `entry.subEventCompetition` and
-    // render the division/Liga label and the edit dialog's competition
-    // field. Before this fallback, freshly-enrolled teams (new enrollment
-    // flow) showed up in the club-teams list without a division until the
-    // sync had assigned a draw, even though the data needed to render the
-    // division was already present on the entry.
-    //
-    // Why both enrollment paths produce drawId = NULL:
-    //   - Old createTeam mutation (this file, ~line 296) does
-    //     EventEntry.findOrCreate keyed on (teamId, subEventId, entryType);
-    //     `EventEntryNewInput` has no `drawId` field, so it is never written.
-    //   - New enrollment flow (EnrollmentEntryService, ~line 110) does
-    //     `EventEntry.create({}, { transaction })` with an empty payload and
-    //     then attaches teamId via `team.setEntry` and subEventId via
-    //     `subEvent.addEventEntry`. Again no `drawId`.
-    // The only place `drawId` gets populated is the federation sync. See
-    // apps/worker/sync/.../competition/processors/standing.processor.ts —
-    // it loads the team with its existing EventEntry filtered by the draw's
-    // subEventId, then runs `entryDraw.drawId = draw.id; entryDraw.save()`.
-    // So sync amends the row created at enrollment time in place; it does
-    // not create a duplicate. Once sync has run, the `find(e => e.drawId)`
-    // branch below wins again and this fallback becomes a no-op.
-    //
-    // Strategy: take the drawId-bearing entry when one exists, otherwise
-    // fall back to any entry for the team. The order of `findAll` is not
-    // guaranteed, but in practice a team has at most one entry per season
-    // until the draw is made, so the fallback is unambiguous in the
-    // pre-draw window.
-    return entries.find((entry: EventEntry) => entry.drawId) ?? entries[0] ?? null;
+    // Delegates to TeamAssociationService which:
+    //   1. Batches all per-team EventEntry lookups in a request into one
+    //      `EventEntry.findAll({ teamId: Op.in([...]) })`.
+    //   2. Groups results by teamId and preserves the existing fallback
+    //      logic: prefer an entry with a `drawId` (federation sync has
+    //      pinned the team to a draw); otherwise fall back to any entry
+    //      for the team (covers freshly-enrolled teams with drawId=NULL).
+    //      See team-association.service.ts:loadEntriesByTeamIds.
+    return this.teamAssociationService.getEntry(team);
   }
 
   @ResolveField(() => Location)
-  async locations(@Parent() team: Team): Promise<Location> {
-    return team.getPrefferedLocation();
+  async locations(@Parent() team: Team): Promise<Location | null> {
+    return this.teamAssociationService.getPrefferedLocation(team);
   }
 
   @ResolveField(() => Player)
-  async captain(@Parent() team: Team): Promise<Player> {
-    return team.getCaptain();
+  async captain(@Parent() team: Team): Promise<Player | null> {
+    return this.teamAssociationService.getCaptain(team);
   }
 
   @ResolveField(() => Club)
-  async club(@Parent() team: Team): Promise<Club> {
-    return team.getClub();
+  async club(@Parent() team: Team): Promise<Club | null> {
+    return this.teamAssociationService.getClub(team);
   }
 
   // Object

--- a/libs/backend/ranking/src/controllers/ranking.controller.ts
+++ b/libs/backend/ranking/src/controllers/ranking.controller.ts
@@ -1,10 +1,11 @@
-import { Player, RankingPlace, RankingSystem } from "@badman/backend-database";
+import { Player, RankingPlace } from "@badman/backend-database";
 import { Controller, Get, Logger, OnModuleDestroy, Query, Res } from "@nestjs/common";
 import { FastifyReply } from "fastify";
 import fs, { existsSync, mkdirSync, rmdirSync, unlinkSync, writeFileSync } from "fs";
 import moment from "moment";
 import { join } from "path";
 import { Op } from "sequelize";
+import { RankingSystemService } from "../services/system/ranking-system.service";
 
 @Controller({
   path: "ranking",
@@ -14,7 +15,7 @@ export class RankingController implements OnModuleDestroy {
   private _resultFolder = join(__dirname, "results");
   private _cleanupTimeouts = new Set<NodeJS.Timeout>();
 
-  constructor() {
+  constructor(private readonly rankingSystemService: RankingSystemService) {
     if (existsSync(this._resultFolder)) {
       // Remove
       rmdirSync(this._resultFolder, { recursive: true });
@@ -40,7 +41,7 @@ export class RankingController implements OnModuleDestroy {
     const files: string[] = [];
     for (const system of systemsIds) {
       const fileNameSafe =
-        (await RankingSystem.findByPk(system, { attributes: ["name"] }))?.name?.replace(
+        (await this.rankingSystemService.getById(system))?.name?.replace(
           /[/\\?%*:|"<>]/g,
           "-"
         ) || "unknown";
@@ -120,7 +121,7 @@ export class RankingController implements OnModuleDestroy {
     const files: string[] = [];
     for (const system of systemsIds) {
       const fileNameSafe =
-        (await RankingSystem.findByPk(system, { attributes: ["name"] }))?.name?.replace(
+        (await this.rankingSystemService.getById(system))?.name?.replace(
           /[/\\?%*:|"<>]/g,
           "-"
         ) || "unknown";
@@ -217,7 +218,7 @@ export class RankingController implements OnModuleDestroy {
     const files: string[] = [];
     for (const system of systemsIds) {
       const fileNameSafe =
-        (await RankingSystem.findByPk(system, { attributes: ["name"] }))?.name?.replace(
+        (await this.rankingSystemService.getById(system))?.name?.replace(
           /[/\\?%*:|"<>]/g,
           "-"
         ) ?? "unknown";


### PR DESCRIPTION
## Summary

- Closes three production Sentry N+1 alerts that survived spec 018: `GetClubPlayers` (#119703169) and `GetClubTeams` (#119723285, #119740683).
- Player resolver: routes `rankingPlaces` / `rankingLastPlaces` (and the `PlayerTeamResolver` overrides) through `RankingSystemService`. Per-player `findOne(primary)` + `findAll(systems)` collapse to one cached primary lookup + one batched by-id call per request.
- New `TeamAssociationService` (`Scope.REQUEST`): microtask-batches `Team.captain` / `locations` / `club` / `entry` / `players` across a request into one `findAll({ id: Op.in })` per association. Preserves the `drawId ?? first` fallback for `Team.entry` and the `player.TeamPlayerMembership` shape consumers expect.
- Migrates remaining out-of-scope RankingSystem fetch sites from spec 018: `rankingPoint`, `assembly`, competition + tournament `subevent` / `event` / `draw` / `encounter` recalculate mutations, `recalculatePlayerRankingPoints`, ranking CSV controller. `calculation.service.ts` left untouched (needs `RankingGroup` eager-load); `rankingSystem.resolver.ts` mutations left untouched (read fresh row inside transaction, then `invalidate()`).

## Test plan

- [x] `nx test backend-graphql` for affected suites (player.resolver, team-association, team.resolver, encounter.resolver) — 34 pass.
- [x] `nx test backend-ranking` — 15 pass.
- [x] `nx lint backend-graphql` — 37 problems, identical to baseline (zero new lint issues).
- [x] New unit specs cover Player ranking field caching + Team association batching.
- [ ] Manual: run `GetClubPlayers` against a club with ≥30 active members with Sequelize logging on. Expect 1 `RankingSystems WHERE primary=true` and 1 `WHERE id IN (...)` per request, independent of member count.
- [ ] Manual: run `GetClubTeams` asking `{ players { id } captain { id } locations { id } club { id } entry { id } }` against a club with ≥10 teams. Expect ≤5 association queries total regardless of team count.
- [ ] Post-deploy: confirm Sentry issues 119703169, 119723285, 119740683 receive zero new events in the 24h window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)