### PR TITLE
fix(graphql): correct M:N include + dedupe enrollment validation

### DIFF
--- a/libs/backend/graphql/src/resolvers/event/enrollment-validation-cache.service.ts
+++ b/libs/backend/graphql/src/resolvers/event/enrollment-validation-cache.service.ts
@@ -1,0 +1,77 @@
+import { EventEntry, Player, Team } from "@badman/backend-database";
+import { EnrollmentValidationService, TeamEnrollmentOutput } from "@badman/backend-enrollment";
+import { TeamMembershipType } from "@badman/utils";
+import { Injectable, Scope } from "@nestjs/common";
+import DataLoader from "dataloader";
+
+type ValidationMap = Map<string, TeamEnrollmentOutput>;
+type CacheKey = string; // `${clubId}:${season}`
+
+/**
+ * Request-scoped DataLoader for enrollment validation.
+ *
+ * The `EventEntry.enrollmentValidation` field resolver runs a club-wide
+ * validation that returns results for every team in the club. Without
+ * batching, a query returning N teams in the same club triggers N full
+ * validations. DataLoader collapses all calls sharing the same
+ * (clubId, season) key into a single computation per request.
+ */
+@Injectable({ scope: Scope.REQUEST })
+export class EnrollmentValidationCacheService {
+  private readonly loader = new DataLoader<CacheKey, ValidationMap>((keys) =>
+    this.batchValidate(keys)
+  );
+
+  constructor(private readonly enrollmentService: EnrollmentValidationService) {}
+
+  async getForTeam(team: Team): Promise<TeamEnrollmentOutput | null> {
+    if (!team.clubId || team.season == null || !team.id) return null;
+    const key: CacheKey = `${team.clubId}:${team.season}`;
+    const byTeamId = await this.loader.load(key);
+    return byTeamId.get(team.id) ?? null;
+  }
+
+  private async batchValidate(keys: readonly CacheKey[]): Promise<ValidationMap[]> {
+    return Promise.all(keys.map((key) => this.computeValidation(key)));
+  }
+
+  private async computeValidation(key: CacheKey): Promise<ValidationMap> {
+    const [clubId, seasonStr] = key.split(":");
+    const season = Number(seasonStr);
+
+    const teamsOfClub = await Team.findAll({
+      where: { clubId, season },
+      include: [{ model: Player, as: "players" }, { model: EventEntry }],
+    });
+
+    const validation = await this.enrollmentService.fetchAndValidate(
+      {
+        teams: teamsOfClub.map((t) => ({
+          id: t.id,
+          name: t.name,
+          type: t.type,
+          link: t.link,
+          teamNumber: t.teamNumber,
+          basePlayers: t.entry?.meta?.competition?.players,
+          players: t.players
+            ?.filter((p) => p.TeamPlayerMembership.membershipType === TeamMembershipType.REGULAR)
+            .map((p) => p.id),
+          backupPlayers: t.players
+            ?.filter((p) => p.TeamPlayerMembership.membershipType === TeamMembershipType.BACKUP)
+            .map((p) => p.id),
+          subEventId: t.entry?.subEventId,
+          clubId: t.clubId,
+        })),
+        clubId,
+        season,
+      },
+      EnrollmentValidationService.defaultValidators()
+    );
+
+    const map: ValidationMap = new Map();
+    for (const t of validation.teams ?? []) {
+      if (t.id) map.set(t.id, t);
+    }
+    return map;
+  }
+}

--- a/libs/backend/graphql/src/resolvers/event/entry.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/entry.resolver.ts
@@ -12,14 +12,14 @@ import {
   SubEventTournament,
   Team,
 } from "@badman/backend-database";
-import { EnrollmentValidationService, TeamEnrollmentOutput } from "@badman/backend-enrollment";
+import { TeamEnrollmentOutput } from "@badman/backend-enrollment";
 import { NotificationService } from "@badman/backend-notifications";
