### PR TITLE
chore(enrollment): enrich SEASON_MISMATCH diagnostics

### DIFF
--- a/libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts
@@ -90,16 +90,35 @@ export class EnrollmentEntryService {
 
     const competitionSeason = subEvent.eventCompetition?.season;
     if (team.season !== competitionSeason) {
-      this.logger.warn({
+      const diagnostic = {
         code: ErrorCode.SEASON_MISMATCH,
-        teamId,
-        subEventCompetitionId: subEventId,
         userId,
+        teamId,
+        teamName: team.name,
+        teamClubId: team.clubId,
+        teamType: team.type,
         teamSeason: team.season,
-        competitionSeason,
-      });
+        subEventCompetitionId: subEventId,
+        subEventName: subEvent.name,
+        subEventType: subEvent.eventType,
+        eventCompetitionId: subEvent.eventCompetition?.id ?? null,
+        eventCompetitionName: subEvent.eventCompetition?.name ?? null,
+        competitionSeason: competitionSeason ?? null,
+        basePlayersCount: basePlayers?.length ?? 0,
+      };
+      this.logger.error(
+        `SEASON_MISMATCH: team ${teamId} (season=${team.season}) vs competition ${subEvent.eventCompetition?.id} (season=${competitionSeason})`,
+        diagnostic
+      );
       throw new GraphQLError("Team season does not match competition season.", {
-        extensions: { code: ErrorCode.SEASON_MISMATCH, teamSeason: team.season, competitionSeason },
+        extensions: {
+          code: ErrorCode.SEASON_MISMATCH,
+          teamId,
+          teamSeason: team.season,
+          subEventCompetitionId: subEventId,
+          eventCompetitionId: subEvent.eventCompetition?.id ?? null,
+          competitionSeason,
+        },
       });
     }
 


### PR DESCRIPTION
## Summary

- Promotes the SEASON_MISMATCH log from `warn` to `error` and enriches it with team/sub-event/competition identifiers and names, so Sentry reports carry enough context to root-cause without follow-up DB queries.
- Mirrors the key identifiers into the `GraphQLError` extensions so clients can surface useful diagnostics.
- Already on develop via PR #919; this PR forwards the same change to main.

## Test plan

- [x] Trigger SEASON_MISMATCH locally and confirm Sentry payload contains team/sub-event/competition fields.
- [x] Confirm extension shape is unchanged for existing clients (only fields added, none removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)