### PR TITLE
test(graphql): align resolver specs with post-merge constructors

### DIFF
--- a/libs/backend/graphql/src/resolvers/event/competition/enrollment.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/enrollment.resolver.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { GraphQLError } from "graphql";
 import { Sequelize } from "sequelize-typescript";
 import { EventEntry, Player, SubEventCompetition, Team } from "@badman/backend-database";
-import { EnrollmentValidationService } from "@badman/backend-enrollment";
+import { EnrollmentValidationService, IndexCalculationService } from "@badman/backend-enrollment";
 import { EnrollmentEntryService } from "./enrollment-entry.service";
 import { EnrollmentResolver } from "./enrollment.resolver";
 
@@ -71,6 +71,10 @@ describe("EnrollmentResolver.createEnrollment", () => {
         {
           provide: EnrollmentValidationService,
           useValue: { fetchAndValidate: jest.fn() },
+        },
+        {
+          provide: IndexCalculationService,
+          useValue: { computeBaseIndexForPlayers: jest.fn() },
         },
       ],
     }).compile();

--- a/libs/backend/graphql/src/resolvers/event/entry.resolver.dataloader.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/entry.resolver.dataloader.spec.ts
@@ -6,6 +6,7 @@ import { SubEventCompetitionLoaderService } from "../../loaders";
 import { EnrollmentValidationService } from "@badman/backend-enrollment";
 import { NotificationService } from "@badman/backend-notifications";
 import { EnrollmentFinalizeService } from "./enrollment-finalize.service";
+import { EnrollmentValidationCacheService } from "./enrollment-validation-cache.service";
 
 describe("EventEntryResolver — DataLoader field resolvers", () => {
   let resolver: EventEntryResolver;
@@ -34,6 +35,10 @@ describe("EventEntryResolver — DataLoader field resolvers", () => {
         {
           provide: EnrollmentValidationService,
           useValue: { fetchAndValidate: jest.fn() },
+        },
+        {
+          provide: EnrollmentValidationCacheService,
+          useValue: { getForTeam: jest.fn() },
         },
         {
           provide: SubEventCompetitionLoaderService,

--- a/libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts
@@ -7,6 +7,7 @@ import { EnrollmentValidationService } from "@badman/backend-enrollment";
 import { NotificationService } from "@badman/backend-notifications";
 import { EventEntryResolver } from "./entry.resolver";
 import { EnrollmentFinalizeService } from "./enrollment-finalize.service";
+import { EnrollmentValidationCacheService } from "./enrollment-validation-cache.service";
 import { SubEventCompetitionLoaderService } from "../../loaders";
 import { ErrorCode } from "../../utils/error-codes";
 
@@ -87,6 +88,10 @@ describe("EventEntryResolver.finishEventEntry", () => {
         {
           provide: EnrollmentValidationService,
           useValue: mockEnrollmentService,
+        },
+        {
+          provide: EnrollmentValidationCacheService,
+          useValue: { getForTeam: jest.fn() },
         },
         {
           provide: SubEventCompetitionLoaderService,

--- a/libs/backend/graphql/src/resolvers/team/team-association.service.spec.ts
+++ b/libs/backend/graphql/src/resolvers/team/team-association.service.spec.ts
@@ -4,7 +4,6 @@ import {
   Location,
   Player,
   Team,
-  TeamPlayerMembership,
 } from "@badman/backend-database";
 import { TeamAssociationService } from "./team-association.service";
 
@@ -110,25 +109,18 @@ describe("TeamAssociationService — request-scoped batching", () => {
     expect(entry2?.id).toBe("e2-fallback");
   });
 
-  it("getPlayers: batches via TeamPlayerMembership join and groups by teamId", async () => {
-    // Build mocks without back-references — the service mutates the player
-    // object to attach the membership, and a jest worker would choke on a
-    // circular `player <-> membership` graph during result serialization.
-    const m1: Partial<TeamPlayerMembership> & { Player: Partial<Player> } = {
-      teamId: "t1",
-      Player: { id: "p1" },
-    };
-    const m2: Partial<TeamPlayerMembership> & { Player: Partial<Player> } = {
-      teamId: "t1",
-      Player: { id: "p2" },
-    };
-    const m3: Partial<TeamPlayerMembership> & { Player: Partial<Player> } = {
-      teamId: "t2",
-      Player: { id: "p3" },
-    };
+  it("getPlayers: batches via Team↔Player M:N include and groups by teamId", async () => {
+    const t1Stub = {
+      id: "t1",
+      players: [{ id: "p1" } as Player, { id: "p2" } as Player],
+    } as unknown as Team;
+    const t2Stub = {
+      id: "t2",
+      players: [{ id: "p3" } as Player],
+    } as unknown as Team;
     const findAll = jest
-      .spyOn(TeamPlayerMembership, "findAll")
-      .mockResolvedValue([m1, m2, m3] as unknown as TeamPlayerMembership[]);
+      .spyOn(Team, "findAll")
+      .mockResolvedValue([t1Stub, t2Stub] as unknown as Team[]);
 
     const [t1Players, t2Players] = await Promise.all([
       service.getPlayers({ id: "t1" } as Team),
@@ -138,9 +130,5 @@ describe("TeamAssociationService — request-scoped batching", () => {
     expect(findAll).toHaveBeenCalledTimes(1);
     expect(t1Players.map((p) => p.id)).toEqual(["p1", "p2"]);
     expect(t2Players.map((p) => p.id)).toEqual(["p3"]);
-    // Membership attached so player.TeamPlayerMembership keeps working
-    expect(
-      (t1Players[0] as Player & { TeamPlayerMembership: TeamPlayerMembership }).TeamPlayerMembership
-    ).toBe(m1);
   });
 });


### PR DESCRIPTION
Update test providers and mocks to match merged service signatures:
- EventEntryResolver: provide EnrollmentValidationCacheService alongside SubEventCompetitionLoaderService.
- EnrollmentResolver: provide IndexCalculationService (new EnrollmentEntryService dep).
- TeamAssociationService: rewrite getPlayers spec to mock Team.findAll with players include (replaces TeamPlayerMembership.findAll path).