### PR TITLE
hotfix(i18n): add enrollment submit server/validation error copy

### DIFF
--- a/libs/backend/translate/assets/i18n/en/all.json
+++ b/libs/backend/translate/assets/i18n/en/all.json
@@ -1684,6 +1684,14 @@
           "network": {
             "title": "Network error",
             "body": "We couldn't reach the server. Check your connection and try again."
+          },
+          "server": {
+            "title": "Submission failed",
+            "body": "The server couldn't process your enrollment. Your draft has been preserved — press Enroll again to retry."
+          },
+          "validation": {
+            "title": "Fix the highlighted issues",
+            "body": "Some teams or fields still have errors. Resolve them and try again."
           }
         }
       },

--- a/libs/backend/translate/assets/i18n/fr_BE/all.json
+++ b/libs/backend/translate/assets/i18n/fr_BE/all.json
@@ -2004,6 +2004,14 @@
           "network": {
             "title": "Erreur réseau",
             "body": "Impossible de joindre le serveur. Vérifiez votre connexion et réessayez."
+          },
+          "server": {
+            "title": "Échec de l'envoi",
+            "body": "Le serveur n'a pas pu traiter votre inscription. Votre brouillon a été conservé — cliquez à nouveau sur S'inscrire pour réessayer."
+          },
+          "validation": {
+            "title": "Corrigez les problèmes signalés",
+            "body": "Certaines équipes ou certains champs contiennent encore des erreurs. Corrigez-les et réessayez."
           }
         }
       },

--- a/libs/backend/translate/assets/i18n/nl_BE/all.json
+++ b/libs/backend/translate/assets/i18n/nl_BE/all.json
@@ -1402,6 +1402,14 @@
           "network": {
             "title": "Netwerkfout",
             "body": "We konden de server niet bereiken. Controleer je verbinding en probeer opnieuw."
+          },
+          "server": {
+            "title": "Indienen mislukt",
+            "body": "De server kon je inschrijving niet verwerken. Je concept is bewaard — klik opnieuw op Inschrijven om het opnieuw te proberen."
+          },
+          "validation": {
+            "title": "Los de gemarkeerde problemen op",
+            "body": "Sommige ploegen of velden bevatten nog fouten. Los ze op en probeer opnieuw."
           }
         }
       },


### PR DESCRIPTION
## Summary
- Adds `enrollment.submit.error.server.{title,body}` and `enrollment.submit.error.validation.{title,body}` in en, nl_BE, fr_BE
- Sits next to the existing `enrollment.submit.error.network` sibling under `all.v1.enrollment.submit.error`
- Unblocks the frontend banner in `EnrollmentSubmissionSummary.tsx`, which currently falls back to `submit.finalisationFailed` for the `server` and `validation` kinds

Banner severity mapping on the frontend: `server` → error, `validation` → warning, `network` → already in place.

Hotfix targeting `main` so the new frontend copy can ship without waiting on the `develop` train. Companion PR against develop: #954.

Frontend counterpart: https://github.com/PandaPandaBE/badman-frontend/pull/474

Translations added via the `translation-manager` agent. `i18n.generated.ts` will be regenerated by nestjs-i18n on the next API boot.

## Test plan
- [ ] Run `nx run api:serve` once so nestjs-i18n regenerates `libs/utils/src/lib/i18n.generated.ts`
- [ ] Trigger a server error during enrollment submit → banner shows "Submission failed" / "Indienen mislukt" / "Échec de l'envoi"
- [ ] Trigger a validation error during enrollment submit → banner shows "Fix the highlighted issues" / "Los de gemarkeerde problemen op" / "Corrigez les problèmes signalés"
- [ ] Confirm `submit.finalisationFailed` fallback no longer appears for these two kinds

🤖 Generated with [Claude Code](https://claude.com/claude-code)