### PR TITLE
feat(graphql): DataLoader batching for N+1 field resolvers (022–026)

### DIFF
--- a/libs/backend/graphql/package.json
+++ b/libs/backend/graphql/package.json
@@ -32,7 +32,8 @@
     "uuid": "^11.0.5",
     "class-validator": "^0.14.1",
     "graphql-type-json": "^0.3.2",
-    "graphql": "^16.10.0"
+    "graphql": "^16.10.0",
+    "dataloader": "^2.2.3"
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/libs/backend/graphql/src/grapqhl.module.ts
+++ b/libs/backend/graphql/src/grapqhl.module.ts
@@ -13,6 +13,7 @@ import { ApolloServerPluginUsageReporting } from "@apollo/server/plugin/usageRep
 import { ConfigType } from "@badman/utils";
 import { ConfigModule, ConfigService } from "@nestjs/config";
 import { join } from "node:path";
+import { PlayerLoaderService } from "./loaders";
 import { ResilientDateTimeScalar } from "./scalars";
 import {
   AvailabilityModule,
@@ -92,5 +93,7 @@ import { ServiceResolverModule } from "./resolvers/services/serice.module";
     CronJobResolverModule,
     SettingResolverModule,
   ],
+  providers: [PlayerLoaderService],
+  exports: [PlayerLoaderService],
 })
 export class GrapqhlModule {}

--- a/libs/backend/graphql/src/loaders/draw-competition-loader.service.ts
+++ b/libs/backend/graphql/src/loaders/draw-competition-loader.service.ts
@@ -1,0 +1,39 @@
+import { DrawCompetition } from "@badman/backend-database";
+import { Injectable, Scope } from "@nestjs/common";
+import DataLoader from "dataloader";
+import { Op } from "sequelize";
+
+/**
+ * Request-scoped DataLoader for batching DrawCompetition lookups by ID.
+ *
+ * Collects all draw IDs arriving in one microtask tick (one per
+ * EncounterCompetition row), issues a single
+ * `DrawCompetition.findAll({ where: { id: { [Op.in]: [...ids] } } })`, and
+ * resolves every caller from the shared result.  Missing IDs resolve to
+ * `null`.  The instance is discarded at request end so no cross-request
+ * cache leakage occurs.
+ *
+ * Reused by: EncounterCompetitionResolver (drawCompetition field resolver).
+ * May be reused by feature 025 (DrawCompetition.subEventCompetition).
+ */
+@Injectable({ scope: Scope.REQUEST })
+export class DrawCompetitionLoaderService {
+  private readonly loader = new DataLoader<string, DrawCompetition | null>((ids) =>
+    this.batchDrawsByIds(ids)
+  );
+
+  /**
+   * Load a DrawCompetition by ID.  Returns `null` when the ID is falsy or
+   * the row does not exist.
+   */
+  load(id: string | null | undefined): Promise<DrawCompetition | null> {
+    if (!id) return Promise.resolve(null);
+    return this.loader.load(id);
+  }
+
+  private async batchDrawsByIds(ids: readonly string[]): Promise<(DrawCompetition | null)[]> {
+    const draws = await DrawCompetition.findAll({ where: { id: { [Op.in]: [...ids] } } });
+    const map = new Map(draws.map((d) => [d.id, d]));
+    return ids.map((id) => map.get(id) ?? null);
+  }
+}

--- a/libs/backend/graphql/src/loaders/event-competition-loader.service.ts
+++ b/libs/backend/graphql/src/loaders/event-competition-loader.service.ts
@@ -1,0 +1,39 @@
+import { EventCompetition } from "@badman/backend-database";
+import { Injectable, Scope } from "@nestjs/common";
+import DataLoader from "dataloader";
+import { Op } from "sequelize";
+
+/**
+ * Request-scoped DataLoader for batching EventCompetition lookups by ID.
+ *
+ * Collects all `eventCompetitionId` values arriving in one microtask tick,
+ * issues a single `EventCompetition.findAll({ where: { id: { [Op.in]: [...ids] } } })`,
+ * and resolves every caller from the shared result.  Missing IDs resolve to
+ * `null`.  The instance is discarded at request end so no cross-request
+ * cache leakage occurs.
+ *
+ * Reused by: SubEventCompetitionResolver.eventCompetition field resolver.
+ */
+@Injectable({ scope: Scope.REQUEST })
+export class EventCompetitionLoaderService {
+  private readonly loader = new DataLoader<string, EventCompetition | null>((ids) =>
+    this.batchEventCompetitionsByIds(ids)
+  );
+
+  /**
+   * Load an EventCompetition by ID.  Returns `null` when the ID is falsy or
+   * the row does not exist.
+   */
+  load(id: string | null | undefined): Promise<EventCompetition | null> {
+    if (!id) return Promise.resolve(null);
+    return this.loader.load(id);
+  }
+
+  private async batchEventCompetitionsByIds(
+    ids: readonly string[]
+  ): Promise<(EventCompetition | null)[]> {
+    const events = await EventCompetition.findAll({ where: { id: { [Op.in]: [...ids] } } });
+    const map = new Map(events.map((e) => [e.id, e]));
+    return ids.map((id) => map.get(id) ?? null);
+  }
+}

--- a/libs/backend/graphql/src/loaders/index.ts
+++ b/libs/backend/graphql/src/loaders/index.ts
@@ -1,0 +1,5 @@
+export * from "./draw-competition-loader.service";
+export * from "./event-competition-loader.service";
+export * from "./player-loader.service";
+export * from "./sub-event-competition-loader.service";
+export * from "./team-loader.service";

--- a/libs/backend/graphql/src/loaders/player-loader.service.ts
+++ b/libs/backend/graphql/src/loaders/player-loader.service.ts
@@ -1,0 +1,37 @@
+import { Player } from "@badman/backend-database";
+import { Injectable, Scope } from "@nestjs/common";
+import DataLoader from "dataloader";
+import { Op } from "sequelize";
+
+/**
+ * Request-scoped DataLoader for batching Player lookups by ID.
+ *
+ * Collects all `playerId` values arriving in one microtask tick, issues a
+ * single `Player.findAll({ where: { id: { [Op.in]: [...ids] } } })`, and
+ * resolves every caller from the shared result.  Missing IDs resolve to
+ * `null`.  The instance is discarded at request end so no cross-request
+ * cache leakage occurs.
+ *
+ * Reused by: RankingPointResolver, LastRankingPlaceResolver, CommentResolver.
+ */
+@Injectable({ scope: Scope.REQUEST })
+export class PlayerLoaderService {
+  private readonly loader = new DataLoader<string, Player | null>((ids) =>
+    this.batchPlayersByIds(ids)
+  );
+
+  /**
+   * Load a Player by ID.  Returns `null` when the ID is falsy or the row
+   * does not exist.
+   */
+  load(id: string | null | undefined): Promise<Player | null> {
+    if (!id) return Promise.resolve(null);
+    return this.loader.load(id);
+  }
+
+  private async batchPlayersByIds(ids: readonly string[]): Promise<(Player | null)[]> {
+    const players = await Player.findAll({ where: { id: { [Op.in]: [...ids] } } });
+    const map = new Map(players.map((p) => [p.id, p]));
+    return ids.map((id) => map.get(id) ?? null);
+  }
+}

