### PR TITLE
perf(auth): cache player permissions per instance

### DIFF
--- a/libs/backend/database/src/models/player.model.spec.ts
+++ b/libs/backend/database/src/models/player.model.spec.ts
@@ -1,0 +1,78 @@
+import "reflect-metadata";
+import { Player } from "@badman/backend-database";
+
+type MutablePlayer = Player & {
+  getClaims: jest.Mock;
+  getRoles: jest.Mock;
+};
+
+const makePlayer = (
+  claimsImpl: () => unknown,
+  rolesImpl: () => unknown = () => []
+): MutablePlayer => {
+  const player = Object.create(Player.prototype) as MutablePlayer;
+  player.getClaims = jest.fn(claimsImpl as () => never);
+  player.getRoles = jest.fn(rolesImpl as () => never);
+  return player;
+};
+
+describe("Player.getPermissions — memoization", () => {
+  it("loads claims and roles once across multiple getPermissions calls", async () => {
+    const player = makePlayer(() => Promise.resolve([{ name: "edit:any" }]));
+
+    const a = await player.getPermissions();
+    const b = await player.getPermissions();
+    const c = await player.getPermissions();
+
+    expect(a).toEqual(["edit:any"]);
+    expect(b).toBe(a);
+    expect(c).toBe(a);
+    expect(player.getClaims).toHaveBeenCalledTimes(1);
+    expect(player.getRoles).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces concurrent calls into a single load", async () => {
+    const player = makePlayer(() => Promise.resolve([{ name: "a" }]));
+
+    const [a, b, c] = await Promise.all([
+      player.getPermissions(),
+      player.getPermissions(),
+      player.getPermissions(),
+    ]);
+
+    expect(a).toEqual(["a"]);
+    expect(b).toEqual(["a"]);
+    expect(c).toEqual(["a"]);
+    expect(player.getClaims).toHaveBeenCalledTimes(1);
+    expect(player.getRoles).toHaveBeenCalledTimes(1);
+  });
+
+  it("hasAnyPermission reuses the cached permission set", async () => {
+    const player = makePlayer(() => Promise.resolve([{ name: "edit:player" }]));
+
+    const r1 = await player.hasAnyPermission(["edit:player"]);
+    const r2 = await player.hasAnyPermission(["edit:player"]);
+    const r3 = await player.hasAnyPermission(["nope"]);
+
+    expect(r1).toBe(true);
+    expect(r2).toBe(true);
+    expect(r3).toBe(false);
+    expect(player.getClaims).toHaveBeenCalledTimes(1);
+    expect(player.getRoles).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears cache on failure so next call retries", async () => {
+    const player = Object.create(Player.prototype) as MutablePlayer;
+    player.getClaims = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("db down"))
+      .mockResolvedValueOnce([{ name: "ok" }]);
+    player.getRoles = jest.fn().mockResolvedValue([]);
+
+    await expect(player.getPermissions()).rejects.toThrow("db down");
+    const result = await player.getPermissions();
+
+    expect(result).toEqual(["ok"]);
+    expect(player.getClaims).toHaveBeenCalledTimes(2);
+  });
+});

--- a/libs/backend/database/src/models/player.model.ts
+++ b/libs/backend/database/src/models/player.model.ts
@@ -331,17 +331,32 @@ export class Player extends Model<InferAttributes<Player>, InferCreationAttribut
     }
   }
 
-  async getPermissions(): Promise<string[]> {
-    let claims = (await this.getClaims()).map((r) => r.name);
-    const roles = await this.getRoles({
-      include: [Claim],
-    });
-    claims = [
-      ...claims,
-      ...roles.map((r) => r?.claims?.map((c) => `${r.linkId}_${c.name}`)).flat(),
-    ].filter((x) => x !== null && x !== undefined);
+  private _cachedPermissions?: Promise<string[]>;
 
-    return claims as string[];
+  async getPermissions(): Promise<string[]> {
+    if (this._cachedPermissions) {
+      return this._cachedPermissions;
+    }
+
+    this._cachedPermissions = (async () => {
+      let claims = (await this.getClaims()).map((r) => r.name);
+      const roles = await this.getRoles({
+        include: [Claim],
+      });
+      claims = [
+        ...claims,
+        ...roles.map((r) => r?.claims?.map((c) => `${r.linkId}_${c.name}`)).flat(),
+      ].filter((x) => x !== null && x !== undefined);
+
+      return claims as string[];
+    })();
+
+    try {
+      return await this._cachedPermissions;
+    } catch (err) {
+      this._cachedPermissions = undefined;
+      throw err;
+    }
   }
 
   // Gets the current ranking for a player, in a given system.


### PR DESCRIPTION
## Summary
- Memoize `Player.getPermissions()` on the instance so repeated `hasAnyPermission` calls in one request don't reissue Claim+Role queries.
- Fixes N+1 reported by Sentry **121331561** on `query GetClubTeams`: `Team.phone` and `Team.email` field resolvers each called `hasAnyPermission`, triggering ~4 identical lookups per team for the same `playerId`.
- In-flight promise is cached so concurrent callers share one DB hit; cache clears on rejection so failures don't poison the request.

## Test plan
- [x] `nx test backend-database` — 4 new specs in `player.model.spec.ts` pass
- [ ] Deploy and confirm Sentry issue 121331561 stops firing
- [ ] Manual: run `GetClubTeams` against a club with several teams and verify only one Claim+Role query per request in Sequelize logs

Refs sentry 121331561