-import { TeamMembershipType } from "@badman/utils";
 import { Logger, NotFoundException, UnauthorizedException } from "@nestjs/common";
 import { Args, ID, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { Sequelize } from "sequelize-typescript";
 import { ListArgs } from "../../utils";
 import { EnrollmentFinalizeService } from "./enrollment-finalize.service";
+import { EnrollmentValidationCacheService } from "./enrollment-validation-cache.service";
 import { FinishEventEntryResult } from "./finish-event-entry-result.object";
 
 @Resolver(() => EventEntry)
@@ -28,7 +28,7 @@ export class EventEntryResolver {
 
   constructor(
     private notificationService: NotificationService,
-    private enrollmentService: EnrollmentValidationService,
+    private enrollmentValidationCache: EnrollmentValidationCacheService,
     private enrollmentFinalizeService: EnrollmentFinalizeService,
     private _sequelize: Sequelize
   ) {}
@@ -89,39 +89,7 @@ export class EventEntryResolver {
     @Parent() eventEntry: EventEntry
   ): Promise<TeamEnrollmentOutput | null> {
     const team = await eventEntry.getTeam();
-    const teamsOfClub = await Team.findAll({
-      where: {
-        clubId: team.clubId,
-        season: team.season,
-      },
-      include: [{ model: Player, as: "players" }, { model: EventEntry }],
-    });
-
-    const validation = await this.enrollmentService.fetchAndValidate(
-      {
-        teams: teamsOfClub.map((t) => ({
-          id: t.id,
-          name: t.name,
-          type: t.type,
-          link: t.link,
-          teamNumber: t.teamNumber,
-          basePlayers: t.entry?.meta?.competition?.players,
-          players: t.players
-            ?.filter((p) => p.TeamPlayerMembership.membershipType === TeamMembershipType.REGULAR)
-            .map((p) => p.id),
-          backupPlayers: t.players
-            ?.filter((p) => p.TeamPlayerMembership.membershipType === TeamMembershipType.BACKUP)
-            .map((p) => p.id),
-          subEventId: t.entry?.subEventId,
-          clubId: t.clubId,
-        })),
-        clubId: team.clubId,
-        season: team.season,
-      },
-      EnrollmentValidationService.defaultValidators()
-    );
-
-    return validation.teams?.find((t) => t.id === team.id) ?? null;
+    return this.enrollmentValidationCache.getForTeam(team);
   }
 
   @Mutation(() => FinishEventEntryResult)

--- a/libs/backend/graphql/src/resolvers/event/event.module.ts
+++ b/libs/backend/graphql/src/resolvers/event/event.module.ts
@@ -2,6 +2,7 @@ import { Module } from "@nestjs/common";
 import { CompetitionResolverModule } from "./competition.module";
 import { EventEntryResolver, EntryCompetitionPlayersResolver } from "./entry.resolver";
 import { EnrollmentFinalizeService } from "./enrollment-finalize.service";
+import { EnrollmentValidationCacheService } from "./enrollment-validation-cache.service";
 import { TournamentResolverModule } from "./tournament.module";
 import { NotificationsModule } from "@badman/backend-notifications";
 import { EnrollmentModule } from "@badman/backend-enrollment";
@@ -13,7 +14,12 @@ import { EnrollmentModule } from "@badman/backend-enrollment";
     NotificationsModule,
     EnrollmentModule,
   ],
-  providers: [EventEntryResolver, EntryCompetitionPlayersResolver, EnrollmentFinalizeService],
+  providers: [
+    EventEntryResolver,
+    EntryCompetitionPlayersResolver,
+    EnrollmentFinalizeService,
+    EnrollmentValidationCacheService,
+  ],
   exports: [EnrollmentFinalizeService],
 })
 export class EventResolverModule {}

--- a/libs/backend/graphql/src/resolvers/team/team-association.service.ts
+++ b/libs/backend/graphql/src/resolvers/team/team-association.service.ts
@@ -4,7 +4,6 @@ import {
   Location,
   Player,
   Team,
-  TeamPlayerMembership,
 } from "@badman/backend-database";
 import { Injectable, Scope } from "@nestjs/common";
 import DataLoader from "dataloader";
@@ -103,26 +102,20 @@ export class TeamAssociationService {
   }
 
   private async batchPlayersByTeamIds(teamIds: readonly string[]): Promise<Player[][]> {
-    // Fetch through TeamPlayerMembership so we can group rows back by teamId.
-    // One query keeps this O(1) DB round trip regardless of team count.
-    const memberships = await TeamPlayerMembership.findAll({
-      where: { teamId: { [Op.in]: [...teamIds] } },
-      include: [{ model: Player, required: true }],
+    // Load via the registered Team↔Player M:N association so Sequelize
+    // auto-attaches the through row as `player.TeamPlayerMembership`,
+    // matching the legacy `team.getPlayers()` shape consumed downstream
+    // (e.g. PlayerTeamResolver.teamMembership).
+    const teams = await Team.findAll({
+      where: { id: { [Op.in]: [...teamIds] } },
+      attributes: ["id"],
+      include: [{ model: Player, as: "players" }],
     });
 
     const grouped = new Map<string, Player[]>();
-    for (const m of memberships as Array<TeamPlayerMembership & { Player?: Player }>) {
-      if (!m.teamId || !m.Player) continue;
-      const player = m.Player;
-      // Attach the membership in the shape `team.getPlayers()` would produce
-      // so downstream consumers reading `player.TeamPlayerMembership` keep
-      // working (e.g. PlayerTeamResolver.teamMembership).
-      (player as Player & { TeamPlayerMembership: TeamPlayerMembership }).TeamPlayerMembership = m;
-      const bucket = grouped.get(m.teamId) ?? [];
-      bucket.push(player);
-      grouped.set(m.teamId, bucket);
+    for (const t of teams as Array<Team & { players?: Player[] }>) {
+      grouped.set(t.id, t.players ?? []);
     }
-
     return teamIds.map((teamId) => grouped.get(teamId) ?? []);
   }
 }


### PR DESCRIPTION
## Summary
- Fix `SequelizeEagerLoadingError: Player is not associated to TeamPlayerMembership!` raised by the `Team.players` field resolver. Junction model has no `@BelongsTo(Player)`; switched the DataLoader to `Team.findAll({ include: [{ model: Player, as: "players" }] })`, the canonical Sequelize M:N path. Through row still hydrates as `player.TeamPlayerMembership`.
- Fix N quadratic enrollment-validation cost on `GetClubTeams`. `EventEntry.enrollmentValidation` field resolver was running a full club-wide validation per team (each loading all club teams + executing the rule engine). Moved behind a request-scoped DataLoader keyed by `(clubId, season)` so all teams in the request share one computation.

Cherry-picked from develop (`e1851b1ee`).

## Test plan
- [ ] `nx test backend-graphql` passes
- [ ] Run the API and re-issue `GetClubTeams` (variables `{ season: 2025, clubId: "4cda4ae6-a647-46ec-a78b-3fc2135028f5" }`); response should have no `errors` array, `teams[i].players` populated, and `entry.enrollmentValidation` resolved
- [ ] Verify validation runs once per club+season per request (log/observe DB query count drops from N validations to 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)