### PR TITLE
fix(visual): allow Player rows without MemberID

### DIFF
--- a/libs/backend/visual/src/utils/__tests__/visual-result.spec.ts
+++ b/libs/backend/visual/src/utils/__tests__/visual-result.spec.ts
@@ -1,6 +1,7 @@
 import {
   XmlItemSchema,
   XmlMatchSchema,
+  XmlPlayerSchema,
   XmlRankingCategorySchema,
   XmlRankingPublicationSchema,
   XmlRankingSchema,
@@ -230,6 +231,25 @@ describe("requiredCoercedString invariant", () => {
       expect(result.data.TournamentID).toBe("1");
       expect(result.data.MatchID).toBe("99");
     }
+  });
+
+  // Visual API /Tournament/:id/Player can include roster rows without a
+  // MemberID (anonymous / placeholder entries, Sentry #104397491). Schema
+  // must accept them so the whole sync batch isn't rejected.
+  it("XmlPlayerSchema: accepts a Player row without MemberID", () => {
+    const result = XmlPlayerSchema.safeParse({
+      Firstname: "Jane",
+      Lastname: "Doe",
+      GenderID: 1,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.MemberID).toBeUndefined();
+  });
+
+  it("XmlPlayerSchema: still coerces a numeric MemberID to string", () => {
+    const result = XmlPlayerSchema.safeParse({ MemberID: 12345, Firstname: "Jane" });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.MemberID).toBe("12345");
   });
 
   // Visual API sometimes returns TournamentTimezone as a number (Sentry #104397491).

--- a/libs/backend/visual/src/utils/visual-result.ts
+++ b/libs/backend/visual/src/utils/visual-result.ts
@@ -198,7 +198,11 @@ export type XmlSets = z.infer<typeof XmlSetsSchema>;
 
 export const XmlPlayerSchema = z
   .object({
-    MemberID: requiredCoercedString,
+    // Tournament /Player endpoint occasionally returns roster rows without a
+    // MemberID (anonymous / placeholder entries). Downstream sync code falls
+    // back to first/last-name matching when memberId is absent, so accept the
+    // row instead of rejecting the entire batch.
+    MemberID: requiredCoercedString.optional(),
     Firstname: z.string().optional(),
     Lastname: z.string().optional(),
     GenderID: z.coerce.number().optional(),


### PR DESCRIPTION
Visual /Tournament/:id/Player can return roster rows without a MemberID (anonymous / placeholder entries). Strict schema rejected the entire batch, crashing SyncEvents. Sync callers already fall back to first/last-name matching when memberId is absent.

Refs Sentry #104397491