--- a/libs/backend/graphql/src/loaders/sub-event-competition-loader.service.ts
+++ b/libs/backend/graphql/src/loaders/sub-event-competition-loader.service.ts
@@ -1,0 +1,43 @@
+import { SubEventCompetition } from "@badman/backend-database";
+import { Injectable, Scope } from "@nestjs/common";
+import DataLoader from "dataloader";
+import { Op } from "sequelize";
+
+/**
+ * Request-scoped DataLoader for batching SubEventCompetition lookups by ID.
+ *
+ * Collects all `subEventCompetitionId` values arriving in one microtask tick,
+ * issues a single `SubEventCompetition.findAll({ where: { id: { [Op.in]: [...ids] } } })`,
+ * and resolves every caller from the shared result.  Missing IDs resolve to
+ * `null`.  The instance is discarded at request end so no cross-request
+ * cache leakage occurs.
+ *
+ * Shared across: DrawCompetitionResolver.subEventCompetition and
+ * EventEntryResolver.subEventCompetition — cross-resolver dedup is automatic
+ * because both resolvers inject the same Scope.REQUEST instance.
+ */
+@Injectable({ scope: Scope.REQUEST })
+export class SubEventCompetitionLoaderService {
+  private readonly loader = new DataLoader<string, SubEventCompetition | null>((ids) =>
+    this.batchSubEventCompetitionsByIds(ids)
+  );
+
+  /**
+   * Load a SubEventCompetition by ID.  Returns `null` when the ID is falsy or
+   * the row does not exist.
+   */
+  load(id: string | null | undefined): Promise<SubEventCompetition | null> {
+    if (!id) return Promise.resolve(null);
+    return this.loader.load(id);
+  }
+
+  private async batchSubEventCompetitionsByIds(
+    ids: readonly string[]
+  ): Promise<(SubEventCompetition | null)[]> {
+    const subEvents = await SubEventCompetition.findAll({
+      where: { id: { [Op.in]: [...ids] } },
+    });
+    const map = new Map(subEvents.map((s) => [s.id, s]));
+    return ids.map((id) => map.get(id) ?? null);
+  }
+}

--- a/libs/backend/graphql/src/loaders/team-loader.service.ts
+++ b/libs/backend/graphql/src/loaders/team-loader.service.ts
@@ -1,0 +1,38 @@
+import { Team } from "@badman/backend-database";
+import { Injectable, Scope } from "@nestjs/common";
+import DataLoader from "dataloader";
+import { Op } from "sequelize";
+
+/**
+ * Request-scoped DataLoader for batching Team lookups by ID.
+ *
+ * Collects all team IDs arriving in one microtask tick (home + away from
+ * multiple EncounterCompetition rows), issues a single
+ * `Team.findAll({ where: { id: { [Op.in]: [...ids] } } })`, and resolves
+ * every caller from the shared result.  Missing IDs resolve to `null`.
+ * The instance is discarded at request end so no cross-request cache
+ * leakage occurs.
+ *
+ * Reused by: EncounterCompetitionResolver (home + away field resolvers).
+ */
+@Injectable({ scope: Scope.REQUEST })
+export class TeamLoaderService {
+  private readonly loader = new DataLoader<string, Team | null>((ids) =>
+    this.batchTeamsByIds(ids)
+  );
+
+  /**
+   * Load a Team by ID.  Returns `null` when the ID is falsy or the row
+   * does not exist.
+   */
+  load(id: string | null | undefined): Promise<Team | null> {
+    if (!id) return Promise.resolve(null);
+    return this.loader.load(id);
+  }
+
+  private async batchTeamsByIds(ids: readonly string[]): Promise<(Team | null)[]> {
+    const teams = await Team.findAll({ where: { id: { [Op.in]: [...ids] } } });
+    const map = new Map(teams.map((t) => [t.id, t]));
+    return ids.map((id) => map.get(id) ?? null);
+  }
+}

--- a/libs/backend/graphql/src/resolvers/comment/comment.module.ts
+++ b/libs/backend/graphql/src/resolvers/comment/comment.module.ts
@@ -1,10 +1,11 @@
 import { DatabaseModule } from "@badman/backend-database";
 import { NotificationsModule } from "@badman/backend-notifications";
 import { Module } from "@nestjs/common";
+import { PlayerLoaderService } from "../../loaders";
 import { CommentResolver } from "./comment.resolver";
 
 @Module({
   imports: [NotificationsModule, DatabaseModule],
-  providers: [CommentResolver],
+  providers: [CommentResolver, PlayerLoaderService],
 })
 export class CommentResolverModule {}

--- a/libs/backend/graphql/src/resolvers/comment/comment.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/comment/comment.resolver.spec.ts
@@ -1,0 +1,107 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { Comment, Player } from "@badman/backend-database";
+import { NotificationService } from "@badman/backend-notifications";
+import { Sequelize } from "sequelize-typescript";
+import { PlayerLoaderService } from "../../loaders";
+import { CommentResolver } from "./comment.resolver";
+
+describe("CommentResolver", () => {
+  let resolver: CommentResolver;
+  let playerLoader: { load: jest.Mock };
+
+  beforeEach(async () => {
+    playerLoader = { load: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CommentResolver,
+        {
+          provide: Sequelize,
+          useValue: {
+            transaction: jest.fn().mockResolvedValue({
+              commit: jest.fn(),
+              rollback: jest.fn(),
+            }),
+          },
+        },
+        {
+          provide: NotificationService,
+          useValue: {
+            notifyEncounterChange: jest.fn(),
+          },
+        },
+        {
+          provide: PlayerLoaderService,
+          useValue: playerLoader,
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<CommentResolver>(CommentResolver);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // ── player ResolveField ───────────────────────────────────────────────────
+
+  describe("player", () => {
+    it("calls playerLoader.load with comment.playerId", async () => {
+      const comment = { playerId: "p1" } as unknown as Comment;
+      const player = { id: "p1" } as unknown as Player;
+      playerLoader.load.mockResolvedValue(player);
+
+      const result = await resolver.player(comment);
+
+      expect(playerLoader.load).toHaveBeenCalledWith("p1");
+      expect(result).toBe(player);
+    });
+
+    it("returns null when playerId is null (anonymous comment)", async () => {
+      const comment = { playerId: null } as unknown as Comment;
+      playerLoader.load.mockResolvedValue(null);
+
+      const result = await resolver.player(comment);
+
+      expect(playerLoader.load).toHaveBeenCalledWith(null);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when playerId is undefined", async () => {
+      const comment = { playerId: undefined } as unknown as Comment;
+      playerLoader.load.mockResolvedValue(null);
+
+      const result = await resolver.player(comment);
+
+      expect(playerLoader.load).toHaveBeenCalledWith(undefined);
+      expect(result).toBeNull();
+    });
+
+    it("batches N rows via a single playerLoader — no direct Player.findAll calls", async () => {
+      const comments = Array.from({ length: 8 }, (_, i) => ({
+        playerId: `p${i}`,
+      })) as unknown as Comment[];
+
+      const players = comments.map((c) => ({ id: c.playerId }) as unknown as Player);
+
+      playerLoader.load.mockImplementation((id: string) =>
+        Promise.resolve(players.find((p) => p.id === id) ?? null)
+      );
+
+      // Spy to confirm resolver does NOT call Player.findAll directly
+      const findAllSpy = jest.spyOn(Player, "findAll").mockResolvedValue([]);
+
+      const results = await Promise.all(comments.map((c) => resolver.player(c)));
+
+      expect(results).toHaveLength(8);
+      results.forEach((r, i) => expect(r?.id).toBe(`p${i}`));
+
+      // Resolver must delegate to the loader, not call findAll directly
+      expect(findAllSpy).not.toHaveBeenCalled();
+
+      // load called once per comment (batching is internal to DataLoader)
+      expect(playerLoader.load).toHaveBeenCalledTimes(8);
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/comment/comment.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/comment/comment.resolver.ts
@@ -17,6 +17,7 @@ import {
 import { Args, ID, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { Transaction } from "sequelize";
 import { Sequelize } from "sequelize-typescript";
+import { PlayerLoaderService } from "../../loaders";
 import { ListArgs } from "../../utils";
 
 @Resolver(() => Comment)
@@ -25,7 +26,8 @@ export class CommentResolver {
 
   constructor(
     private _sequelize: Sequelize,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    private playerLoader: PlayerLoaderService
   ) {}
 
   @Query(() => Comment)
@@ -44,8 +46,8 @@ export class CommentResolver {
   }
 
   @ResolveField(() => Player, { nullable: true })
-  async player(@Parent() comment: Comment): Promise<Player> {
-    return comment.getPlayer();
+  async player(@Parent() comment: Comment): Promise<Player | null> {
+    return this.playerLoader.load(comment.playerId);
   }
 
   @Mutation(() => Comment)

--- a/libs/backend/graphql/src/resolvers/event/competition.module.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition.module.ts
@@ -8,6 +8,12 @@ import { QueueModule } from "@badman/backend-queue";
 import { RankingModule } from "@badman/backend-ranking";
 import { Module } from "@nestjs/common";
 import {
+  DrawCompetitionLoaderService,
+  EventCompetitionLoaderService,
+  SubEventCompetitionLoaderService,
+  TeamLoaderService,
+} from "../../loaders";
+import {
   AssemblyResolver,
   CalculateIndexResolver,
   DrawCompetitionResolver,
@@ -52,6 +58,10 @@ import { EnrollmentFinalizeService } from "./enrollment-finalize.service";
     ClubMembershipService,
     TeamWriteService,
     EnrollmentFinalizeService,
+    TeamLoaderService,
+    DrawCompetitionLoaderService,
+    EventCompetitionLoaderService,
+    SubEventCompetitionLoaderService,
   ],
 })
 export class CompetitionResolverModule {}

--- a/libs/backend/graphql/src/resolvers/event/competition/draw.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/draw.resolver.spec.ts
@@ -1,0 +1,95 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { DrawCompetition, SubEventCompetition } from "@badman/backend-database";
+import { getQueueToken } from "@nestjs/bull";
+import { Sequelize } from "sequelize-typescript";
+import { DrawCompetitionResolver } from "./draw.resolver";
+import { SubEventCompetitionLoaderService } from "../../../loaders";
+import { PointsService, RankingSystemService } from "@badman/backend-ranking";
+import { SyncQueue } from "@badman/backend-queue";
+
+describe("DrawCompetitionResolver — DataLoader field resolvers", () => {
+  let resolver: DrawCompetitionResolver;
+  let subEventLoaderService: SubEventCompetitionLoaderService;
+
+  const makeDraw = (overrides: Partial<DrawCompetition> = {}) =>
+    ({
+      id: "draw-uuid",
+      subeventId: "subevent-uuid",
+      ...overrides,
+    }) as unknown as DrawCompetition;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DrawCompetitionResolver,
+        {
+          provide: getQueueToken(SyncQueue),
+          useValue: { add: jest.fn() },
+        },
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn() },
+        },
+        {
+          provide: PointsService,
+          useValue: {},
+        },
+        {
+          provide: RankingSystemService,
+          useValue: {},
+        },
+        {
+          provide: SubEventCompetitionLoaderService,
+          useValue: { load: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<DrawCompetitionResolver>(DrawCompetitionResolver);
+    subEventLoaderService = module.get<SubEventCompetitionLoaderService>(
+      SubEventCompetitionLoaderService
+    );
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("subEventCompetition field resolver", () => {
+    it("calls subEventLoader.load with draw.subeventId", async () => {
+      const draw = makeDraw({ subeventId: "subevent-uuid" });
+      const fakeSubEvent = { id: "subevent-uuid" } as unknown as SubEventCompetition;
+      jest.spyOn(subEventLoaderService, "load").mockResolvedValue(fakeSubEvent);
+
+      const result = await resolver.subEventCompetition(draw);
+
+      expect(subEventLoaderService.load).toHaveBeenCalledWith("subevent-uuid");
+      expect(result).toBe(fakeSubEvent);
+    });
+
+    it("returns null when subeventId is null", async () => {
+      const draw = makeDraw({ subeventId: undefined });
+      jest.spyOn(subEventLoaderService, "load").mockResolvedValue(null);
+
+      const result = await resolver.subEventCompetition(draw);
+
+      expect(subEventLoaderService.load).toHaveBeenCalledWith(undefined);
+      expect(result).toBeNull();
+    });
+
+    it("issues a loader call per draw when resolving multiple draws", async () => {
+      const loadSpy = jest
+        .spyOn(subEventLoaderService, "load")
+        .mockResolvedValue({ id: "subevent-uuid" } as unknown as SubEventCompetition);
+
+      const draws = Array.from({ length: 8 }, (_, i) =>
+        makeDraw({ id: `draw-${i}`, subeventId: "subevent-uuid" })
+      );
+
+      await Promise.all(draws.map((d) => resolver.subEventCompetition(d)));
+
+      expect(loadSpy).toHaveBeenCalledTimes(8);
+      draws.forEach((d) => {
+        expect(loadSpy).toHaveBeenCalledWith(d.subeventId);
+      });
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/event/competition/draw.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/draw.resolver.ts
@@ -15,6 +15,7 @@ import { sortStanding } from "@badman/utils";
 import { Logger, NotFoundException, UnauthorizedException } from "@nestjs/common";
 import { Args, ID, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { Sequelize } from "sequelize-typescript";
+import { SubEventCompetitionLoaderService } from "../../../loaders";
 import { ListArgs } from "../../../utils";
 import { Sync, SyncQueue } from "@badman/backend-queue";
 import { InjectQueue } from "@nestjs/bull";
@@ -28,7 +29,8 @@ export class DrawCompetitionResolver {
     private _sequelize: Sequelize,
     private _pointService: PointsService,
     @InjectQueue(SyncQueue) private _syncQueue: Queue,
-    private readonly rankingSystemService: RankingSystemService
+    private readonly rankingSystemService: RankingSystemService,
+    private readonly subEventLoader: SubEventCompetitionLoaderService
   ) {}
 
   @Query(() => DrawCompetition)
@@ -48,7 +50,7 @@ export class DrawCompetitionResolver {
 
   @ResolveField(() => SubEventCompetition)
   async subEventCompetition(@Parent() draw: DrawCompetition): Promise<SubEventCompetition> {
-    return draw.getSubEventCompetition();
+    return this.subEventLoader.load(draw.subeventId) as Promise<SubEventCompetition>;
   }
 
   @ResolveField(() => [EventEntry])

--- a/libs/backend/graphql/src/resolvers/event/competition/encounter.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/encounter.resolver.spec.ts
@@ -1,0 +1,197 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import {
+  DrawCompetition,
+  EncounterCompetition,
+  Team,
+  Player,
+} from "@badman/backend-database";
+import { getQueueToken } from "@nestjs/bull";
+import { Sequelize } from "sequelize-typescript";
+import { EncounterCompetitionResolver } from "./encounter.resolver";
+import { DrawCompetitionLoaderService } from "../../../loaders/draw-competition-loader.service";
+import { TeamLoaderService } from "../../../loaders/team-loader.service";
+import { EncounterValidationService } from "@badman/backend-change-encounter";
+import { EncounterGamesGenerationService } from "@badman/backend-encounter-games";
+import { PointsService, RankingSystemService } from "@badman/backend-ranking";
+import { SyncQueue } from "@badman/backend-queue";
+
+describe("EncounterCompetitionResolver — DataLoader field resolvers", () => {
+  let resolver: EncounterCompetitionResolver;
+  let teamLoaderService: TeamLoaderService;
+  let drawLoaderService: DrawCompetitionLoaderService;
+
+  const makeEncounter = (overrides: Partial<EncounterCompetition> = {}) =>
+    ({
+      id: "enc-uuid",
+      homeTeamId: "home-team-uuid",
+      awayTeamId: "away-team-uuid",
+      drawId: "draw-uuid",
+      ...overrides,
+    }) as unknown as EncounterCompetition;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EncounterCompetitionResolver,
+        {
+          provide: getQueueToken(SyncQueue),
+          useValue: { add: jest.fn() },
+        },
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn() },
+        },
+        {
+          provide: PointsService,
+          useValue: {},
+        },
+        {
+          provide: EncounterValidationService,
+          useValue: {},
+        },
+        {
+          provide: EncounterGamesGenerationService,
+          useValue: {},
+        },
+        {
+          provide: RankingSystemService,
+          useValue: {},
+        },
+        {
+          provide: TeamLoaderService,
+          useValue: { load: jest.fn() },
+        },
+        {
+          provide: DrawCompetitionLoaderService,
+          useValue: { load: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<EncounterCompetitionResolver>(EncounterCompetitionResolver);
+    teamLoaderService = module.get<TeamLoaderService>(TeamLoaderService);
+    drawLoaderService = module.get<DrawCompetitionLoaderService>(DrawCompetitionLoaderService);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("home field resolver", () => {
+    it("calls teamLoader.load with encounter.homeTeamId", async () => {
+      const encounter = makeEncounter({ homeTeamId: "home-team-uuid" });
+      const fakeTeam = { id: "home-team-uuid" } as unknown as Team;
+      jest.spyOn(teamLoaderService, "load").mockResolvedValue(fakeTeam);
+
+      const result = await resolver.home(encounter);
+
+      expect(teamLoaderService.load).toHaveBeenCalledWith("home-team-uuid");
+      expect(result).toBe(fakeTeam);
+    });
+
+    it("returns null when homeTeamId is null", async () => {
+      const encounter = makeEncounter({ homeTeamId: undefined });
+      jest.spyOn(teamLoaderService, "load").mockResolvedValue(null);
+
+      const result = await resolver.home(encounter);
+
+      expect(teamLoaderService.load).toHaveBeenCalledWith(undefined);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when loader throws", async () => {
+      const encounter = makeEncounter();
+      jest.spyOn(teamLoaderService, "load").mockRejectedValue(new Error("DB error"));
+
+      const result = await resolver.home(encounter);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("away field resolver", () => {
+    it("calls teamLoader.load with encounter.awayTeamId", async () => {
+      const encounter = makeEncounter({ awayTeamId: "away-team-uuid" });
+      const fakeTeam = { id: "away-team-uuid" } as unknown as Team;
+      jest.spyOn(teamLoaderService, "load").mockResolvedValue(fakeTeam);
+
+      const result = await resolver.away(encounter);
+
+      expect(teamLoaderService.load).toHaveBeenCalledWith("away-team-uuid");
+      expect(result).toBe(fakeTeam);
+    });
+
+    it("returns null when awayTeamId is null", async () => {
+      const encounter = makeEncounter({ awayTeamId: undefined });
+      jest.spyOn(teamLoaderService, "load").mockResolvedValue(null);
+
+      const result = await resolver.away(encounter);
+
+      expect(teamLoaderService.load).toHaveBeenCalledWith(undefined);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when loader throws", async () => {
+      const encounter = makeEncounter();
+      jest.spyOn(teamLoaderService, "load").mockRejectedValue(new Error("DB error"));
+
+      const result = await resolver.away(encounter);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("drawCompetition field resolver", () => {
+    it("calls drawLoader.load with encounter.drawId", async () => {
+      const encounter = makeEncounter({ drawId: "draw-uuid" });
+      const fakeDraw = { id: "draw-uuid" } as unknown as DrawCompetition;
+      jest.spyOn(drawLoaderService, "load").mockResolvedValue(fakeDraw);
+
+      const result = await resolver.drawCompetition(encounter);
+
+      expect(drawLoaderService.load).toHaveBeenCalledWith("draw-uuid");
+      expect(result).toBe(fakeDraw);
+    });
+
+    it("returns null when drawId is null", async () => {
+      const encounter = makeEncounter({ drawId: undefined });
+      jest.spyOn(drawLoaderService, "load").mockResolvedValue(null);
+
+      const result = await resolver.drawCompetition(encounter);
+
+      expect(drawLoaderService.load).toHaveBeenCalledWith(undefined);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when loader throws", async () => {
+      const encounter = makeEncounter();
+      jest.spyOn(drawLoaderService, "load").mockRejectedValue(new Error("DB error"));
+
+      const result = await resolver.drawCompetition(encounter);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("home + away batching via shared TeamLoaderService", () => {
+    it("uses the same teamLoader instance for both home and away calls", async () => {
+      const homeEncounter = makeEncounter({ homeTeamId: "team-1" });
+      const awayEncounter = makeEncounter({ awayTeamId: "team-2" });
+      const teamA = { id: "team-1" } as unknown as Team;
+      const teamB = { id: "team-2" } as unknown as Team;
+
+      const loadSpy = jest
+        .spyOn(teamLoaderService, "load")
+        .mockImplementation(async (id) => (id === "team-1" ? teamA : teamB));
+
+      const [homeResult, awayResult] = await Promise.all([
+        resolver.home(homeEncounter),
+        resolver.away(awayEncounter),
+      ]);
+
+      expect(loadSpy).toHaveBeenCalledTimes(2);
+      expect(loadSpy).toHaveBeenCalledWith("team-1");
+      expect(loadSpy).toHaveBeenCalledWith("team-2");
+      expect(homeResult).toBe(teamA);
+      expect(awayResult).toBe(teamB);
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/event/competition/encounter.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/encounter.resolver.ts
@@ -39,6 +39,7 @@ import { Queue } from "bull";
 import { Sequelize } from "sequelize-typescript";
 import { QueryTypes, Op } from "sequelize";
 import { ListArgs } from "../../../utils";
+import { DrawCompetitionLoaderService, TeamLoaderService } from "../../../loaders";
 
 @ObjectType()
 export class PagedEncounterCompetition {
@@ -68,7 +69,9 @@ export class EncounterCompetitionResolver {
     private _pointService: PointsService,
     private encounterValidationService: EncounterValidationService,
     private encounterGamesService: EncounterGamesGenerationService,
-    private readonly rankingSystemService: RankingSystemService
+    private readonly rankingSystemService: RankingSystemService,
+    private readonly teamLoader: TeamLoaderService,
+    private readonly drawLoader: DrawCompetitionLoaderService
   ) {}
 
   @Query(() => EncounterCompetition)
@@ -278,7 +281,7 @@ export class EncounterCompetitionResolver {
     @Parent() encounter: EncounterCompetition
   ): Promise<DrawCompetition | null> {
     try {
-      return await encounter.getDrawCompetition();
+      return await this.drawLoader.load(encounter.drawId);
     } catch (error) {
       this.logger.debug(
         "[drawCompetition] Client disconnected or error occurred:",
@@ -304,7 +307,7 @@ export class EncounterCompetitionResolver {
   @ResolveField(() => Team)
   async home(@Parent() encounter: EncounterCompetition): Promise<Team | null> {
     try {
-      return await encounter.getHome();
+      return await this.teamLoader.load(encounter.homeTeamId);
     } catch (error) {
       this.logger.debug(
         "[home] Client disconnected or error occurred:",
@@ -317,7 +320,7 @@ export class EncounterCompetitionResolver {
   @ResolveField(() => Team)
   async away(@Parent() encounter: EncounterCompetition): Promise<Team | null> {
     try {
-      return await encounter.getAway();
+      return await this.teamLoader.load(encounter.awayTeamId);
     } catch (error) {
       this.logger.debug(
         "[away] Client disconnected or error occurred:",

--- a/libs/backend/graphql/src/resolvers/event/competition/subevent.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/subevent.resolver.spec.ts
@@ -1,0 +1,100 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { EventCompetition, SubEventCompetition } from "@badman/backend-database";
+import { getQueueToken } from "@nestjs/bull";
+import { CACHE_MANAGER } from "@nestjs/cache-manager";
+import { Sequelize } from "sequelize-typescript";
+import { SubEventCompetitionResolver } from "./subevent.resolver";
+import { EventCompetitionLoaderService } from "../../../loaders";
+import { PointsService, RankingSystemService } from "@badman/backend-ranking";
+import { SyncQueue } from "@badman/backend-queue";
+
+describe("SubEventCompetitionResolver — DataLoader field resolvers", () => {
+  let resolver: SubEventCompetitionResolver;
+  let eventCompetitionLoaderService: EventCompetitionLoaderService;
+
+  const makeSubEvent = (overrides: Partial<SubEventCompetition> = {}) =>
+    ({
+      id: "subevent-uuid",
+      eventId: "event-uuid",
+      ...overrides,
+    }) as unknown as SubEventCompetition;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SubEventCompetitionResolver,
+        {
+          provide: CACHE_MANAGER,
+          useValue: { get: jest.fn().mockResolvedValue(null), set: jest.fn() },
+        },
+        {
+          provide: getQueueToken(SyncQueue),
+          useValue: { add: jest.fn() },
+        },
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn() },
+        },
+        {
+          provide: PointsService,
+          useValue: {},
+        },
+        {
+          provide: RankingSystemService,
+          useValue: {},
+        },
+        {
+          provide: EventCompetitionLoaderService,
+          useValue: { load: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<SubEventCompetitionResolver>(SubEventCompetitionResolver);
+    eventCompetitionLoaderService = module.get<EventCompetitionLoaderService>(
+      EventCompetitionLoaderService
+    );
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("eventCompetition field resolver", () => {
+    it("calls eventCompetitionLoader.load with subEvent.eventId", async () => {
+      const subEvent = makeSubEvent({ eventId: "event-uuid" });
+      const fakeEvent = { id: "event-uuid" } as unknown as EventCompetition;
+      jest.spyOn(eventCompetitionLoaderService, "load").mockResolvedValue(fakeEvent);
+
+      const result = await resolver.eventCompetition(subEvent);
+
+      expect(eventCompetitionLoaderService.load).toHaveBeenCalledWith("event-uuid");
+      expect(result).toBe(fakeEvent);
+    });
+
+    it("returns null when eventId is null", async () => {
+      const subEvent = makeSubEvent({ eventId: undefined });
+      jest.spyOn(eventCompetitionLoaderService, "load").mockResolvedValue(null);
+
+      const result = await resolver.eventCompetition(subEvent);
+
+      expect(eventCompetitionLoaderService.load).toHaveBeenCalledWith(undefined);
+      expect(result).toBeNull();
+    });
+
+    it("issues a single batch call for multiple subEvents sharing one eventId", async () => {
+      const loadSpy = jest
+        .spyOn(eventCompetitionLoaderService, "load")
+        .mockResolvedValue({ id: "event-uuid" } as unknown as EventCompetition);
+
+      const subEvents = Array.from({ length: 8 }, (_, i) =>
+        makeSubEvent({ id: `subevent-${i}`, eventId: "event-uuid" })
+      );
+
+      await Promise.all(subEvents.map((s) => resolver.eventCompetition(s)));
+
+      expect(loadSpy).toHaveBeenCalledTimes(8);
+      subEvents.forEach((s) => {
+        expect(loadSpy).toHaveBeenCalledWith(s.eventId);
+      });
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/event/competition/subevent.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/subevent.resolver.ts
@@ -24,6 +24,7 @@ import { Args, ID, Mutation, Parent, Query, ResolveField, Resolver } from "@nest
 import { Queue } from "bull";
 import { Cache } from "cache-manager";
 import { Sequelize } from "sequelize-typescript";
+import { EventCompetitionLoaderService } from "../../../loaders";
 import { ListArgs } from "../../../utils";
 
 @Resolver(() => SubEventCompetition)
@@ -35,7 +36,8 @@ export class SubEventCompetitionResolver {
     @InjectQueue(SyncQueue) private _syncQueue: Queue,
     private _sequelize: Sequelize,
     private _pointService: PointsService,
-    private readonly rankingSystemService: RankingSystemService
+    private readonly rankingSystemService: RankingSystemService,
+    private readonly eventCompetitionLoader: EventCompetitionLoaderService
   ) {}
 
   @Query(() => SubEventCompetition)
@@ -60,7 +62,7 @@ export class SubEventCompetitionResolver {
 
   @ResolveField(() => EventCompetition)
   async eventCompetition(@Parent() subEvent: SubEventCompetition): Promise<EventCompetition> {
-    return subEvent.getEventCompetition();
+    return this.eventCompetitionLoader.load(subEvent.eventId) as Promise<EventCompetition>;
   }
 
   @ResolveField(() => [DrawCompetition])

--- a/libs/backend/graphql/src/resolvers/event/entry.resolver.dataloader.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/entry.resolver.dataloader.spec.ts
@@ -1,0 +1,92 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { EventEntry, Player, SubEventCompetition } from "@badman/backend-database";
+import { Sequelize } from "sequelize-typescript";
+import { EventEntryResolver } from "./entry.resolver";
+import { SubEventCompetitionLoaderService } from "../../loaders";
+import { EnrollmentValidationService } from "@badman/backend-enrollment";
+import { NotificationService } from "@badman/backend-notifications";
+import { EnrollmentFinalizeService } from "./enrollment-finalize.service";
+
+describe("EventEntryResolver — DataLoader field resolvers", () => {
+  let resolver: EventEntryResolver;
+  let subEventLoaderService: SubEventCompetitionLoaderService;
+
+  const makeEntry = (overrides: Partial<EventEntry> = {}) =>
+    ({
+      id: "entry-uuid",
+      subEventId: "subevent-uuid",
+      ...overrides,
+    }) as unknown as EventEntry;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EventEntryResolver,
+        EnrollmentFinalizeService,
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn() },
+        },
+        {
+          provide: NotificationService,
+          useValue: { notifyEnrollment: jest.fn() },
+        },
+        {
+          provide: EnrollmentValidationService,
+          useValue: { fetchAndValidate: jest.fn() },
+        },
+        {
+          provide: SubEventCompetitionLoaderService,
+          useValue: { load: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<EventEntryResolver>(EventEntryResolver);
+    subEventLoaderService = module.get<SubEventCompetitionLoaderService>(
+      SubEventCompetitionLoaderService
+    );
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("subEventCompetition field resolver", () => {
+    it("calls subEventLoader.load with eventEntry.subEventId", async () => {
+      const entry = makeEntry({ subEventId: "subevent-uuid" });
+      const fakeSubEvent = { id: "subevent-uuid" } as unknown as SubEventCompetition;
+      jest.spyOn(subEventLoaderService, "load").mockResolvedValue(fakeSubEvent);
+
+      const result = await resolver.subEventCompetition(entry);
+
+      expect(subEventLoaderService.load).toHaveBeenCalledWith("subevent-uuid");
+      expect(result).toBe(fakeSubEvent);
+    });
+
+    it("returns null when subEventId is null", async () => {
+      const entry = makeEntry({ subEventId: undefined });
+      jest.spyOn(subEventLoaderService, "load").mockResolvedValue(null);
+
+      const result = await resolver.subEventCompetition(entry);
+
+      expect(subEventLoaderService.load).toHaveBeenCalledWith(undefined);
+      expect(result).toBeNull();
+    });
+
+    it("issues a loader call per entry when resolving multiple entries", async () => {
+      const loadSpy = jest
+        .spyOn(subEventLoaderService, "load")
+        .mockResolvedValue({ id: "subevent-uuid" } as unknown as SubEventCompetition);
+
+      const entries = Array.from({ length: 8 }, (_, i) =>
+        makeEntry({ id: `entry-${i}`, subEventId: "subevent-uuid" })
+      );
+
+      await Promise.all(entries.map((e) => resolver.subEventCompetition(e)));
+
+      expect(loadSpy).toHaveBeenCalledTimes(8);
+      entries.forEach((e) => {
+        expect(loadSpy).toHaveBeenCalledWith(e.subEventId);
+      });
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts
@@ -7,6 +7,7 @@ import { EnrollmentValidationService } from "@badman/backend-enrollment";
 import { NotificationService } from "@badman/backend-notifications";
 import { EventEntryResolver } from "./entry.resolver";
 import { EnrollmentFinalizeService } from "./enrollment-finalize.service";
+import { SubEventCompetitionLoaderService } from "../../loaders";
 import { ErrorCode } from "../../utils/error-codes";
 
 const CLUB_UUID = "f47ac10b-58cc-4372-a567-0e02b2c3d479";
@@ -86,6 +87,10 @@ describe("EventEntryResolver.finishEventEntry", () => {
         {
           provide: EnrollmentValidationService,
           useValue: mockEnrollmentService,
+        },
+        {
+          provide: SubEventCompetitionLoaderService,
+          useValue: { load: jest.fn() },
         },
       ],
     }).compile();

--- a/libs/backend/graphql/src/resolvers/event/entry.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/entry.resolver.ts
@@ -14,6 +14,7 @@ import {
 } from "@badman/backend-database";
 import { EnrollmentValidationService, TeamEnrollmentOutput } from "@badman/backend-enrollment";
 import { NotificationService } from "@badman/backend-notifications";
+import { SubEventCompetitionLoaderService } from "../../loaders";
 import { TeamMembershipType } from "@badman/utils";
 import { Logger, NotFoundException, UnauthorizedException } from "@nestjs/common";
 import { Args, ID, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
@@ -30,7 +31,8 @@ export class EventEntryResolver {
     private notificationService: NotificationService,
     private enrollmentService: EnrollmentValidationService,
     private enrollmentFinalizeService: EnrollmentFinalizeService,
-    private _sequelize: Sequelize
+    private _sequelize: Sequelize,
+    private readonly subEventLoader: SubEventCompetitionLoaderService
   ) {}
 
   @Query(() => EventEntry)
@@ -60,7 +62,7 @@ export class EventEntryResolver {
 
   @ResolveField(() => SubEventCompetition, { nullable: true })
   async subEventCompetition(@Parent() eventEntry: EventEntry): Promise<SubEventCompetition> {
-    return eventEntry.getSubEventCompetition();
+    return this.subEventLoader.load(eventEntry.subEventId) as Promise<SubEventCompetition>;
   }
   @ResolveField(() => DrawCompetition, { nullable: true })
   async drawCompetition(@Parent() eventEntry: EventEntry): Promise<DrawCompetition> {

--- a/libs/backend/graphql/src/resolvers/event/event.module.ts
+++ b/libs/backend/graphql/src/resolvers/event/event.module.ts
@@ -5,6 +5,7 @@ import { EnrollmentFinalizeService } from "./enrollment-finalize.service";
 import { TournamentResolverModule } from "./tournament.module";
 import { NotificationsModule } from "@badman/backend-notifications";
 import { EnrollmentModule } from "@badman/backend-enrollment";
+import { SubEventCompetitionLoaderService } from "../../loaders";
 
 @Module({
   imports: [
@@ -13,7 +14,12 @@ import { EnrollmentModule } from "@badman/backend-enrollment";
     NotificationsModule,
     EnrollmentModule,
   ],
-  providers: [EventEntryResolver, EntryCompetitionPlayersResolver, EnrollmentFinalizeService],
+  providers: [
+    EventEntryResolver,
+    EntryCompetitionPlayersResolver,
+    EnrollmentFinalizeService,
+    SubEventCompetitionLoaderService,
+  ],
   exports: [EnrollmentFinalizeService],
 })
 export class EventResolverModule {}

--- a/libs/backend/graphql/src/resolvers/ranking/lastRankingPlace.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/ranking/lastRankingPlace.resolver.spec.ts
@@ -1,15 +1,18 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { NotFoundException } from "@nestjs/common";
-import { RankingLastPlace, RankingSystem } from "@badman/backend-database";
+import { Player, RankingLastPlace, RankingSystem } from "@badman/backend-database";
 import { RankingSystemService } from "@badman/backend-ranking";
+import { PlayerLoaderService } from "../../loaders";
 import { LastRankingPlaceResolver } from "./lastRankingPlace.resolver";
 
-describe("LastRankingPlaceResolver — rankingSystem ResolveField", () => {
+describe("LastRankingPlaceResolver", () => {
   let resolver: LastRankingPlaceResolver;
   let rankingSystemService: { getById: jest.Mock };
+  let playerLoader: { load: jest.Mock };
 
   beforeEach(async () => {
     rankingSystemService = { getById: jest.fn() };
+    playerLoader = { load: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -17,6 +20,10 @@ describe("LastRankingPlaceResolver — rankingSystem ResolveField", () => {
         {
           provide: RankingSystemService,
           useValue: rankingSystemService,
+        },
+        {
+          provide: PlayerLoaderService,
+          useValue: playerLoader,
         },
       ],
     }).compile();
@@ -28,29 +35,97 @@ describe("LastRankingPlaceResolver — rankingSystem ResolveField", () => {
     jest.restoreAllMocks();
   });
 
-  it("calls getById with rankingPlace.systemId", async () => {
-    const place = { systemId: "s1" } as unknown as RankingLastPlace;
-    rankingSystemService.getById.mockResolvedValue({ id: "s1" });
+  // ── rankingSystem ResolveField ────────────────────────────────────────────
 
-    await resolver.rankingSystem(place);
+  describe("rankingSystem", () => {
+    it("calls getById with rankingPlace.systemId", async () => {
+      const place = { systemId: "s1" } as unknown as RankingLastPlace;
+      rankingSystemService.getById.mockResolvedValue({ id: "s1" });
 
-    expect(rankingSystemService.getById).toHaveBeenCalledWith("s1");
+      await resolver.rankingSystem(place);
+
+      expect(rankingSystemService.getById).toHaveBeenCalledWith("s1");
+    });
+
+    it("returns the resolved system on success", async () => {
+      const place = { systemId: "s1" } as unknown as RankingLastPlace;
+      const system = { id: "s1" } as unknown as RankingSystem;
+      rankingSystemService.getById.mockResolvedValue(system);
+
+      const result = await resolver.rankingSystem(place);
+
+      expect(result).toBe(system);
+    });
+
+    it("throws NotFoundException when getById returns null", async () => {
+      const place = { systemId: "missing" } as unknown as RankingLastPlace;
+      rankingSystemService.getById.mockResolvedValue(null);
+
+      await expect(resolver.rankingSystem(place)).rejects.toThrow(NotFoundException);
+    });
   });
 
-  it("returns the resolved system on success", async () => {
-    const place = { systemId: "s1" } as unknown as RankingLastPlace;
-    const system = { id: "s1" } as unknown as RankingSystem;
-    rankingSystemService.getById.mockResolvedValue(system);
+  // ── player ResolveField ───────────────────────────────────────────────────
 
-    const result = await resolver.rankingSystem(place);
+  describe("player", () => {
+    it("calls playerLoader.load with rankingPlace.playerId", async () => {
+      const place = { playerId: "p1" } as unknown as RankingLastPlace;
+      const player = { id: "p1" } as unknown as Player;
+      playerLoader.load.mockResolvedValue(player);
 
-    expect(result).toBe(system);
-  });
+      const result = await resolver.player(place);
 
-  it("throws NotFoundException when getById returns null", async () => {
-    const place = { systemId: "missing" } as unknown as RankingLastPlace;
-    rankingSystemService.getById.mockResolvedValue(null);
+      expect(playerLoader.load).toHaveBeenCalledWith("p1");
+      expect(result).toBe(player);
+    });
 
-    await expect(resolver.rankingSystem(place)).rejects.toThrow(NotFoundException);
+    it("returns null when playerId is null", async () => {
+      const place = { playerId: null } as unknown as RankingLastPlace;
+      playerLoader.load.mockResolvedValue(null);
+
+      const result = await resolver.player(place);
+
+      expect(playerLoader.load).toHaveBeenCalledWith(null);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when playerId is undefined", async () => {
+      const place = { playerId: undefined } as unknown as RankingLastPlace;
+      playerLoader.load.mockResolvedValue(null);
+
+      const result = await resolver.player(place);
+
+      expect(playerLoader.load).toHaveBeenCalledWith(undefined);
+      expect(result).toBeNull();
+    });
+
+    it("batches N rows via a single playerLoader (DataLoader contract)", async () => {
+      // Simulate 10 ranking places — all resolved via a single batch call
+      const places = Array.from({ length: 10 }, (_, i) => ({
+        playerId: `p${i}`,
+      })) as unknown as RankingLastPlace[];
+
+      const players = places.map((p) => ({ id: p.playerId }) as unknown as Player);
+
+      // The loader.load spy must return the matching player for each call
+      playerLoader.load.mockImplementation((id: string) =>
+        Promise.resolve(players.find((pl) => pl.id === id) ?? null)
+      );
+
+      // Spy on Player.findAll to confirm it is NOT called by the resolver itself
+      const findAllSpy = jest.spyOn(Player, "findAll").mockResolvedValue([]);
+
+      const results = await Promise.all(places.map((place) => resolver.player(place)));
+
+      // Each place resolved to its player
+      expect(results).toHaveLength(10);
+      results.forEach((r, i) => expect(r?.id).toBe(`p${i}`));
+
+      // The resolver MUST delegate to the loader — not call Player.findAll directly
+      expect(findAllSpy).not.toHaveBeenCalled();
+
+      // The loader was called once per place (batching is internal to DataLoader)
+      expect(playerLoader.load).toHaveBeenCalledTimes(10);
+    });
   });
 });

--- a/libs/backend/graphql/src/resolvers/ranking/lastRankingPlace.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/ranking/lastRankingPlace.resolver.ts
@@ -12,6 +12,7 @@ import {
   ResolveField,
   Resolver,
 } from "@nestjs/graphql";
+import { PlayerLoaderService } from "../../loaders";
 import { ListArgs } from "../../utils";
 
 @ObjectType()
@@ -25,7 +26,10 @@ export class PagedLastRankingPlace {
 
 @Resolver(() => RankingLastPlace)
 export class LastRankingPlaceResolver {
-  constructor(private readonly rankingSystemService: RankingSystemService) {}
+  constructor(
+    private readonly rankingSystemService: RankingSystemService,
+    private readonly playerLoader: PlayerLoaderService
+  ) {}
 
   @Query(() => RankingLastPlace)
   async rankingLastPlace(@Args("id", { type: () => ID }) id: string): Promise<RankingLastPlace> {
@@ -51,9 +55,9 @@ export class LastRankingPlaceResolver {
     return system;
   }
 
-  @ResolveField(() => Player)
-  async player(@Parent() rankingPlace: RankingLastPlace): Promise<Player> {
-    return rankingPlace.getPlayer();
+  @ResolveField(() => Player, { nullable: true })
+  async player(@Parent() rankingPlace: RankingLastPlace): Promise<Player | null> {
+    return this.playerLoader.load(rankingPlace.playerId);
   }
 
   // @Mutation(returns => RankingLastPlace)

--- a/libs/backend/graphql/src/resolvers/ranking/ranking.module.ts
+++ b/libs/backend/graphql/src/resolvers/ranking/ranking.module.ts
@@ -1,6 +1,7 @@
 import { DatabaseModule } from "@badman/backend-database";
 import { RankingModule } from "@badman/backend-ranking";
 import { Module } from "@nestjs/common";
+import { PlayerLoaderService } from "../../loaders";
 import { LastRankingPlaceResolver } from "./lastRankingPlace.resolver";
 import { RankingPlaceResolver } from "./rankingPlace.resolver";
 import { RankingPointResolver } from "./rankingPoint.resolver";
@@ -15,6 +16,7 @@ import { RankingGroupsResolver } from "./rankingSystemGroup.resolver";
     RankingPointResolver,
     RankingPlaceResolver,
     LastRankingPlaceResolver,
+    PlayerLoaderService,
   ],
 })
 export class RankingResolverModule {}

--- a/libs/backend/graphql/src/resolvers/ranking/rankingPoint.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/ranking/rankingPoint.resolver.spec.ts
@@ -1,0 +1,93 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { Sequelize } from "sequelize-typescript";
+import { Player, RankingPoint } from "@badman/backend-database";
+import { PointsService, RankingSystemService } from "@badman/backend-ranking";
+import { PlayerLoaderService } from "../../loaders";
+import { RankingPointResolver } from "./rankingPoint.resolver";
+
+describe("RankingPointResolver — player ResolveField", () => {
+  let resolver: RankingPointResolver;
+  let playerLoaderService: { load: jest.Mock };
+  let rankingSystemService: { getById: jest.Mock };
+
+  beforeEach(async () => {
+    playerLoaderService = { load: jest.fn() };
+    rankingSystemService = { getById: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RankingPointResolver,
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn() },
+        },
+        {
+          provide: PointsService,
+          useValue: { createRankingPointforGame: jest.fn() },
+        },
+        {
+          provide: RankingSystemService,
+          useValue: rankingSystemService,
+        },
+        {
+          provide: PlayerLoaderService,
+          useValue: playerLoaderService,
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<RankingPointResolver>(RankingPointResolver);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("player ResolveField", () => {
+    it("delegates to playerLoader.load with the rankingPoint.playerId", async () => {
+      const player = { id: "p1" } as unknown as Player;
+      playerLoaderService.load.mockResolvedValue(player);
+      const rankingPoint = { playerId: "p1" } as unknown as RankingPoint;
+
+      const result = await resolver.player(rankingPoint);
+
+      expect(playerLoaderService.load).toHaveBeenCalledWith("p1");
+      expect(result).toBe(player);
+    });
+
+    it("returns null when playerId is null", async () => {
+      playerLoaderService.load.mockResolvedValue(null);
+      const rankingPoint = { playerId: null } as unknown as RankingPoint;
+
+      const result = await resolver.player(rankingPoint);
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when playerId is undefined", async () => {
+      playerLoaderService.load.mockResolvedValue(null);
+      const rankingPoint = { playerId: undefined } as unknown as RankingPoint;
+
+      const result = await resolver.player(rankingPoint);
+
+      expect(result).toBeNull();
+    });
+
+    it("batches N rows into a single Player.findAll call via the loader", async () => {
+      const players = Array.from({ length: 10 }, (_, i) => ({ id: `p${i}` } as unknown as Player));
+      const findAllSpy = jest.spyOn(Player, "findAll").mockResolvedValue(players as Player[]);
+
+      const realLoader = new PlayerLoaderService();
+      const rankingPoints = players.map(
+        (p) => ({ playerId: p.id } as unknown as RankingPoint)
+      );
+
+      const results = await Promise.all(
+        rankingPoints.map((rp) => realLoader.load(rp.playerId))
+      );
+
+      expect(findAllSpy).toHaveBeenCalledTimes(1);
+      expect(results).toHaveLength(10);
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/ranking/rankingPoint.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/ranking/rankingPoint.resolver.ts
@@ -5,6 +5,7 @@ import { ListArgs } from "../../utils";
 import { User } from "@badman/backend-authorization";
 import { Sequelize } from "sequelize-typescript";
 import { PointsService, RankingSystemService } from "@badman/backend-ranking";
+import { PlayerLoaderService } from "../../loaders";
 
 @Resolver(() => RankingPoint)
 export class RankingPointResolver {
@@ -13,7 +14,8 @@ export class RankingPointResolver {
   constructor(
     private _sequelize: Sequelize,
     private pointService: PointsService,
-    private readonly rankingSystemService: RankingSystemService
+    private readonly rankingSystemService: RankingSystemService,
+    private readonly playerLoader: PlayerLoaderService
   ) {}
 
   @Query(() => RankingPoint)
@@ -39,9 +41,9 @@ export class RankingPointResolver {
     return RankingPoint.findAll(ListArgs.toFindOptions(listArgs));
   }
 
-  @ResolveField(() => Player)
-  async player(@Parent() rankingPoint: RankingPoint): Promise<Player> {
-    return rankingPoint.getPlayer();
+  @ResolveField(() => Player, { nullable: true })
+  async player(@Parent() rankingPoint: RankingPoint): Promise<Player | null> {
+    return this.playerLoader.load(rankingPoint.playerId);
   }
 
   @ResolveField(() => RankingSystem)


### PR DESCRIPTION
## Summary

- **PlayerLoaderService**: shared request-scoped DataLoader batching `Player.findAll` by UUID (null-safe, per-request cache)
- **TeamLoaderService** + **DrawCompetitionLoaderService**: batch home/away/draw lookups on `EncounterCompetition`
- **EventCompetitionLoaderService** + **SubEventCompetitionLoaderService**: batch parent FK lookups on `SubEvent`, `DrawCompetition`, `EventEntry`
- All `getPlayer()` / `getX()` per-row ORM calls replaced with loader calls across: `RankingPointResolver`, `LastRankingPlaceResolver`, `CommentResolver`, `EncounterResolver`, `DrawResolver`, `SubeventResolver`, `EntryResolver`
- `grapqhl.module.ts`: registers `PlayerLoaderService` at top-level module
- Unit tests added for all migrated resolvers

## Test plan

- [ ] `nx test backend-graphql` — all tests pass
- [ ] `nx build backend-graphql` — zero TS errors
- [ ] Query a large ranking points list and confirm single Player bulk query in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)