### PR TITLE
hotfix(028): gate EventEntry.enrollmentValidation behind opt-in arg

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/027-fix-search-player-n1"
+  "feature_directory": "specs/028-gate-enrollment-validation"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,6 @@ Long-form internal docs live under [`docs/`](docs/). Skim the relevant ones befo
 
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-[specs/027-fix-search-player-n1/plan.md](specs/027-fix-search-player-n1/plan.md)
+[specs/028-gate-enrollment-validation/plan.md](specs/028-gate-enrollment-validation/plan.md)
 
 <!-- SPECKIT END -->

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -2,6 +2,7 @@
 
 <!--
 Versions (newest first):
+- v1.3 — 2026-05-21 — Add "Enrollment validation: cross-request caching deferred" from feat-028.
 - v1.2 — 2026-04-30 — Add three team-resolver entries from
   002-team-resolver-improvements: no DB uniqueness on `Teams(link, season)`
   (narrow concurrent-write window), pre-existing `teamNumber`
@@ -36,6 +37,7 @@ Versions (newest first):
 | [Team: `teamNumber` auto-increment race on `createTeam`](#team-teamnumber-auto-increment-race-on-createteam)                     | Backend  | `libs/backend/graphql/src/resolvers/team/team.resolver.ts`                                                                             | ~half day                        | First observed duplicate-`teamNumber` collision in prod (likely surfaces as user-visible duplicate team name)                | open   |
 | [Team: FE migration of `createTeam` callers (BAD-128)](#team-fe-migration-of-createteam-callers-bad-128)                         | Frontend | active frontend repo (separate); pointer only here                                                                                     | tracked in Linear                | BAD-128 closes                                                                                                               | open   |
 | [Legacy Angular frontend](#legacy-angular-frontend)                                                                              | Frontend | `apps/badman/`, `libs/frontend/`                                                                                                       | 1–2 days                         | New frontend repo solo in prod for one release cycle                                                                         | open   |
+| [Enrollment validation: cross-request caching deferred](#enrollment-validation-cross-request-caching-deferred)                   | Backend  | `libs/backend/competition/enrollment/src/services/cache/enrollment-validation-cache.service.ts`                                        | ~1–2 days                        | First complaint that repeated `enrollmentValidation(validate: true)` calls are slow across separate GraphQL requests         | open   |
 
 ---
 
@@ -107,6 +109,14 @@ Versions (newest first):
 - **What**: When the caller omits `data.teamNumber`, the resolver computes `MAX(teamNumber) + 1` for `(clubId, type, season)` outside any locking. Two concurrent creates with the same club/type/season can both compute the same next number, and the `Teams` table has no DB-level uniqueness on `(clubId, type, season, teamNumber)` (dropped in 2023-05). The result is two teams with identical `teamNumber` (and thus identical user-visible names like "TC 1MX").
 - **Why we shipped it**: pre-existing behavior; spec clarification Q4 explicitly scoped this race out of `002-team-resolver-improvements`. Observed user pattern (one admin creates teams sequentially per club) does not produce the race; introducing a fix would broaden the scope of a contract fix.
 - **Fix**: either (a) add `CREATE UNIQUE INDEX teams_clubid_type_season_number_unique ON public."Teams" (clubId, type, season, teamNumber)` and translate `SequelizeUniqueConstraintError` into a new classified `TEAM_NUMBER_CONFLICT` code (extends the closed v1 list); or (b) wrap the `MAX+1` lookup in a `LOCK.UPDATE` row-lock against the same partition; or (c) accept it and document the operator workaround (renumber via `updateTeam` if a collision is reported). Decide with product if/when this surfaces. Update the FE error map and the resolver spec accordingly.
+- **Status**: open. **Owner**: unowned.
+
+### Enrollment validation: cross-request caching deferred
+
+- **Where**: `libs/backend/competition/enrollment/src/services/cache/enrollment-validation-cache.service.ts`. Reference: `specs/028-gate-enrollment-validation/`.
+- **What**: `EnrollmentValidationCacheService` collapses duplicate `(clubId, season)` lookups _within a single GraphQL request_ (DataLoader-style) but has no cross-request cache. A second `enrollmentValidation(validate: true)` call in a separate request recomputes the full club-wide validation from scratch.
+- **Why we shipped it**: the primary goal of feat-028 was to eliminate unwanted computation entirely (default `null`). Cross-request caching is out of scope per spec (research R-003); it requires cache-invalidation semantics (enrollment changes, player-roster edits, team-delete) that carry meaningful coordination risk.
+- **Fix**: introduce a TTL-backed Redis cache keyed on `(clubId, season, systemId)`; invalidate on `createEnrollment`, `updateTeam`, and player-roster mutations. Assess cache-stampede risk under concurrent enrollment wizard sessions.
 - **Status**: open. **Owner**: unowned.
 
 ## Frontend

--- a/libs/backend/competition/enrollment/src/services/index-calculation/index-calculation.service.spec.ts
+++ b/libs/backend/competition/enrollment/src/services/index-calculation/index-calculation.service.spec.ts
@@ -88,10 +88,9 @@ describe("IndexCalculationService", () => {
 
     it("returns RANKING_SYSTEM_NOT_FOUND for every input when neither primary nor explicit system resolves", async () => {
       jest.spyOn(RankingSystem, "findOne").mockResolvedValue(null);
-      jest.spyOn(Player, "findAll").mockResolvedValue([
-        stubPlayer("player-k1"),
-        stubPlayer("player-k2"),
-      ]);
+      jest
+        .spyOn(Player, "findAll")
+        .mockResolvedValue([stubPlayer("player-k1"), stubPlayer("player-k2")]);
 
       const results = await service.calculate([minimalInput("k1"), minimalInput("k2")]);
 
@@ -106,20 +105,21 @@ describe("IndexCalculationService", () => {
 
     it("surfaces INTERNAL_ERROR for an input that throws unexpectedly during processing", async () => {
       jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(Player, "findAll").mockResolvedValue([
-        stubPlayer("player-ok"),
-        stubPlayer("player-boom"),
-      ]);
+      jest
+        .spyOn(Player, "findAll")
+        .mockResolvedValue([stubPlayer("player-ok"), stubPlayer("player-boom")]);
       jest.spyOn(RankingPlace, "findAll").mockResolvedValue([]);
 
-      const origCompute = (service as unknown as { computeResult: (...a: unknown[]) => unknown }).computeResult.bind(service);
-      jest.spyOn(service as unknown as { computeResult: jest.Mock }, "computeResult").mockImplementation(
-        (...args: unknown[]) => {
+      const origCompute = (
+        service as unknown as { computeResult: (...a: unknown[]) => unknown }
+      ).computeResult.bind(service);
+      jest
+        .spyOn(service as unknown as { computeResult: jest.Mock }, "computeResult")
+        .mockImplementation((...args: unknown[]) => {
           const input = args[0] as IndexCalculationInput;
           if (input.key === "boom") throw new Error("Simulated crash");
           return origCompute(...args);
-        }
-      );
+        });
 
       const results = await service.calculate([minimalInput("ok"), minimalInput("boom")]);
 
@@ -139,9 +139,7 @@ describe("IndexCalculationService", () => {
     it("returns the single result from calculate", async () => {
       jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
       jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("player-k1")]);
-      jest.spyOn(RankingPlace, "findAll").mockResolvedValue([
-        stubPlace("player-k1", 8, 8, 12),
-      ]);
+      jest.spyOn(RankingPlace, "findAll").mockResolvedValue([stubPlace("player-k1", 8, 8, 12)]);
 
       const result = await service.calculateOne({
         key: "k1",
@@ -203,9 +201,7 @@ describe("IndexCalculationService", () => {
     it("defaults all components to amountOfLevels+2 when no RankingPlace row exists", async () => {
       const playerId = "player-norate-0000-0000-0000-000000000000";
 
-      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(
-        stubSystem({ amountOfLevels: 10 })
-      );
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem({ amountOfLevels: 10 }));
       jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer(playerId)]);
       jest.spyOn(RankingPlace, "findAll").mockResolvedValue([]);
 
@@ -257,17 +253,15 @@ describe("IndexCalculationService", () => {
   describe("type / season derivation from sub-event", () => {
     it("derives type and season from SubEventCompetition when caller omits them", async () => {
       jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(SubEventCompetition, "findAll").mockResolvedValue([
-        stubSubEvent(SubEventTypeEnum.MX, { season: 2024 }),
-      ]);
-      jest.spyOn(Player, "findAll").mockResolvedValue([
-        stubPlayer("p1", "M"),
-        stubPlayer("p2", "F"),
-      ]);
-      const placeSpy = jest.spyOn(RankingPlace, "findAll").mockResolvedValue([
-        stubPlace("p1", 6, 6, 6),
-        stubPlace("p2", 6, 6, 6),
-      ]);
+      jest
+        .spyOn(SubEventCompetition, "findAll")
+        .mockResolvedValue([stubSubEvent(SubEventTypeEnum.MX, { season: 2024 })]);
+      jest
+        .spyOn(Player, "findAll")
+        .mockResolvedValue([stubPlayer("p1", "M"), stubPlayer("p2", "F")]);
+      const placeSpy = jest
+        .spyOn(RankingPlace, "findAll")
+        .mockResolvedValue([stubPlace("p1", 6, 6, 6), stubPlace("p2", 6, 6, 6)]);
 
       const result = await service.calculateOne({
         key: "k",
@@ -324,9 +318,9 @@ describe("IndexCalculationService", () => {
 
     it("explicit type/season override the sub-event-derived values", async () => {
       jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(SubEventCompetition, "findAll").mockResolvedValue([
-        stubSubEvent(SubEventTypeEnum.M, { season: 2020 }),
-      ]);
+      jest
+        .spyOn(SubEventCompetition, "findAll")
+        .mockResolvedValue([stubSubEvent(SubEventTypeEnum.M, { season: 2020 })]);
       jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
       const placeSpy = jest.spyOn(RankingPlace, "findAll").mockResolvedValue([]);
 
@@ -398,9 +392,9 @@ describe("IndexCalculationService", () => {
   describe("snapshot dedupe", () => {
     it("calls RankingPlace.findAll once when three inputs share the same (system, season)", async () => {
       jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(Player, "findAll").mockResolvedValue([
-        stubPlayer("p1"), stubPlayer("p2"), stubPlayer("p3"),
-      ]);
+      jest
+        .spyOn(Player, "findAll")
+        .mockResolvedValue([stubPlayer("p1"), stubPlayer("p2"), stubPlayer("p3")]);
       const spy = jest.spyOn(RankingPlace, "findAll").mockResolvedValue([]);
 
       await service.calculate([
@@ -463,7 +457,7 @@ describe("IndexCalculationService", () => {
   describe("partial failure does not fail the batch", () => {
     it("returns Success for input[0] and PLAYER_NOT_FOUND for input[1]", async () => {
       const goodId = "player-good-0000-0000-0000-000000000000";
-      const badId  = "player-bad--0000-0000-0000-000000000000";
+      const badId = "player-bad--0000-0000-0000-000000000000";
 
       jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
       // Only goodId is in the DB — badId is absent.
@@ -472,7 +466,7 @@ describe("IndexCalculationService", () => {
 
       const results = await service.calculate([
         { key: "good", type: SubEventTypeEnum.M, season: SEASON, players: [{ id: goodId }] },
-        { key: "bad",  type: SubEventTypeEnum.M, season: SEASON, players: [{ id: badId }] },
+        { key: "bad", type: SubEventTypeEnum.M, season: SEASON, players: [{ id: badId }] },
       ]);
 
       expect(results).toHaveLength(2);
@@ -502,9 +496,9 @@ describe("IndexCalculationService", () => {
       const noGenderId = "player-nogender-0000-0000-000000000000";
 
       jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(Player, "findAll").mockResolvedValue([
-        { id: noGenderId, gender: null } as unknown as Player,
-      ]);
+      jest
+        .spyOn(Player, "findAll")
+        .mockResolvedValue([{ id: noGenderId, gender: null } as unknown as Player]);
       jest.spyOn(RankingPlace, "findAll").mockResolvedValue([]);
 
       const result = await service.calculateOne({
@@ -527,13 +521,10 @@ describe("IndexCalculationService", () => {
   describe("computeResult — missing-player count", () => {
     it("sets missingPlayerCount to max(0, 4 − contributingPlayers.length)", async () => {
       jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(Player, "findAll").mockResolvedValue([
-        stubPlayer("p1"), stubPlayer("p2"),
-      ]);
-      jest.spyOn(RankingPlace, "findAll").mockResolvedValue([
-        stubPlace("p1", 8, 8, 12),
-        stubPlace("p2", 8, 8, 12),
-      ]);
+      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1"), stubPlayer("p2")]);
+      jest
+        .spyOn(RankingPlace, "findAll")
+        .mockResolvedValue([stubPlace("p1", 8, 8, 12), stubPlace("p2", 8, 8, 12)]);
 
       const result = await service.calculateOne({
         key: "k",
@@ -555,9 +546,7 @@ describe("IndexCalculationService", () => {
   // -------------------------------------------------------------------------
   describe("RankingPlace fetch error", () => {
     it("falls back to default-fill (amountOfLevels+2) when RankingPlace.findAll throws", async () => {
-      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(
-        stubSystem({ amountOfLevels: 12 })
-      );
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem({ amountOfLevels: 12 }));
       jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
       jest.spyOn(RankingPlace, "findAll").mockRejectedValue(new Error("DB timeout"));
 
@@ -582,15 +571,22 @@ describe("IndexCalculationService", () => {
   describe("validator parity", () => {
     it("M team, 4 ranked players: matches validator's baseIndex computation", async () => {
       jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(Player, "findAll").mockResolvedValue([
-        stubPlayer("p1"), stubPlayer("p2"), stubPlayer("p3"), stubPlayer("p4"),
-      ]);
-      jest.spyOn(RankingPlace, "findAll").mockResolvedValue([
-        stubPlace("p1", 5, 5, 7),
-        stubPlace("p2", 6, 6, 8),
-        stubPlace("p3", 7, 7, 9),
-        stubPlace("p4", 8, 8, 10),
-      ]);
+      jest
+        .spyOn(Player, "findAll")
+        .mockResolvedValue([
+          stubPlayer("p1"),
+          stubPlayer("p2"),
+          stubPlayer("p3"),
+          stubPlayer("p4"),
+        ]);
+      jest
+        .spyOn(RankingPlace, "findAll")
+        .mockResolvedValue([
+          stubPlace("p1", 5, 5, 7),
+          stubPlace("p2", 6, 6, 8),
+          stubPlace("p3", 7, 7, 9),
+          stubPlace("p4", 8, 8, 10),
+        ]);
 
       const result = await service.calculateOne({
         key: "k",
@@ -608,9 +604,14 @@ describe("IndexCalculationService", () => {
 
     it("M team, one unranked player: matches validator's min+2 fallback", async () => {
       jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
-      jest.spyOn(Player, "findAll").mockResolvedValue([
-        stubPlayer("p1"), stubPlayer("p2"), stubPlayer("p3"), stubPlayer("p4"),
-      ]);
+      jest
+        .spyOn(Player, "findAll")
+        .mockResolvedValue([
+          stubPlayer("p1"),
+          stubPlayer("p2"),
+          stubPlayer("p3"),
+          stubPlayer("p4"),
+        ]);
       jest.spyOn(RankingPlace, "findAll").mockResolvedValue([
         stubPlace("p1", 5, 5, 7),
         stubPlace("p2", 6, 6, 8),
@@ -630,6 +631,86 @@ describe("IndexCalculationService", () => {
         // Same setup as validator's "Player without RankingPlace falls back…" test → 64
         expect(result.index).toBe(64);
       }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Caller-tag log enrichment (spec FR-008, SC-004)
+  // T017, T018, T019, T020
+  // -------------------------------------------------------------------------
+  describe("caller-tag log enrichment (FR-008)", () => {
+    // T017 — WARN log includes [CallerTag] when slow (duration > 1000 ms)
+    it("includes [CallerTag] in WARN log line when duration exceeds 1000 ms", async () => {
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
+      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
+      jest.spyOn(RankingPlace, "findAll").mockResolvedValue([stubPlace("p1", 5, 5, 7)]);
+
+      // Simulate a slow execution by making Date.now() return values 1500 ms apart
+      const nowSpy = jest.spyOn(Date, "now");
+      nowSpy.mockReturnValueOnce(0).mockReturnValue(1500);
+
+      const warnSpy = jest.spyOn(service["logger"], "warn");
+
+      await service.calculate(
+        [{ key: "k", type: SubEventTypeEnum.M, season: SEASON, players: [{ id: "p1" }] }],
+        { caller: "TestCaller" }
+      );
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("[TestCaller]"));
+    });
+
+    // T018 — DEBUG log includes [CallerTag] when fast (duration <= 1000 ms)
+    it("includes [CallerTag] in DEBUG log line when duration is within normal range", async () => {
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
+      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
+      jest.spyOn(RankingPlace, "findAll").mockResolvedValue([stubPlace("p1", 5, 5, 7)]);
+
+      // Fast execution — both Date.now() calls return 0 → duration = 0 ms
+      jest.spyOn(Date, "now").mockReturnValue(0);
+
+      const debugSpy = jest.spyOn(service["logger"], "debug");
+
+      await service.calculate(
+        [{ key: "k", type: SubEventTypeEnum.M, season: SEASON, players: [{ id: "p1" }] }],
+        { caller: "TestCaller" }
+      );
+
+      expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining("[TestCaller]"));
+    });
+
+    // T019 — log lines do NOT include a bracketed tag when caller is omitted
+    it("renders log lines WITHOUT a bracketed tag when options.caller is omitted", async () => {
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
+      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
+      jest.spyOn(RankingPlace, "findAll").mockResolvedValue([stubPlace("p1", 5, 5, 7)]);
+
+      jest.spyOn(Date, "now").mockReturnValue(0);
+
+      const debugSpy = jest.spyOn(service["logger"], "debug");
+
+      await service.calculate([
+        { key: "k", type: SubEventTypeEnum.M, season: SEASON, players: [{ id: "p1" }] },
+      ]);
+
+      expect(debugSpy).toHaveBeenCalledWith(expect.not.stringContaining("["));
+    });
+
+    // T020 — calculateOne forwards caller to the underlying calculate invocation
+    it("calculateOne forwards caller option to calculate so the log tag appears", async () => {
+      jest.spyOn(RankingSystem, "findOne").mockResolvedValue(stubSystem());
+      jest.spyOn(Player, "findAll").mockResolvedValue([stubPlayer("p1")]);
+      jest.spyOn(RankingPlace, "findAll").mockResolvedValue([stubPlace("p1", 5, 5, 7)]);
+
+      jest.spyOn(Date, "now").mockReturnValue(0);
+
+      const debugSpy = jest.spyOn(service["logger"], "debug");
+
+      await service.calculateOne(
+        { key: "k", type: SubEventTypeEnum.M, season: SEASON, players: [{ id: "p1" }] },
+        { caller: "SingleCaller" }
+      );
+
+      expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining("[SingleCaller]"));
     });
   });
 });

--- a/libs/backend/competition/enrollment/src/services/index-calculation/index-calculation.service.ts
+++ b/libs/backend/competition/enrollment/src/services/index-calculation/index-calculation.service.ts
@@ -76,10 +76,16 @@ export class IndexCalculationService {
    * Calculate index values for a batch of inputs in a single call.
    * Per-input failures are surfaced as IndexCalculationFailure entries;
    * they do not abort the batch.
+   *
+   * @param options.caller Optional stable identifier for the calling code path.
+   *   When provided it is included in every log line as `[<caller>]` and set
+   *   as the `index_calc.caller` Sentry span attribute, enabling triage
+   *   engineers to attribute slow-calculation warnings without a debugger
+   *   (spec FR-008, SC-004).
    */
   async calculate(
     inputs: IndexCalculationInput[],
-    options?: { transaction?: Transaction }
+    options?: { transaction?: Transaction; caller?: string }
   ): Promise<IndexCalculationResult[]> {
     if (inputs.length === 0) {
       return [];
@@ -98,17 +104,21 @@ export class IndexCalculationService {
       },
       async (span) => {
         try {
+          if (options?.caller) {
+            span?.setAttribute("index_calc.caller", options.caller);
+          }
           return await this._calculate(inputs, options);
         } finally {
           const durationMs = Date.now() - start;
           span?.setAttribute("index_calc.duration_ms", durationMs);
+          const callerTag = options?.caller ? ` [${options.caller}]` : "";
           if (durationMs > 1000) {
             this.logger.warn(
-              `Slow index calculation: ${inputs.length} input(s), ${totalPlayers} player ref(s), ${durationMs}ms`
+              `Slow index calculation:${callerTag} ${inputs.length} input(s), ${totalPlayers} player ref(s), ${durationMs}ms`
             );
           } else {
             this.logger.debug(
-              `Index calculation: ${inputs.length} input(s), ${totalPlayers} player ref(s), ${durationMs}ms`
+              `Index calculation:${callerTag} ${inputs.length} input(s), ${totalPlayers} player ref(s), ${durationMs}ms`
             );
           }
         }
@@ -301,7 +311,7 @@ export class IndexCalculationService {
   /** Convenience wrapper for single-input callers (e.g., the entry-model hook). */
   async calculateOne(
     input: IndexCalculationInput,
-    options?: { transaction?: Transaction }
+    options?: { transaction?: Transaction; caller?: string }
   ): Promise<IndexCalculationResult> {
     const results = await this.calculate([input], options);
     return results[0];

--- a/libs/backend/competition/enrollment/src/services/validate/enrollment.service.ts
+++ b/libs/backend/competition/enrollment/src/services/validate/enrollment.service.ts
@@ -195,9 +195,7 @@ export class EnrollmentValidationService {
       );
 
       const backupPlayers = playersForTeam.filter((p) =>
-        t.backupPlayers
-          ?.map((p) => (instanceOfEntryCompetitionPlayer(p) ? p.id : p))
-          .includes(p.id)
+        t.backupPlayers?.map((p) => (instanceOfEntryCompetitionPlayer(p) ? p.id : p)).includes(p.id)
       );
 
       const previousSeasonTeam = previousSeasonTeams.find((p) => p.link === t.link);
@@ -275,7 +273,9 @@ export class EnrollmentValidationService {
 
     const indexResults =
       indexInputs.length > 0
-        ? await this.indexCalculationService.calculate(indexInputs)
+        ? await this.indexCalculationService.calculate(indexInputs, {
+            caller: "EnrollmentValidationService.fetchAndValidate",
+          })
         : [];
     const resultsByKey = new Map(indexResults.map((r) => [r.key, r]));
 

--- a/libs/backend/database/src/models/event/entry.model.ts
+++ b/libs/backend/database/src/models/event/entry.model.ts
@@ -48,7 +48,7 @@ interface IIndexCalculationService {
       subEventCompetitionId?: string;
       players: { id: string }[];
     },
-    options?: { transaction?: unknown }
+    options?: { transaction?: unknown; caller?: string }
   ): Promise<
     | {
         _tag: "success";
@@ -249,7 +249,7 @@ export class EventEntry extends Model<
         subEventCompetitionId: instance.subEventId ?? undefined,
         players: (instance.meta.competition.players ?? []).map((p) => ({ id: p.id! })),
       },
-      { transaction: options?.transaction }
+      { transaction: options?.transaction, caller: "EventEntry.recalculateCompetitionIndex" }
     );
 
     if (result._tag === "failure") {

--- a/libs/backend/graphql/src/resolvers/event/competition/calculate-index/calculate-index.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/calculate-index/calculate-index.resolver.ts
@@ -1,10 +1,6 @@
 import { User } from "@badman/backend-authorization";
 import { Player } from "@badman/backend-database";
-import {
-  IndexCalculationService,
-  isFailure,
-  isSuccess,
-} from "@badman/backend-enrollment";
+import { IndexCalculationService, isFailure, isSuccess } from "@badman/backend-enrollment";
 import { IsUUID } from "@badman/utils";
 import { Logger } from "@nestjs/common";
 import { Args, Query, Resolver } from "@nestjs/graphql";
@@ -43,9 +39,12 @@ export class CalculateIndexResolver {
 
     const keys = inputs.map((i) => i.key);
     if (new Set(keys).size !== keys.length) {
-      throw new GraphQLError("inputs contains duplicate key values. Each key must be unique within a batch.", {
-        extensions: { code: ErrorCode.BAD_USER_INPUT },
-      });
+      throw new GraphQLError(
+        "inputs contains duplicate key values. Each key must be unique within a batch.",
+        {
+          extensions: { code: ErrorCode.BAD_USER_INPUT },
+        }
+      );
     }
 
     const currentYear = new Date().getFullYear();
@@ -57,10 +56,9 @@ export class CalculateIndexResolver {
         );
       }
       if (input.subEventCompetitionId && !IsUUID(input.subEventCompetitionId)) {
-        throw new GraphQLError(
-          `inputs[${input.key}].subEventCompetitionId is not a valid UUID.`,
-          { extensions: { code: ErrorCode.BAD_USER_INPUT, key: input.key } }
-        );
+        throw new GraphQLError(`inputs[${input.key}].subEventCompetitionId is not a valid UUID.`, {
+          extensions: { code: ErrorCode.BAD_USER_INPUT, key: input.key },
+        });
       }
       for (const player of input.players) {
         if (!IsUUID(player.id)) {
@@ -82,9 +80,14 @@ export class CalculateIndexResolver {
 
     let serviceResults;
     try {
-      serviceResults = await this.indexCalculationService.calculate(serviceInputs);
+      serviceResults = await this.indexCalculationService.calculate(serviceInputs, {
+        caller: "CalculateIndexResolver.calculateIndex",
+      });
     } catch (err) {
-      this.logger.error("IndexCalculationService.calculate threw", err instanceof Error ? err.stack : String(err));
+      this.logger.error(
+        "IndexCalculationService.calculate threw",
+        err instanceof Error ? err.stack : String(err)
+      );
       throw new GraphQLError("Failed to calculate index.", {
         extensions: { code: ErrorCode.INTERNAL_ERROR },
       });

--- a/libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts
@@ -135,7 +135,7 @@ export class EnrollmentEntryService {
           subEventCompetitionId: subEventId,
           players: basePlayers.map((id) => ({ id })),
         },
-        { transaction }
+        { transaction, caller: "EnrollmentEntryService.createEntry" }
       );
 
       if (isFailure(result)) {

--- a/libs/backend/graphql/src/resolvers/event/entry.resolver.dataloader.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/entry.resolver.dataloader.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigService } from "@nestjs/config";
 import { EventEntry, Player, Standing, SubEventCompetition, Team } from "@badman/backend-database";
 import { Sequelize } from "sequelize-typescript";
 import { EventEntryResolver } from "./entry.resolver";
@@ -63,6 +64,10 @@ describe("EventEntryResolver — DataLoader field resolvers", () => {
         {
           provide: EnrollmentValidationCacheService,
           useValue: { getForTeam: jest.fn() },
+        },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue(false) },
         },
       ],
     }).compile();
@@ -227,7 +232,7 @@ describe("EventEntryResolver — DataLoader field resolvers", () => {
       jest.spyOn(teamLoaderService, "load").mockResolvedValue(fakeTeam);
       jest.spyOn(enrollmentValidationCacheService, "getForTeam").mockResolvedValue(null);
 
-      await resolver.enrollmentValidation(entry);
+      await resolver.enrollmentValidation(entry, true);
 
       expect(teamLoaderService.load).toHaveBeenCalledWith("team-1");
     });
@@ -249,7 +254,7 @@ describe("EventEntryResolver — DataLoader field resolvers", () => {
       // Resolve both team and enrollmentValidation on all entries concurrently
       await Promise.all([
         ...entries.map((e) => resolver.team(e)),
-        ...entries.map((e) => resolver.enrollmentValidation(e)),
+        ...entries.map((e) => resolver.enrollmentValidation(e, true)),
       ]);
 
       // Both team() and enrollmentValidation() must route through teamLoader.load
@@ -263,7 +268,7 @@ describe("EventEntryResolver — DataLoader field resolvers", () => {
       jest.spyOn(teamLoaderService, "load").mockResolvedValue(null);
       const getForTeamSpy = jest.spyOn(enrollmentValidationCacheService, "getForTeam");
 
-      const result = await resolver.enrollmentValidation(entry);
+      const result = await resolver.enrollmentValidation(entry, true);
 
       expect(result).toBeNull();
       expect(getForTeamSpy).not.toHaveBeenCalled();

--- a/libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
 import { GraphQLError } from "graphql";
 import { Sequelize } from "sequelize-typescript";
 import { Club, EventEntry, Logging, Player, Team } from "@badman/backend-database";
@@ -106,6 +107,10 @@ describe("EventEntryResolver.finishEventEntry", () => {
         {
           provide: EnrollmentValidationCacheService,
           useValue: { getForTeam: jest.fn() },
+        },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue(false) },
         },
       ],
     }).compile();
@@ -420,5 +425,171 @@ describe("EventEntryResolver.finishEventEntry", () => {
     expect(result.success).toBe(true);
     expect(result.alreadyFinalised).toBe(false);
     expect(mockTransaction.commit).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EventEntryResolver.enrollmentValidation gate (FR-001, FR-002, FR-006, FR-010)
+// T004, T005, T006, T010, T011, T012
+// ---------------------------------------------------------------------------
+describe("EventEntryResolver.enrollmentValidation (gate)", () => {
+  let resolver: EventEntryResolver;
+  let mockCacheService: { getForTeam: jest.Mock };
+  let mockConfigService: { get: jest.Mock };
+  let mockTeamLoader: { load: jest.Mock };
+
+  const stubTeamModel = (id = "team-uuid", clubId = "club-uuid", season = 2026) =>
+    asUnknown<Team>({ id, clubId, season });
+
+  const stubEventEntry = (teamId = "team-uuid") =>
+    asUnknown<EventEntry>({ teamId });
+
+  const buildModule = async (enrollmentValidationDefaultEnabled: boolean) => {
+    mockCacheService = { getForTeam: jest.fn() };
+    mockTeamLoader = { load: jest.fn() };
+    mockConfigService = {
+      get: jest.fn((key: string) => {
+        if (key === "ENROLLMENT_VALIDATION_DEFAULT_ENABLED")
+          return enrollmentValidationDefaultEnabled;
+        return undefined;
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EventEntryResolver,
+        EnrollmentFinalizeService,
+        {
+          provide: Sequelize,
+          useValue: {
+            transaction: jest.fn().mockResolvedValue({
+              commit: jest.fn(),
+              rollback: jest.fn(),
+              LOCK: { UPDATE: "UPDATE" },
+            }),
+          },
+        },
+        {
+          provide: NotificationService,
+          useValue: { notifyEnrollment: jest.fn() },
+        },
+        {
+          provide: EnrollmentValidationService,
+          useValue: { fetchAndValidate: jest.fn() },
+        },
+        {
+          provide: EnrollmentValidationCacheService,
+          useValue: mockCacheService,
+        },
+        {
+          provide: SubEventCompetitionLoaderService,
+          useValue: { load: jest.fn() },
+        },
+        {
+          provide: TeamLoaderService,
+          useValue: mockTeamLoader,
+        },
+        {
+          provide: StandingLoaderService,
+          useValue: { load: jest.fn() },
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    }).compile();
+
+    return module.get<EventEntryResolver>(EventEntryResolver);
+  };
+
+  afterEach(() => jest.restoreAllMocks());
+
+  // T004 — validate omitted (undefined) + env flag false → null, no cache call
+  it("returns null and does not call getForTeam when validate is undefined and env flag is false", async () => {
+    resolver = await buildModule(false);
+    const entry = stubEventEntry();
+
+    const result = await resolver.enrollmentValidation(entry, undefined);
+
+    expect(result).toBeNull();
+    expect(mockCacheService.getForTeam).not.toHaveBeenCalled();
+  });
+
+  // T005 — validate explicitly false + env flag false → null, no cache call
+  it("returns null and does not call getForTeam when validate is false and env flag is false", async () => {
+    resolver = await buildModule(false);
+    const entry = stubEventEntry();
+
+    const result = await resolver.enrollmentValidation(entry, false);
+
+    expect(result).toBeNull();
+    expect(mockCacheService.getForTeam).not.toHaveBeenCalled();
+  });
+
+  // T006 — when computation is skipped, teamLoader.load must NOT be called (no unnecessary association fetch)
+  it("does not call teamLoader.load() when computation is skipped", async () => {
+    resolver = await buildModule(false);
+    const entry = stubEventEntry();
+
+    await resolver.enrollmentValidation(entry, undefined);
+
+    expect(mockTeamLoader.load).not.toHaveBeenCalled();
+  });
+
+  // T010 — validate: true → delegates to cache and returns result verbatim
+  it("calls teamLoader.load() once and getForTeam(team) once, returning the cache value when validate is true", async () => {
+    resolver = await buildModule(false);
+    const team = stubTeamModel();
+    mockTeamLoader.load.mockResolvedValue(team);
+    const entry = stubEventEntry();
+    const fakeOutput = { teams: [] } as unknown as ReturnType<typeof mockCacheService.getForTeam>;
+    mockCacheService.getForTeam.mockResolvedValue(fakeOutput);
+
+    const result = await resolver.enrollmentValidation(entry, true);
+
+    expect(mockTeamLoader.load).toHaveBeenCalledTimes(1);
+    expect(mockTeamLoader.load).toHaveBeenCalledWith("team-uuid");
+    expect(mockCacheService.getForTeam).toHaveBeenCalledWith(team);
+    expect(result).toBe(fakeOutput);
+  });
+
+  // T011 — validate omitted + env flag true (kill-switch) → delegates to cache
+  it("delegates to cache when validate is omitted AND ENROLLMENT_VALIDATION_DEFAULT_ENABLED is true", async () => {
+    resolver = await buildModule(true);
+    const team = stubTeamModel();
+    mockTeamLoader.load.mockResolvedValue(team);
+    const entry = stubEventEntry();
+    const fakeOutput = { teams: [] } as unknown as ReturnType<typeof mockCacheService.getForTeam>;
+    mockCacheService.getForTeam.mockResolvedValue(fakeOutput);
+
+    const result = await resolver.enrollmentValidation(entry, undefined);
+
+    expect(mockTeamLoader.load).toHaveBeenCalledTimes(1);
+    expect(mockCacheService.getForTeam).toHaveBeenCalledWith(team);
+    expect(result).toBe(fakeOutput);
+  });
+
+  // T012 — validate: true but cache rejects → rejection surfaces (spec FR-006)
+  it("propagates cache rejection when validate is true (does NOT swallow to null)", async () => {
+    resolver = await buildModule(false);
+    const team = stubTeamModel();
+    mockTeamLoader.load.mockResolvedValue(team);
+    const entry = stubEventEntry();
+    mockCacheService.getForTeam.mockRejectedValue(new Error("DB down"));
+
+    await expect(resolver.enrollmentValidation(entry, true)).rejects.toThrow("DB down");
+  });
+
+  // Edge case: explicit validate: false with kill-switch true → MUST still return null
+  it("returns null when validate is explicitly false even if ENROLLMENT_VALIDATION_DEFAULT_ENABLED is true", async () => {
+    resolver = await buildModule(true);
+    const entry = stubEventEntry();
+
+    const result = await resolver.enrollmentValidation(entry, false);
+
+    expect(result).toBeNull();
+    expect(mockTeamLoader.load).not.toHaveBeenCalled();
+    expect(mockCacheService.getForTeam).not.toHaveBeenCalled();
   });
 });

--- a/libs/backend/graphql/src/resolvers/event/entry.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/entry.resolver.ts
@@ -14,7 +14,9 @@ import {
 } from "@badman/backend-database";
 import { TeamEnrollmentOutput } from "@badman/backend-enrollment";
 import { NotificationService } from "@badman/backend-notifications";
+import { ConfigType } from "@badman/utils";
 import { Logger, NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
 import { Args, ID, Int, Mutation, Parent, Query, ResolveField, Resolver } from "@nestjs/graphql";
 import { Sequelize } from "sequelize-typescript";
 import { ListArgs } from "../../utils";
@@ -38,7 +40,8 @@ export class EventEntryResolver {
     private _sequelize: Sequelize,
     private readonly subEventLoader: SubEventCompetitionLoaderService,
     private readonly teamLoader: TeamLoaderService,
-    private readonly standingLoader: StandingLoaderService
+    private readonly standingLoader: StandingLoaderService,
+    private readonly configService: ConfigService<ConfigType>
   ) {}
 
   @Query(() => EventEntry)
@@ -91,11 +94,24 @@ export class EventEntryResolver {
 
   @ResolveField(() => TeamEnrollmentOutput, {
     nullable: true,
-    description: `Validate the enrollment\n\r**note**: the levels are the ones from may!`,
+    description:
+      "Validate the enrollment. Defaults to null. Pass `validate: true` to compute — " +
+      "this is a club-wide computation; only request it when you really need it. " +
+      "**note**: the levels are the ones from may!",
   })
   async enrollmentValidation(
-    @Parent() eventEntry: EventEntry
+    @Parent() eventEntry: EventEntry,
+    @Args("validate", { type: () => Boolean, nullable: true }) validate?: boolean
   ): Promise<TeamEnrollmentOutput | null> {
+    // Explicit caller intent always wins (spec Clarifications Q1):
+    //   validate === false  → always return null (even if kill-switch is on)
+    //   validate === true   → always compute
+    //   validate === undefined (omitted) → fall through to the rollout-safety env flag
+    if (validate === false) return null;
+    const effectiveValidate =
+      validate === true ||
+      this.configService.get<boolean>("ENROLLMENT_VALIDATION_DEFAULT_ENABLED") === true;
+    if (!effectiveValidate) return null;
     const team = await this.teamLoader.load(eventEntry.teamId);
     if (!team) return null;
     return this.enrollmentValidationCache.getForTeam(team);

--- a/libs/backend/graphql/src/resolvers/event/event.module.ts
+++ b/libs/backend/graphql/src/resolvers/event/event.module.ts
@@ -1,4 +1,5 @@
 import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
 import { CompetitionResolverModule } from "./competition.module";
 import { EventEntryResolver, EntryCompetitionPlayersResolver } from "./entry.resolver";
 import { EnrollmentFinalizeService } from "./enrollment-finalize.service";
@@ -14,6 +15,7 @@ import {
 
 @Module({
   imports: [
+    ConfigModule,
     CompetitionResolverModule,
     TournamentResolverModule,
     NotificationsModule,

--- a/libs/backend/graphql/src/resolvers/team/team.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/team/team.resolver.ts
@@ -374,7 +374,7 @@ export class TeamsResolver {
       if (core.indexPayload) {
         const [calcResult] = await this.indexCalculationService.calculate(
           [core.indexPayload.input],
-          { transaction }
+          { transaction, caller: "TeamsResolver.createTeam" }
         );
         if (isFailure(calcResult)) {
           this.indexFailureToGraphQLError(calcResult, { clubId: core.indexPayload.clubId, userId });
@@ -430,7 +430,7 @@ export class TeamsResolver {
       if (payloads.length > 0) {
         const calcResults = await this.indexCalculationService.calculate(
           payloads.map((p) => p.input),
-          { transaction }
+          { transaction, caller: "TeamsResolver.createTeams" }
         );
         for (const r of calcResults) {
           if (isFailure(r)) {

--- a/libs/utils/src/config/configuration.ts
+++ b/libs/utils/src/config/configuration.ts
@@ -46,6 +46,7 @@ export const configSchema = Joi.object({
   ENTER_SCORES_ENABLED: Joi.boolean().optional(),
   HANG_BEFORE_BROWSER_CLEANUP: Joi.boolean().optional(),
   VISUAL_SYNC_ENABLED: Joi.boolean().optional(),
+  ENROLLMENT_VALIDATION_DEFAULT_ENABLED: Joi.boolean().optional().default(false),
   VISUAL_FORCE_CACHE_DEV: Joi.string().valid("true", "false").default("true"),
   REDIS_DATABASE: Joi.number().integer().optional(),
   REDIS_HOST: Joi.when("DB_CACHE", {
@@ -114,7 +115,8 @@ export const configSchema = Joi.object({
   DEV_ONLY_ALLOW_QUEUE_JOB_WITHOUT_AUTH: Joi.when("NODE_ENV", {
     is: Joi.valid("production", "staging"),
     then: Joi.forbidden().messages({
-      "any.unknown": "DEV_ONLY_ALLOW_QUEUE_JOB_WITHOUT_AUTH must not be set when NODE_ENV is production or staging.",
+      "any.unknown":
+        "DEV_ONLY_ALLOW_QUEUE_JOB_WITHOUT_AUTH must not be set when NODE_ENV is production or staging.",
     }),
     otherwise: Joi.boolean().optional(),
   }),
@@ -125,7 +127,8 @@ export const configSchema = Joi.object({
   DEV_ONLY_QUEUE_JOB_AS_PLAYER_ID: Joi.when("NODE_ENV", {
     is: Joi.valid("production", "staging"),
     then: Joi.forbidden().messages({
-      "any.unknown": "DEV_ONLY_QUEUE_JOB_AS_PLAYER_ID must not be set when NODE_ENV is production or staging.",
+      "any.unknown":
+        "DEV_ONLY_QUEUE_JOB_AS_PLAYER_ID must not be set when NODE_ENV is production or staging.",
     }),
     otherwise: Joi.string().uuid().optional(),
   }),
@@ -200,6 +203,8 @@ export const load = () => ({
   VR_CHANGE_DATES: process.env?.["VR_CHANGE_DATES"] === "true",
   VR_ACCEPT_ENCOUNTERS: process.env?.["VR_ACCEPT_ENCOUNTERS"] === "true",
   VISUAL_SYNC_ENABLED: process.env?.["VISUAL_SYNC_ENABLED"] === "true",
+  ENROLLMENT_VALIDATION_DEFAULT_ENABLED:
+    process.env?.["ENROLLMENT_VALIDATION_DEFAULT_ENABLED"] === "true",
 });
 
 export type ConfigType = {
@@ -231,6 +236,7 @@ export type ConfigType = {
   AUTH0_ISSUER_URL: string;
   AUTH0_AUDIENCE: string;
   VISUAL_SYNC_ENABLED: boolean;
+  ENROLLMENT_VALIDATION_DEFAULT_ENABLED: boolean;
   VISUAL_FORCE_CACHE_DEV: string;
   ENTER_SCORES_ENABLED: boolean;
   HANG_BEFORE_BROWSER_CLEANUP: boolean;

--- a/specs/028-gate-enrollment-validation/checklists/requirements.md
+++ b/specs/028-gate-enrollment-validation/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Gate Enrollment Validation Field
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec references the implementation plan at `/Users/arno/.claude/plans/scalable-gliding-dawn.md` only as background context — the spec itself is implementation-agnostic.
+- The spec names the GraphQL field (`EventEntry.enrollmentValidation`) and the service class (`IndexCalculationService`, `EnrollmentValidationCacheService`) for traceability to the production incident; these are observable system surfaces (schema field, log emitter name), not implementation choices, so they remain in the spec.
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.

--- a/specs/028-gate-enrollment-validation/contracts/graphql-schema-delta.md
+++ b/specs/028-gate-enrollment-validation/contracts/graphql-schema-delta.md
@@ -1,0 +1,75 @@
+# GraphQL Schema Delta
+
+## Field affected
+
+`EventEntry.enrollmentValidation`
+
+## Before
+
+```graphql
+type EventEntry {
+  # ... unchanged fields ...
+
+  """
+  Validate the enrollment
+  **note**: the levels are the ones from may!
+  """
+  enrollmentValidation: TeamEnrollmentOutput
+}
+```
+
+## After
+
+```graphql
+type EventEntry {
+  # ... unchanged fields ...
+
+  """
+  Validate the enrollment. Defaults to null. Pass `validate: true` to compute —
+  this is a club-wide computation; only request it when you really need it.
+  **note**: the levels are the ones from may!
+  """
+  enrollmentValidation(validate: Boolean = false): TeamEnrollmentOutput
+}
+```
+
+## Compatibility analysis
+
+| Concern | Verdict |
+|---|---|
+| Field name | Unchanged. |
+| Return type | Unchanged (still `TeamEnrollmentOutput`, still nullable). |
+| New argument | Optional with default `false`. Existing query documents that select the field without arguments remain valid SDL. |
+| Runtime semantics for legacy queries | **Changes**: returns `null` instead of a computed payload. This is the intended fix. The kill-switch env var lets the platform team flip back to "compute by default" without redeploy. |
+| Codegen / typed clients | New optional arg appears in generated types. No type narrowing breaks; return type already includes `| null`. |
+
+## Caller contract
+
+Callers that need the validation payload MUST pass `validate: true`:
+
+```graphql
+query MyEnrollmentWizardQuery($teamId: ID!) {
+  team(id: $teamId) {
+    entries {
+      id
+      enrollmentValidation(validate: true) {
+        # ... unchanged payload shape ...
+      }
+    }
+  }
+}
+```
+
+Callers that do not need the payload should drop the field from the selection set (preferred) or accept `null`.
+
+## Error contract
+
+When `validate: true` (or the kill-switch is active) and the underlying
+`EnrollmentValidationCacheService.getForTeam(team)` rejects, the error MUST
+propagate to the client. The resolver MUST NOT swallow the rejection into
+`null` — that would conflate "not requested" with "computation failed"
+(spec FR-006).
+
+## Sibling resolver
+
+`EnrollmentResolver.enrollmentValidation` at `libs/backend/graphql/src/resolvers/event/competition/enrollment.resolver.ts:25-35` is a top-level `Query`-side resolver that already requires an explicit `EnrollmentInput` argument. It is opt-in by construction and is NOT changed by this contract delta.

--- a/specs/028-gate-enrollment-validation/data-model.md
+++ b/specs/028-gate-enrollment-validation/data-model.md
@@ -1,0 +1,38 @@
+# Phase 1 Data Model: Gate Enrollment Validation Field
+
+## Persistent entities
+
+None added or modified. No migration. No `@badman/backend-database` model change.
+
+## Non-persistent / runtime artifacts
+
+### Config flag
+
+| Name | Type | Default | Lifecycle | Read at |
+|---|---|---|---|---|
+| `ENROLLMENT_VALIDATION_DEFAULT_ENABLED` | `boolean` | `false` | env var, validated at API boot by the `@badman/utils` config schema | per request inside `EventEntry.enrollmentValidation` resolver |
+
+Behavior matrix:
+
+| GraphQL `validate` arg | `ENROLLMENT_VALIDATION_DEFAULT_ENABLED` | Resolver behavior |
+|---|---|---|
+| `true` | any | Delegates to `EnrollmentValidationCacheService.getForTeam(team)`. |
+| `false` | any | Returns `null` immediately. No cache hit. No DB read. |
+| omitted | `false` | Returns `null` immediately. (Default rollout state.) |
+| omitted | `true` | Delegates to cache. (Temporary kill-switch state.) |
+
+### GraphQL argument
+
+| Field | Argument | Type | Default (SDL) | Effective default at runtime |
+|---|---|---|---|---|
+| `EventEntry.enrollmentValidation` | `validate` | `Boolean` (optional) | `false` | resolved by combining the arg with the env flag (table above) |
+
+## Existing data shapes (unchanged, listed for traceability)
+
+- `TeamEnrollmentOutput` (`@badman/backend-enrollment`) — return type. Unchanged.
+- `IndexCalculationInput` / `IndexCalculationResult` (`index-calculation.types.ts`) — internal to `IndexCalculationService`. Unchanged.
+- `EventEntry`, `Team`, `Player`, `RankingPlace`, `RankingSystem`, `SubEventCompetition` Sequelize models — unchanged.
+
+## State transitions
+
+None. No new persistent state. The flag is read-only at request time; no write path adds state to it.

--- a/specs/028-gate-enrollment-validation/plan.md
+++ b/specs/028-gate-enrollment-validation/plan.md
@@ -1,0 +1,192 @@
+# Implementation Plan: Gate Enrollment Validation Field
+
+**Branch**: `028-gate-enrollment-validation` | **Date**: 2026-05-21 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/028-gate-enrollment-validation/spec.md`
+
+## Summary
+
+Make the `EventEntry.enrollmentValidation` GraphQL field opt-in via a `validate: Boolean = false` argument. When omitted or `false`, the resolver returns `null` immediately and does not invoke `EnrollmentValidationCacheService`. The wizard (active frontend, separate repo) opts in by passing `validate: true`. A runtime kill-switch (env var) lets the platform team temporarily flip the default back to "always compute" if the frontend rollout slips, per spec FR-010. Slow-log lines from `IndexCalculationService` gain a `caller` tag per spec FR-008.
+
+This removes the per-request club-wide validation that floods the API process at night when the sync worker saturates the shared Postgres instance.
+
+## Technical Context
+
+**Language/Version**: TypeScript (Node.js 20+, per repo baseline)
+**Primary Dependencies**: NestJS, Apollo (`@nestjs/graphql`, code-first), Sequelize, Bull. No new dependencies.
+**Storage**: PostgreSQL (Sequelize). No schema change; no migration.
+**Testing**: Jest, per `libs/backend/graphql/jest.config.ts` and `libs/backend/competition/enrollment/jest.config.ts`. Follow resolver-test convention from [enrollmentSetting.resolver.spec.ts](../../libs/backend/graphql/src/resolvers/enrollmentSetting/enrollmentSetting.resolver.spec.ts).
+**Target Platform**: API process (NestJS on Fastify, port 5010). No worker-process changes.
+**Project Type**: Nx monorepo, backend libraries imported as `@badman/<name>`.
+**Performance Goals**: Eliminate `Slow index calculation` WARNs from non-enrollment-wizard traffic (spec SC-002: ≥95% drop). Eliminate health-check timeout events during nightly sync window (spec SC-001: zero events over 14 nights).
+**Constraints**: Database health-check timeout fixed at 1 s (environmental). Schema is code-first via Sequelize/`@nestjs/graphql`; field cannot be removed or renamed (spec FR-005).
+**Scale/Scope**: Two GraphQL resolver edits, one service-method-signature extension (`caller?: string`), ~6 call-site updates to pass the caller tag, one env-var read for the kill-switch, plus tests. No data migration. No external API change beyond the new optional GraphQL arg.
+
+## Constitution Check
+
+| Principle | Applies? | Status |
+|---|---|---|
+| I. Code-First GraphQL via Sequelize Models | No new entity introduced. Existing `EventEntry` model and `TeamEnrollmentOutput` `@ObjectType` reused as-is. | PASS |
+| II. Translation Discipline (NON-NEGOTIABLE) | No `all.json` changes. No user-facing copy added. | N/A |
+| III. Transactional Mutations | Not a mutation. Field is a read-side `@ResolveField`. No idempotency contract involved. | N/A |
+| IV. Resolver Test Discipline | New tests follow the reference pattern from `enrollmentSetting.resolver.spec.ts`: `Test.createTestingModule`, mocked `EnrollmentValidationCacheService`, `afterEach(jest.restoreAllMocks)`. CRUD cases not applicable (read-side resolve-field), so coverage targets: gate-off returns `null` and does not call cache; gate-on delegates to cache; cache failure surfaces (spec FR-006). | PASS |
+| V. Legacy Frontend Boundary (NON-NEGOTIABLE) | No work in `apps/badman/` or `libs/frontend/`. Frontend opt-in lives in the separate active-frontend repo and is out of scope. | PASS |
+
+**Gate**: PASS. No violations. `Complexity Tracking` section omitted (nothing to justify).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/028-gate-enrollment-validation/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (minimal — no schema change)
+├── contracts/
+│   └── graphql-schema-delta.md   # GraphQL schema change (added arg)
+├── quickstart.md        # Phase 1 output (local verification)
+├── checklists/
+│   └── requirements.md  # Created by /speckit.specify
+└── tasks.md             # /speckit.tasks output (not created here)
+```
+
+### Source Code (repository root)
+
+Existing Nx monorepo. Touched paths only:
+
+```text
+libs/backend/graphql/src/resolvers/event/
+├── entry.resolver.ts                          # ADD `validate` arg + gate
+├── entry.resolver.spec.ts                     # ADD tests for gate
+└── enrollment-validation-cache.service.ts     # UNCHANGED (already DataLoader-cached per request)
+
+libs/backend/competition/enrollment/src/services/
+├── index-calculation/
+│   ├── index-calculation.service.ts           # ADD optional `caller` in options; include in slow/normal log
+│   └── index-calculation.service.spec.ts      # ADD assertion that caller tag appears in WARN message
+└── validate/
+    └── enrollment.service.ts                  # Pass `caller: "EnrollmentValidationService.fetchAndValidate"`
+
+libs/backend/graphql/src/resolvers/team/team.resolver.ts          # Pass caller `"TeamsResolver.updateTeam"` / `"TeamsResolver.createTeams"`
+libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts  # Pass caller `"EnrollmentEntryService.createEntry"`
+libs/backend/graphql/src/resolvers/event/competition/calculate-index/calculate-index.resolver.ts  # Pass caller `"CalculateIndexResolver.calculateIndex"`
+libs/backend/database/src/models/event/entry.model.ts             # Pass caller `"EventEntry.recalculateCompetitionIndex"` from hook
+
+libs/utils/src/lib/config/                    # Add `ENROLLMENT_VALIDATION_DEFAULT_ENABLED` (default: false) to config schema
+apps/api/src/app/app.module.ts                # No edit unless ConfigService is not already wired here (it is)
+```
+
+**Structure Decision**: Single-project edit pattern. No new lib, no new module. The `EventEntry.enrollmentValidation` resolver lives at `libs/backend/graphql/src/resolvers/event/entry.resolver.ts:86-95`; the cache service it delegates to is request-scoped and stays request-scoped. The sibling `EnrollmentResolver.enrollmentValidation` at `libs/backend/graphql/src/resolvers/event/competition/enrollment.resolver.ts:28` is a **top-level `@Query` already requiring an explicit `EnrollmentInput` argument**, so it is already opt-in by construction — no gate needed there. Spec FR-003 is satisfied by inspection (verified during planning).
+
+## Phase 0: Research
+
+See [research.md](research.md). Summary:
+
+- **Decision**: Gate via optional GraphQL field arg with server-side default controlled by env var (kill-switch).
+- **Rationale**: Smallest blast radius. Field stays in schema; current consumers get `null` until they opt in; platform team can flip default per-environment without redeploy.
+- **Alternatives considered**: (1) Cross-request Redis cache — doesn't fix cold-cache stampedes and validation depends on mutable team rosters; (2) Detach into dedicated top-level `clubEnrollmentValidation(clubId, season)` query — cleaner long-term but requires frontend repo schema-shape change; (3) Detect sync activity and skip — requires DB/IPC coupling between api and worker-sync. Field-arg gate captures the intent of all three with one resolver edit.
+
+No NEEDS CLARIFICATION items remained from spec.
+
+## Phase 1: Design
+
+### Contract (GraphQL schema delta)
+
+See [contracts/graphql-schema-delta.md](contracts/graphql-schema-delta.md). Summary:
+
+```graphql
+type EventEntry {
+  # ... unchanged fields ...
+  enrollmentValidation(validate: Boolean = false): TeamEnrollmentOutput
+}
+```
+
+- Field exists today with no arg. After change: same field, same return type (still `nullable`), one new optional arg with a server-controlled default.
+- Backwards-compatible at the SDL level: existing query documents continue to validate.
+- Semantic change: previously-implicit "always compute" becomes "do not compute unless asked." Mitigated by the env-var kill-switch.
+
+### Data model
+
+See [data-model.md](data-model.md). No schema change. The only behavioral artifact is the new server-controlled flag:
+
+- `ENROLLMENT_VALIDATION_DEFAULT_ENABLED` (boolean, default `false`).
+  - When `false` and the GraphQL caller did not pass `validate`, the resolver returns `null` and skips computation.
+  - When `true`, the resolver behaves as it does today (always compute). Used as a temporary kill-switch only.
+- Added to the `@badman/utils` config schema so it is validated at API boot.
+
+### Caller-tag log enrichment
+
+`IndexCalculationService.calculate(inputs, options)` adds an optional `options.caller: string`. The two existing log lines:
+
+```ts
+this.logger.warn(`Slow index calculation: ${inputs.length} input(s), ${totalPlayers} player ref(s), ${durationMs}ms`);
+this.logger.debug(`Index calculation: ${inputs.length} input(s), ${totalPlayers} player ref(s), ${durationMs}ms`);
+```
+
+become:
+
+```ts
+const tag = options?.caller ? ` [${options.caller}]` : "";
+this.logger.warn(`Slow index calculation:${tag} ${inputs.length} input(s), ${totalPlayers} player ref(s), ${durationMs}ms`);
+this.logger.debug(`Index calculation:${tag} ${inputs.length} input(s), ${totalPlayers} player ref(s), ${durationMs}ms`);
+```
+
+`calculateOne` forwards `options` unchanged. Sentry span attribute `index_calc.caller` set when present.
+
+Each call site passes a stable string:
+
+| File | Caller value |
+|---|---|
+| [libs/backend/competition/enrollment/src/services/validate/enrollment.service.ts](../../libs/backend/competition/enrollment/src/services/validate/enrollment.service.ts) | `"EnrollmentValidationService.fetchAndValidate"` |
+| [libs/backend/graphql/src/resolvers/team/team.resolver.ts](../../libs/backend/graphql/src/resolvers/team/team.resolver.ts) `updateTeam` | `"TeamsResolver.updateTeam"` |
+| [libs/backend/graphql/src/resolvers/team/team.resolver.ts](../../libs/backend/graphql/src/resolvers/team/team.resolver.ts) `createTeams` | `"TeamsResolver.createTeams"` |
+| [libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts](../../libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts) | `"EnrollmentEntryService.createEntry"` |
+| [libs/backend/graphql/src/resolvers/event/competition/calculate-index/calculate-index.resolver.ts](../../libs/backend/graphql/src/resolvers/event/competition/calculate-index/calculate-index.resolver.ts) | `"CalculateIndexResolver.calculateIndex"` |
+| [libs/backend/database/src/models/event/entry.model.ts](../../libs/backend/database/src/models/event/entry.model.ts) hook | `"EventEntry.recalculateCompetitionIndex"` |
+
+### Resolver gate
+
+[libs/backend/graphql/src/resolvers/event/entry.resolver.ts:86-95](../../libs/backend/graphql/src/resolvers/event/entry.resolver.ts#L86-L95):
+
+```ts
+@ResolveField(() => TeamEnrollmentOutput, {
+  nullable: true,
+  description:
+    "Validate the enrollment. Defaults to null. Pass `validate: true` to compute — " +
+    "this is a club-wide computation; only request it when you really need it. " +
+    "**note**: the levels are the ones from may!",
+})
+async enrollmentValidation(
+  @Parent() eventEntry: EventEntry,
+  @Args("validate", { type: () => Boolean, nullable: true, defaultValue: false })
+  validate: boolean,
+): Promise<TeamEnrollmentOutput | null> {
+  const effectiveValidate =
+    validate || this.configService.get<boolean>("ENROLLMENT_VALIDATION_DEFAULT_ENABLED") === true;
+  if (!effectiveValidate) return null;
+  const team = await eventEntry.getTeam();
+  return this.enrollmentValidationCache.getForTeam(team);
+}
+```
+
+Constructor adds `private readonly configService: ConfigService<ConfigType>` (already wired throughout the project — see `app.controller.ts` for the precedent).
+
+### Quickstart
+
+See [quickstart.md](quickstart.md). Local verification:
+
+1. `npm run docker:up`
+2. `nx run-many --target=serve --projects=api,worker-sync --parallel`
+3. Hit GraphiQL or curl with two requests — one without `validate`, one with `validate: true` — and watch the log stream for the new `[caller]` tag.
+
+### Agent context update
+
+Updated `CLAUDE.md` (via `AGENTS.md` symlink) `SPECKIT` block to reference this plan path.
+
+## Constitution Check (post-design re-evaluation)
+
+Re-checked after Phase 1. No new violations introduced by the design (no models added, no translations touched, no mutation work, tests follow the reference pattern, no legacy-frontend edits). Gate **PASS**.
+
+## Complexity Tracking
+
+Not applicable. No violations to justify.

--- a/specs/028-gate-enrollment-validation/quickstart.md
+++ b/specs/028-gate-enrollment-validation/quickstart.md
@@ -1,0 +1,100 @@
+# Quickstart: Local Verification
+
+## Prerequisites
+
+- `npm run docker:up` running (PostgreSQL, Redis, pgAdmin).
+- `.env` populated (Auth0, DB, etc.).
+- Optionally `npm run seed:test-data` for fixture data.
+
+## Run
+
+```bash
+nx run-many --target=serve --projects=api,worker-sync --parallel
+```
+
+API listens on `http://localhost:5010`. GraphQL endpoint at `/graphql` (Playground enabled in development).
+
+## Test 1 — Default (opt-out): no computation
+
+Pick any `EventEntry` ID from the seed data (or your local DB). Send:
+
+```graphql
+query NoOptIn {
+  eventEntries(args: { take: 5 }) {
+    rows {
+      id
+      enrollmentValidation {
+        teams { id }
+      }
+    }
+  }
+}
+```
+
+Expected:
+
+- Every row returns `enrollmentValidation: null`.
+- The API stdout shows **no** `[IndexCalculationService]` log lines for this request.
+
+## Test 2 — Opt-in: validation runs and is tagged
+
+```graphql
+query OptIn {
+  eventEntries(args: { take: 5 }) {
+    rows {
+      id
+      enrollmentValidation(validate: true) {
+        teams { id name }
+      }
+    }
+  }
+}
+```
+
+Expected:
+
+- Rows now include a non-null `enrollmentValidation` payload (where the entry's team has a club + season).
+- API stdout shows lines like:
+  ```text
+  DEBUG [IndexCalculationService] Index calculation: [EnrollmentValidationService.fetchAndValidate] 33 input(s), 117 player ref(s), 352ms
+  ```
+  - Verify the `[EnrollmentValidationService.fetchAndValidate]` caller tag is present.
+  - Verify only ONE batch per `(clubId, season)` even if multiple entries in the response share a club (DataLoader collapsing).
+
+## Test 3 — Kill-switch (env var)
+
+Stop the API. Set:
+
+```bash
+export ENROLLMENT_VALIDATION_DEFAULT_ENABLED=true
+nx run-many --target=serve --projects=api,worker-sync --parallel
+```
+
+Re-run **Test 1** (without `validate`). Now `enrollmentValidation` returns a payload and `[EnrollmentValidationService.fetchAndValidate]` log lines appear — same as Test 2. Unset the env var to restore default-off behavior.
+
+## Test 4 — Write-path caller tags still appear
+
+Trigger a write that recomputes index:
+
+- `mutation { updateTeam(data: { id: "<some-team-id>", phone: "+32 000" }) { id } }`
+
+API stdout should show:
+
+```text
+DEBUG [IndexCalculationService] Index calculation: [TeamsResolver.updateTeam] 1 input(s), 4 player ref(s), 12ms
+```
+
+Confirm the caller-tag matches the mutation. Repeat for `createTeams`, `createEntry`, `calculateIndex`, and an `EventEntry.save()` that mutates `meta.competition` (each tagged distinctly).
+
+## Test 5 — Failure propagation (spec FR-006)
+
+Temporarily break the cache (e.g. point `RankingSystem` primary at a non-existent system, or drop a required column in a transaction) and run **Test 2**. Expected: a GraphQL error surfaces; the response is **not** silently `null`.
+
+## Unit tests
+
+```bash
+nx test backend-graphql
+nx test backend-enrollment
+```
+
+All existing tests pass. New tests cover the four resolver behaviors in [research.md §R-005](research.md#r-005-test-strategy) and the caller-tag rendering in `IndexCalculationService`.

--- a/specs/028-gate-enrollment-validation/research.md
+++ b/specs/028-gate-enrollment-validation/research.md
@@ -1,0 +1,127 @@
+# Phase 0 Research: Gate Enrollment Validation Field
+
+## R-001: How is `IndexCalculationService` invoked from the API process today?
+
+**Decision (verified)**: Three trigger families in the api process.
+
+1. **Read-side GraphQL field traversal** (dominant — root cause of the flood)
+   - `EventEntry.enrollmentValidation` `@ResolveField` at
+     [libs/backend/graphql/src/resolvers/event/entry.resolver.ts:86-95](../../libs/backend/graphql/src/resolvers/event/entry.resolver.ts#L86-L95).
+   - Delegates to `EnrollmentValidationCacheService.getForTeam()` →
+     `EnrollmentValidationService.fetchAndValidate()` →
+     `IndexCalculationService.calculate([3 inputs per team of the club])`
+     at [libs/backend/competition/enrollment/src/services/validate/enrollment.service.ts:247-278](../../libs/backend/competition/enrollment/src/services/validate/enrollment.service.ts#L247-L278).
+   - DataLoader collapses calls to one computation per `(clubId, season)` per request. **No cross-request cache.**
+
+2. **Write-side mutations** (rare; correct behavior)
+   - `TeamsResolver.updateTeam` / `createTeams` at
+     [libs/backend/graphql/src/resolvers/team/team.resolver.ts:375,431](../../libs/backend/graphql/src/resolvers/team/team.resolver.ts).
+   - `EnrollmentEntryService.createEntry` at
+     [libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts:131](../../libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts#L131).
+   - `CalculateIndexResolver.calculateIndex` mutation (explicit recompute).
+
+3. **Sequelize hook** (rare; correct behavior)
+   - `EventEntry.recalculateCompetitionIndex` `@BeforeCreate` / `@BeforeUpdate` at
+     [libs/backend/database/src/models/event/entry.model.ts:226-268](../../libs/backend/database/src/models/event/entry.model.ts#L226-L268). Fires only when `instance.meta` changed AND `meta.competition` exists.
+
+**Rationale**: The 12:27 production logs show batches matching pattern (1) — input sizes 6, 16, 22, 26, 32, 36 with 4 player-refs per input, which corresponds to clubs of 2–12 teams × 3 inputs per team (`base`, `team`, `backup`). The "appname: api" in logs confirms it is the API process, not worker-sync.
+
+**Alternatives considered**: None — this is fact-finding, not a choice.
+
+---
+
+## R-002: Where is the same field name exposed elsewhere?
+
+**Decision (verified)**:
+
+- Sibling resolver at [libs/backend/graphql/src/resolvers/event/competition/enrollment.resolver.ts:25-35](../../libs/backend/graphql/src/resolvers/event/competition/enrollment.resolver.ts#L25-L35) is a **top-level `@Query`** that already requires an explicit `EnrollmentInput` argument (`teams`, `clubId`, `season`). It is already opt-in by construction: a client must build and send the input or no computation occurs. **No additional gate needed there.**
+- No other `enrollmentValidation` field exists in the GraphQL schema (verified via `grep -rn "enrollmentValidation" libs/backend/graphql`).
+
+**Rationale**: Confirms spec FR-003 is satisfied by inspection and avoids needless edits.
+
+---
+
+## R-003: Approach for gating — field arg vs. dedicated query vs. cache
+
+**Decision**: Optional GraphQL field argument with server-controlled default (env-var kill-switch).
+
+**Rationale**:
+
+- **Smallest blast radius**: schema stays backwards-compatible (field still exists, return type unchanged, only an optional new arg). Old query documents continue to validate against the new schema.
+- **Frontend cost is one query string edit** in the active-frontend repo (the wizard query adds `(validate: true)`).
+- **Kill-switch via `ENROLLMENT_VALIDATION_DEFAULT_ENABLED`** lets the platform team revert behavior per-environment without redeploy, satisfying spec FR-010.
+- **No new schema entry point needed** — preserves existing client tooling and codegen.
+
+**Alternatives considered**:
+
+| Option | Rejected because |
+|---|---|
+| Cross-request Redis cache (e.g. 5–60 min TTL by `clubId:season`) | Doesn't help cold-cache stampedes. Validation depends on team rosters, player memberships, and ranking data that change continuously — invalidation surface is large. Doesn't eliminate the computation, only amortizes it; the original incident would still recur on cache-miss bursts. Useful as a follow-up, not as the primary fix. |
+| Dedicated top-level `clubEnrollmentValidation(clubId: ID!, season: Int!)` query | Cleaner long-term API contract. But requires a frontend-repo query-shape change (not just an arg change), so coupling is tighter. Field-argument approach achieves the same runtime outcome with one server edit. Can refactor later without re-doing this work. |
+| Detect sync-worker activity (via DB flag) and skip during sync window | Adds operational coupling between api and worker-sync. The flood would still happen during high-traffic daytime windows. The gate also has to be safe to flip; an env-var is simpler and less surprising. |
+| Disable / remove the `enrollmentValidation` resolver entirely | Breaks the wizard. Non-starter. |
+
+---
+
+## R-004: Should `ENROLLMENT_VALIDATION_DEFAULT_ENABLED` default to `false`?
+
+**Decision**: `false` in all environments (development, staging, production).
+
+**Rationale**:
+
+- The fix is only effective if the default is `false`. A `true` default in development would mask whether the wizard's opt-in is actually wired up correctly — bugs would only surface in production where the default is `false`.
+- A `false` default in development matches production behavior, eliminating environment drift.
+- The platform team can still flip it temporarily via env var on a per-environment basis if the active frontend lags behind the backend deploy.
+
+**Alternatives considered**:
+
+- `true` in dev, `false` in prod: rejected — masks rollout bugs.
+- Per-request header override (e.g. `x-validate-enrollment: true`): rejected — overlaps with the GraphQL arg and adds two ways to express the same intent.
+
+---
+
+## R-005: Test strategy
+
+**Decision**: Unit tests only, mirroring the resolver-test convention in [enrollmentSetting.resolver.spec.ts](../../libs/backend/graphql/src/resolvers/enrollmentSetting/enrollmentSetting.resolver.spec.ts).
+
+Coverage:
+
+1. `EventEntry.enrollmentValidation` resolver
+   - Returns `null` when `validate` omitted and env flag false (no cache call).
+   - Returns `null` when `validate: false` and env flag false.
+   - Delegates to `EnrollmentValidationCacheService.getForTeam` when `validate: true`.
+   - Delegates to `EnrollmentValidationCacheService.getForTeam` when `validate` omitted and env flag true (kill-switch path).
+   - Surfaces cache failure (rejected promise) instead of swallowing to `null` (spec FR-006).
+2. `IndexCalculationService`
+   - When `options.caller` is provided, both DEBUG and WARN log lines include `[<caller>]`.
+   - When `options.caller` is absent, log lines render without the tag (backwards-compatible format for log parsers, if any).
+3. Existing tests for `enrollment.service.ts`, `team.resolver.ts`, `entry.model.ts`, `calculate-index.resolver.ts` continue to pass after the `caller` argument addition.
+
+No integration test against a real database. No e2e test. No frontend test (separate repo).
+
+**Rationale**: The change is structural (schema-level + log-level), not behavioral inside the computation. Existing integration coverage of `EnrollmentValidationService` is unaffected.
+
+---
+
+## R-006: Rollout sequencing
+
+**Decision**: Single PR deploys server with default-off; second PR (in frontend repo) adds the opt-in to the wizard.
+
+**Sequencing**:
+
+1. Deploy backend with the gate. Active-frontend wizard temporarily receives `null` from `enrollmentValidation`.
+2. If the wizard breaks visibly, platform team sets `ENROLLMENT_VALIDATION_DEFAULT_ENABLED=true` as a temporary kill-switch.
+3. Active-frontend PR adds `(validate: true)` to the wizard query. Deploy.
+4. Confirm wizard renders correctly. Unset the kill-switch (or leave it at `false`).
+
+**Rationale**: The kill-switch makes the deploy reversible without a backend redeploy, removing the need to ship both repos in lockstep.
+
+**Alternatives considered**:
+
+- Ship both repos in lockstep: possible but operationally tighter; the kill-switch makes lockstep unnecessary.
+
+---
+
+## Open questions
+
+None. All NEEDS CLARIFICATION items from the spec phase were resolved during specification.

--- a/specs/028-gate-enrollment-validation/spec.md
+++ b/specs/028-gate-enrollment-validation/spec.md
@@ -1,0 +1,139 @@
+# Feature Specification: Gate Enrollment Validation Field
+
+**Feature Branch**: `028-gate-enrollment-validation`
+**Created**: 2026-05-21
+**Status**: Draft
+**Input**: User description: "Stop the IndexCalculationService flood that takes the API down during nightly ranking sync by making the EventEntry.enrollmentValidation GraphQL field opt-in instead of always running."
+
+## Background & Problem Context
+
+During the nightly ranking-sync window, the production API repeatedly fails health checks (`{"database":{"message":"timeout of 1000ms exceeded","status":"down"}}`) and restarts. Investigation shows the trigger is **not** ranking-sync itself — sync runs in the separate `worker-sync` process. The API process logs (`appname: 'api'`) show hundreds of `Slow index calculation` warnings emitted by `IndexCalculationService`, with durations climbing from ~1.5 s to ~29 s as the sync worker saturates the shared database.
+
+The root cause is that the GraphQL field resolver `EventEntry.enrollmentValidation` currently:
+
+- Has no field argument — it executes on every request that selects it.
+- Triggers a **club-wide** validation (every team of the club, three index inputs per team: base / team / backup).
+- Is cached only per request via a `DataLoader` — there is no cross-request cache.
+
+So any client (e.g. a page rendering encounters, team listings, score-entry screens) that traverses an `EventEntry` and asks for the `enrollmentValidation` field forces a heavy multi-table scan per club. During sync, the database has no spare capacity → calls slow down → health checks time out → the API restarts → the cycle repeats.
+
+The fix is to make this expensive computation **opt-in**: only the enrollment-wizard screen actually needs it. All other consumers should get `null` and not pay the cost.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Quiet API during nightly sync (Priority: P1)
+
+As the platform operator, when the nightly ranking-sync cron runs, I need the public API to remain responsive and pass health checks, so that end users hitting the app at night still see content and the API process is not killed by the orchestrator's restart loop.
+
+**Why this priority**: This is the production incident driving the work. Health-check failures cause API restarts that lose in-flight requests and trigger pager noise. P1.
+
+**Independent Test**: Trigger the sync window in a staging environment (or simulate by running the sync worker against the staging DB) while a synthetic client polls representative GraphQL queries that previously caused the flood. Verify no `Slow index calculation` warnings appear from un-related queries, and health-check endpoints stay green throughout.
+
+**Acceptance Scenarios**:
+
+1. **Given** the sync worker is actively writing ranking data, **When** a GraphQL query that traverses `EventEntry` records is made without explicitly opting in to enrollment validation, **Then** the response returns `enrollmentValidation: null` and no `IndexCalculationService` calculation is performed.
+2. **Given** the sync worker is actively writing ranking data, **When** the platform's automated health-check pings the API, **Then** it succeeds within the 1 s database timeout.
+3. **Given** a 24-hour observation window covering at least one nightly sync, **When** the system is queried for `Slow index calculation` log occurrences from background (non-enrollment-wizard) traffic, **Then** the count is zero.
+
+---
+
+### User Story 2 — Enrollment wizard still works (Priority: P1)
+
+As a club admin using the enrollment wizard, when I review my club's teams for the upcoming season, I need to still see the per-team enrollment validation (rule violations, computed team index, contributing players, etc.) so that I can finalize my submissions.
+
+**Why this priority**: The change must not break the one consumer that legitimately needs the data. If the wizard breaks the rollout is reverted. P1.
+
+**Independent Test**: Open the enrollment wizard for a representative club in a staging environment after the change is deployed and verify the same validation output as before is shown for every team. Compare side-by-side against a pre-change baseline of the same club/season.
+
+**Acceptance Scenarios**:
+
+1. **Given** the enrollment wizard is opened for a club and season, **When** the wizard requests enrollment validation explicitly, **Then** the same validation result (team indices, rule failures, base/team/backup ranks) is returned as before the change.
+2. **Given** the wizard renders a club with 12 teams, **When** the validation completes, **Then** exactly one club-wide computation happens per request (not 12).
+
+---
+
+### User Story 3 — Other screens are unaffected (Priority: P2)
+
+As a regular user (player, captain, spectator) browsing the app — looking at encounters, standings, my own profile, my team's roster — I should never trigger a club-wide validation computation just by loading a page.
+
+**Why this priority**: Same root cause as Story 1, but observed during normal daytime traffic. Reducing background load improves performance broadly. P2.
+
+**Independent Test**: Drive an automated walk-through of the public-facing pages and inspect API logs. No `Index calculation` (DEBUG or WARN) entries should appear from those flows.
+
+**Acceptance Scenarios**:
+
+1. **Given** a player profile page, an encounter detail page, or a team roster page is opened, **When** the page completes loading, **Then** no `IndexCalculationService` log entry is produced from that request.
+2. **Given** any client that previously consumed the `enrollmentValidation` field without opting in, **When** it inspects the response, **Then** it sees the field key still present in the schema with a `null` value (no breaking schema removal).
+
+---
+
+### User Story 4 — Diagnostics for the next incident (Priority: P3)
+
+As an engineer investigating a future regression, when I see a `Slow index calculation` warning in the logs, I want to know which code path triggered it so I can narrow the cause within minutes instead of hours.
+
+**Why this priority**: This is a defensive add-on, not load-bearing for the fix. P3.
+
+**Independent Test**: After the change, trigger each known caller (enrollment wizard, team-create mutation, entry-save hook) once and confirm the log line names the caller.
+
+**Acceptance Scenarios**:
+
+1. **Given** any `IndexCalculationService` log line (DEBUG or WARN), **When** I read it, **Then** it includes a stable caller identifier (e.g. `"EnrollmentValidationService.fetchAndValidate"`, `"TeamsResolver.createTeams"`, `"EventEntry hook"`).
+
+---
+
+### Edge Cases
+
+- A query asks for `enrollmentValidation` with the opt-in **false**: must return `null` and skip computation entirely (no DB hit, no logs).
+- A query asks for `enrollmentValidation` without supplying the argument: must default to the opt-out behavior (return `null`) — never silently compute.
+- Multiple teams of the same club appear in one request and the client opts in: must collapse to one underlying club computation (existing per-request DataLoader behavior preserved).
+- The opted-in computation fails internally: must surface a clear error to the caller, not a silent `null`, so the wizard distinguishes "not requested" from "computation failed".
+- An entry's `meta.competition` is updated by a server-side write (e.g. team create / update mutation, sync worker writing player rosters from Visual): the existing per-entry `IndexCalculationService` recomputation on save MUST still run — that path is correct and rare and is **not** what's flooding the logs.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The `EventEntry.enrollmentValidation` GraphQL field MUST accept an opt-in argument and MUST return `null` without invoking any underlying computation when the argument is omitted or set to false.
+- **FR-002**: When the opt-in argument is set to true, the field MUST return the same validation payload that the existing implementation returns today (no change to the shape, set of fields, or values).
+- **FR-003**: The same opt-in semantics MUST apply to every GraphQL field in the schema that today delegates to `EnrollmentValidationCacheService` / `EnrollmentValidationService.fetchAndValidate` (i.e. the sibling `enrollmentValidation` resolver on the competition-enrollment graph node, if present).
+- **FR-004**: Within a single GraphQL request, multiple opted-in lookups for the same `(clubId, season)` MUST collapse to one underlying validation (preserve current per-request DataLoader behavior).
+- **FR-005**: The change MUST NOT remove the `enrollmentValidation` field from the schema, MUST NOT rename it, and MUST NOT change its return type — only add the argument.
+- **FR-006**: When the opted-in computation fails internally (e.g. database error, missing ranking system), the response MUST surface the failure to the caller. It MUST NOT return a misleading `null` (which is now reserved for "not requested").
+- **FR-007**: Server-side write paths that legitimately recompute index data (entry-save hook, team create/update mutations, explicit calculate-index mutation, enrollment-entry create) MUST continue to function unchanged.
+- **FR-008**: Every `IndexCalculationService` log line (DEBUG and WARN) MUST include a stable caller identifier so a triage engineer can distinguish hot paths in production logs.
+- **FR-009**: Existing unit tests for resolvers and the enrollment validation service MUST continue to pass; new tests MUST cover the opt-out (default) and opt-in branches of the gated resolver(s).
+- **FR-010**: A rollout-safety mechanism MUST exist so that if the active frontend has not yet shipped the opt-in argument, the platform team can temporarily flip the default back to "always compute" without redeploying schema changes (e.g. a configuration knob).
+
+### Key Entities *(include if feature involves data)*
+
+- **EventEntry**: A team's entry into a sub-event. Carries the per-team enrollment metadata (`meta.competition.players` etc.). The GraphQL field under change is one of its resolvers; the underlying record is unchanged.
+- **Enrollment Validation Result**: Existing computed object describing a club's teams and per-team rule violations and indices. Unchanged in shape; only **when** it is computed changes.
+- **IndexCalculationService log event**: The slow/normal log line emitted per `calculate(...)` call. Gains a caller identifier under FR-008.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: During the nightly sync window, zero `Health Check has failed!` events caused by database timeout, measured across at least 14 consecutive nights post-deploy. (Baseline: multiple failures per night, observed 2026-05-21.)
+- **SC-002**: Across a representative 24-hour production window, the volume of `IndexCalculationService` log entries from non-enrollment-wizard traffic drops by at least 95% compared to the 24-hour window prior to deploy.
+- **SC-003**: The enrollment-wizard end-to-end flow (open wizard → see per-team validation for all teams of a club → submit) completes successfully for the test club in staging, with identical validation output before and after the change.
+- **SC-004**: When a triage engineer searches production logs for a single `Slow index calculation` warning, they can identify the originating code path in under 30 seconds from the log line alone, without needing to attach a debugger or open additional dashboards.
+- **SC-005**: No regression in p95 latency of the enrollment-wizard query under typical club sizes (≤ 36 teams) compared to the pre-change baseline.
+
+## Assumptions
+
+- The active (Next.js) frontend lives in a separate repository. A coordinated change there (or a runtime config flip — see FR-010) is required so that the enrollment wizard explicitly opts in. The legacy Angular frontend in this repo is reference-only per `CLAUDE.md` and is not maintained.
+- The current production cron schedule and worker topology (api process schedules crons, worker-sync runs sync jobs, both share the same Postgres instance) are out of scope. This work does not change them; it only stops the API process from generating background load that competes with the worker.
+- Cross-request caching of validation results (e.g. Redis with TTL) is a possible follow-up but is **not** in scope here. The opt-in gate is sufficient to remove the production incident.
+- The 1 s database health-check timeout is treated as a fixed environmental constraint. The fix removes the source of contention rather than relaxing the timeout.
+- `IndexCalculationService.calculate` paths invoked by server-side **writes** (entry-save hook, team mutations, enrollment-entry create, explicit calculate-index mutation) are rare and correct, and are not the cause of the flood. They remain enabled by default and unchanged.
+- "Stable caller identifier" (FR-008) is a free-form short string the developer sets at each call site; no enum or central registry is required.
+
+## Out of Scope
+
+- Cross-request caching of enrollment validation results.
+- Splitting `enrollmentValidation` into a dedicated top-level GraphQL query (could be a future refactor, but the field-argument gate achieves the same effect with smaller blast radius).
+- Disabling or rescheduling the ranking-sync cron, or changing connection-pool sizing.
+- Changes to the active frontend (separate repository, separate ticket).
+- Removing the legacy Angular consumer (legacy, not maintained).
+- Changes to the entry-save hook recompute path.

--- a/specs/028-gate-enrollment-validation/spec.md
+++ b/specs/028-gate-enrollment-validation/spec.md
@@ -5,6 +5,14 @@
 **Status**: Draft
 **Input**: User description: "Stop the IndexCalculationService flood that takes the API down during nightly ranking sync by making the EventEntry.enrollmentValidation GraphQL field opt-in instead of always running."
 
+## Clarifications
+
+### Session 2026-05-21
+
+- Q: When the rollout-safety mechanism (FR-010) is engaged and a client explicitly sends `validate: false`, what wins? → A: Explicit caller intent always wins. `validate: false` returns `null`; the rollout-safety override only fills in when the argument is omitted.
+- Q: How is SC-002's "non-enrollment-wizard traffic" attributed in logs? → A: Drop the wizard/non-wizard split. Measure the total `IndexCalculationService` log volume drop instead.
+- Q: Does FR-003 require a code change at the sibling `EnrollmentResolver.enrollmentValidation` resolver? → A: No. The sibling is a top-level `Query` already requiring an explicit `EnrollmentInput` argument; it is opt-in by construction. FR-003 is satisfied by inspection.
+
 ## Background & Problem Context
 
 During the nightly ranking-sync window, the production API repeatedly fails health checks (`{"database":{"message":"timeout of 1000ms exceeded","status":"down"}}`) and restarts. Investigation shows the trigger is **not** ranking-sync itself — sync runs in the separate `worker-sync` process. The API process logs (`appname: 'api'`) show hundreds of `Slow index calculation` warnings emitted by `IndexCalculationService`, with durations climbing from ~1.5 s to ~29 s as the sync worker saturates the shared database.
@@ -83,8 +91,8 @@ As an engineer investigating a future regression, when I see a `Slow index calcu
 
 ### Edge Cases
 
-- A query asks for `enrollmentValidation` with the opt-in **false**: must return `null` and skip computation entirely (no DB hit, no logs).
-- A query asks for `enrollmentValidation` without supplying the argument: must default to the opt-out behavior (return `null`) — never silently compute.
+- A query asks for `enrollmentValidation` with the opt-in **false**: must return `null` and skip computation entirely (no DB hit, no logs), even if the rollout-safety override is engaged.
+- A query asks for `enrollmentValidation` without supplying the argument: must default to the opt-out behavior (return `null`) — never silently compute. The only exception is when the rollout-safety override is engaged, in which case omitted-argument requests fall through to computation per FR-010.
 - Multiple teams of the same club appear in one request and the client opts in: must collapse to one underlying club computation (existing per-request DataLoader behavior preserved).
 - The opted-in computation fails internally: must surface a clear error to the caller, not a silent `null`, so the wizard distinguishes "not requested" from "computation failed".
 - An entry's `meta.competition` is updated by a server-side write (e.g. team create / update mutation, sync worker writing player rosters from Visual): the existing per-entry `IndexCalculationService` recomputation on save MUST still run — that path is correct and rare and is **not** what's flooding the logs.
@@ -95,14 +103,14 @@ As an engineer investigating a future regression, when I see a `Slow index calcu
 
 - **FR-001**: The `EventEntry.enrollmentValidation` GraphQL field MUST accept an opt-in argument and MUST return `null` without invoking any underlying computation when the argument is omitted or set to false.
 - **FR-002**: When the opt-in argument is set to true, the field MUST return the same validation payload that the existing implementation returns today (no change to the shape, set of fields, or values).
-- **FR-003**: The same opt-in semantics MUST apply to every GraphQL field in the schema that today delegates to `EnrollmentValidationCacheService` / `EnrollmentValidationService.fetchAndValidate` (i.e. the sibling `enrollmentValidation` resolver on the competition-enrollment graph node, if present).
+- **FR-003**: The same opt-in semantics MUST apply to every GraphQL field in the schema that today delegates to `EnrollmentValidationCacheService` / `EnrollmentValidationService.fetchAndValidate`. The sibling resolver `EnrollmentResolver.enrollmentValidation` (top-level `Query` at `libs/backend/graphql/src/resolvers/event/competition/enrollment.resolver.ts:28`) is opt-in by construction — it requires a non-default `EnrollmentInput` argument and cannot fire on accidental field traversal — and therefore satisfies FR-003 without code changes. Any future delegating resolver MUST adopt the same opt-in pattern.
 - **FR-004**: Within a single GraphQL request, multiple opted-in lookups for the same `(clubId, season)` MUST collapse to one underlying validation (preserve current per-request DataLoader behavior).
 - **FR-005**: The change MUST NOT remove the `enrollmentValidation` field from the schema, MUST NOT rename it, and MUST NOT change its return type — only add the argument.
 - **FR-006**: When the opted-in computation fails internally (e.g. database error, missing ranking system), the response MUST surface the failure to the caller. It MUST NOT return a misleading `null` (which is now reserved for "not requested").
 - **FR-007**: Server-side write paths that legitimately recompute index data (entry-save hook, team create/update mutations, explicit calculate-index mutation, enrollment-entry create) MUST continue to function unchanged.
 - **FR-008**: Every `IndexCalculationService` log line (DEBUG and WARN) MUST include a stable caller identifier so a triage engineer can distinguish hot paths in production logs.
 - **FR-009**: Existing unit tests for resolvers and the enrollment validation service MUST continue to pass; new tests MUST cover the opt-out (default) and opt-in branches of the gated resolver(s).
-- **FR-010**: A rollout-safety mechanism MUST exist so that if the active frontend has not yet shipped the opt-in argument, the platform team can temporarily flip the default back to "always compute" without redeploying schema changes (e.g. a configuration knob).
+- **FR-010**: A rollout-safety mechanism MUST exist so that if the active frontend has not yet shipped the opt-in argument, the platform team can temporarily flip the default back to "always compute" without redeploying schema changes (e.g. a configuration knob). The mechanism MUST only take effect when the caller omits the opt-in argument. An explicit `validate: false` from the caller MUST always return `null` regardless of the rollout-safety setting (explicit caller intent wins).
 
 ### Key Entities *(include if feature involves data)*
 
@@ -115,7 +123,7 @@ As an engineer investigating a future regression, when I see a `Slow index calcu
 ### Measurable Outcomes
 
 - **SC-001**: During the nightly sync window, zero `Health Check has failed!` events caused by database timeout, measured across at least 14 consecutive nights post-deploy. (Baseline: multiple failures per night, observed 2026-05-21.)
-- **SC-002**: Across a representative 24-hour production window, the volume of `IndexCalculationService` log entries from non-enrollment-wizard traffic drops by at least 95% compared to the 24-hour window prior to deploy.
+- **SC-002**: Across a representative 24-hour production window, the total volume of `IndexCalculationService` log entries (DEBUG + WARN combined) drops by at least 95% compared to the 24-hour window prior to deploy. Wizard-versus-non-wizard attribution is intentionally NOT required for this measurement — a single aggregate count is sufficient. (Wizard traffic is small enough relative to the pre-fix flood that the 95% drop holds in aggregate.)
 - **SC-003**: The enrollment-wizard end-to-end flow (open wizard → see per-team validation for all teams of a club → submit) completes successfully for the test club in staging, with identical validation output before and after the change.
 - **SC-004**: When a triage engineer searches production logs for a single `Slow index calculation` warning, they can identify the originating code path in under 30 seconds from the log line alone, without needing to attach a debugger or open additional dashboards.
 - **SC-005**: No regression in p95 latency of the enrollment-wizard query under typical club sizes (≤ 36 teams) compared to the pre-change baseline.
@@ -134,6 +142,10 @@ As an engineer investigating a future regression, when I see a `Slow index calcu
 - Cross-request caching of enrollment validation results.
 - Splitting `enrollmentValidation` into a dedicated top-level GraphQL query (could be a future refactor, but the field-argument gate achieves the same effect with smaller blast radius).
 - Disabling or rescheduling the ranking-sync cron, or changing connection-pool sizing.
-- Changes to the active frontend (separate repository, separate ticket).
+- Changes to the active frontend (separate repository, separate ticket — tracked as [BAD-228](https://linear.app/dashdot/issue/BAD-228) "Wire `validate: true` into enrollmentValidation queries").
 - Removing the legacy Angular consumer (legacy, not maintained).
 - Changes to the entry-save hook recompute path.
+
+## Related work
+
+- **Frontend follow-up**: [BAD-228](https://linear.app/dashdot/issue/BAD-228) — adds `(validate: true)` to every `enrollmentValidation` selection in the active frontend repo. Must ship with or shortly after this spec's backend deploy; the kill-switch `ENROLLMENT_VALIDATION_DEFAULT_ENABLED=true` is the temporary safety net if the FE rollout lags (see FR-010).

--- a/specs/028-gate-enrollment-validation/tasks.md
+++ b/specs/028-gate-enrollment-validation/tasks.md
@@ -1,0 +1,232 @@
+---
+description: "Task list for gate-enrollment-validation feature"
+---
+
+# Tasks: Gate Enrollment Validation Field
+
+**Input**: Design documents from `/specs/028-gate-enrollment-validation/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/graphql-schema-delta.md, quickstart.md
+
+**Tests**: Included. Spec FR-009 requires new unit tests covering the opt-out and opt-in branches; plan §"Phase 1 Design" pins these as part of the deliverable.
+
+**Organization**: Grouped by user story so each can be implemented, tested, and verified independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Nx monorepo (no new project). All edits under existing libs:
+
+- `libs/backend/graphql/src/resolvers/event/`
+- `libs/backend/competition/enrollment/src/services/`
+- `libs/backend/graphql/src/resolvers/team/`
+- `libs/backend/graphql/src/resolvers/event/competition/`
+- `libs/backend/database/src/models/event/`
+- `libs/utils/src/config/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Wire the rollout-safety kill-switch into the platform's central config schema so every consumer sees the same flag.
+
+- [ ] T001 Add `ENROLLMENT_VALIDATION_DEFAULT_ENABLED: Joi.boolean().optional().default(false)` to the Joi `configSchema` in `libs/utils/src/config/configuration.ts` (alongside the other boolean toggles such as `DB_CACHE`, `VISUAL_SYNC_ENABLED`).
+- [ ] T002 Add `ENROLLMENT_VALIDATION_DEFAULT_ENABLED: process.env?.["ENROLLMENT_VALIDATION_DEFAULT_ENABLED"] === "true"` to the `load()` return object in `libs/utils/src/config/configuration.ts` so the env value is parsed into a boolean.
+- [ ] T003 Add `ENROLLMENT_VALIDATION_DEFAULT_ENABLED: boolean;` to the `ConfigType` declaration in `libs/utils/src/config/configuration.ts` so resolvers can type-safely read it via `ConfigService<ConfigType>`.
+
+**Checkpoint**: `nx build utils` succeeds. The new flag is visible to all consumers that import `ConfigType` from `@badman/utils`.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: None. The setup phase produces the only cross-story prerequisite (the config flag). No additional foundational scaffolding is required because the change set is one resolver edit + one service-signature extension; there are no shared models, no migrations, and no new modules.
+
+---
+
+## Phase 3: User Story 1 — Quiet API during nightly sync (Priority: P1) 🎯 MVP
+
+**Goal**: `EventEntry.enrollmentValidation` returns `null` and performs no DB work when the caller does not opt in. This single change removes the production flood and is the MVP.
+
+**Independent Test**: Start `api` + `worker-sync` locally; run a GraphQL query that selects `enrollmentValidation` on several `EventEntry` rows **without** passing the `validate` argument; confirm every response field is `null` and that no `[IndexCalculationService]` log line is emitted for the request (matches spec User Story 1 Acceptance Scenario 1 and Quickstart Test 1).
+
+### Tests for User Story 1
+
+- [ ] T004 [P] [US1] In `libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts`, add a new `describe("EventEntryResolver.enrollmentValidation (gate)")` block following the conventions of the existing `finishEventEntry` describe block in the same file (`Test.createTestingModule`, mocked `ConfigService`, mocked `EnrollmentValidationCacheService`, `afterEach(jest.restoreAllMocks)`). Add a test: when `validate` is omitted and `ENROLLMENT_VALIDATION_DEFAULT_ENABLED` is `false`, the resolver returns `null` and `enrollmentValidationCache.getForTeam` is NOT called.
+- [ ] T005 [P] [US1] Same file: add a test that when `validate: false` is passed and `ENROLLMENT_VALIDATION_DEFAULT_ENABLED` is `false`, the resolver returns `null` and `getForTeam` is NOT called.
+- [ ] T006 [P] [US1] Same file: add a test verifying the resolver does NOT call `eventEntry.getTeam()` when computation is skipped (avoid the unnecessary association fetch).
+
+### Implementation for User Story 1
+
+- [ ] T007 [US1] In `libs/backend/graphql/src/resolvers/event/entry.resolver.ts` (the `enrollmentValidation` `@ResolveField` currently at lines 86–95): inject `private readonly configService: ConfigService<ConfigType>` into the constructor (import `ConfigService` from `@nestjs/config` and `ConfigType` from `@badman/utils` — see `apps/api/src/app/controllers/app.controller.ts` for the precedent pattern). Add an `@Args("validate", { type: () => Boolean, nullable: true, defaultValue: false }) validate: boolean` parameter to the resolver method. Update the field description to mention the default-null behavior and the opt-in arg.
+- [ ] T008 [US1] In the same resolver method, implement the gate **with explicit-arg precedence** (per spec Clarifications 2026-05-21 Q1): if `validate === false` (received explicitly OR via the default), return `null` without calling `getTeam()` or the cache UNLESS the caller omitted the argument AND `configService.get("ENROLLMENT_VALIDATION_DEFAULT_ENABLED") === true`. To distinguish "explicit false" from "omitted with default-applied", change the `@Args` declaration to `nullable: true` (no `defaultValue`) and type the parameter `validate?: boolean`; treat `validate === undefined` as "omitted" (kill-switch applies) and `validate === false` as "explicit false" (always returns `null`).
+- [ ] T009 [US1] Run `nx test backend-graphql -- --testPathPattern=entry.resolver` and confirm all three new tests pass and existing `finishEventEntry` tests still pass.
+
+**Checkpoint**: Default-off behavior is wired. Spec Acceptance Scenarios US1#1 and Edge Case "opt-in false → null even with kill-switch" pass in unit tests.
+
+---
+
+## Phase 4: User Story 2 — Enrollment wizard still works (Priority: P1)
+
+**Goal**: When a caller opts in via `validate: true`, the resolver returns the same payload the legacy implementation did, and the existing per-request DataLoader (`EnrollmentValidationCacheService`) still collapses multiple lookups for the same `(clubId, season)` into a single underlying computation.
+
+**Independent Test**: Run a GraphQL query that selects `enrollmentValidation(validate: true)` for 5+ `EventEntry` rows from a club with multiple teams; confirm the response payload is non-null for each row and that exactly ONE `[IndexCalculationService]` `Index calculation: ... input(s)` log line appears per unique `(clubId, season)` in the response (matches spec US2 Acceptance Scenarios and Quickstart Test 2).
+
+### Tests for User Story 2
+
+- [ ] T010 [P] [US2] In `libs/backend/graphql/src/resolvers/event/entry.resolver.spec.ts`, add a test: when `validate: true` is passed, the resolver calls `eventEntry.getTeam()` once and `enrollmentValidationCache.getForTeam(team)` once, and returns the cache's resolved value verbatim.
+- [ ] T011 [P] [US2] Same file: add a test for the kill-switch path — when `validate` is omitted AND `ENROLLMENT_VALIDATION_DEFAULT_ENABLED` is `true`, the resolver behaves identically to `validate: true` (delegates to the cache).
+- [ ] T012 [P] [US2] Same file: add a test that when `validate: true` is passed but `enrollmentValidationCache.getForTeam` rejects (simulated `new Error("DB down")`), the rejection is surfaced to the caller (the resolver does NOT swallow it into `null`). This pins spec FR-006 / Edge Case "computation fails internally".
+
+### Implementation for User Story 2
+
+- [ ] T013 [US2] No new resolver edits beyond US1. Verify the resolver path from T008 already calls `enrollmentValidationCache.getForTeam(team)` when `validate === true` (or when omitted + kill-switch on) and returns its result unchanged. If the rejection-propagation test (T012) fails because of a defensive try/catch, remove the try/catch — the resolver must not catch.
+- [ ] T014 [US2] Manual verification: run `nx run-many --target=serve --projects=api,worker-sync --parallel`, execute Quickstart Test 2 in `specs/028-gate-enrollment-validation/quickstart.md` against local data, and confirm the log line shows ONE batch per `(clubId, season)`.
+
+**Checkpoint**: Wizard query still works end-to-end. Spec Acceptance Scenarios US2#1, US2#2 and FR-002/FR-004/FR-006 pass.
+
+---
+
+## Phase 5: User Story 3 — Other screens are unaffected (Priority: P2)
+
+**Goal**: Non-wizard pages (player profile, encounter detail, team roster, score-entry) produce zero `[IndexCalculationService]` log lines per request.
+
+**Independent Test**: Manually load each of the listed pages in the active frontend (or simulate via curl/Insomnia against `/graphql`) and confirm the API log stream shows zero `[IndexCalculationService]` lines tied to those requests.
+
+### Tests for User Story 3
+
+No new unit tests required. US3 is the observable consequence of US1's default-null gate; the resolver-level tests in T004–T006 already pin the behavior. Verification is operational.
+
+### Implementation for User Story 3
+
+- [ ] T015 [US3] Manual verification: run Quickstart Test 1 in `specs/028-gate-enrollment-validation/quickstart.md` and confirm log silence for representative public-facing queries (`eventEntries`, `team(id:)`, `encounterCompetitions`).
+- [ ] T016 [US3] Document in `specs/028-gate-enrollment-validation/quickstart.md` (or a new `verification-log.md`) the exact queries used for verification and the log evidence (zero `[IndexCalculationService]` lines) so future regression checks can replay them. Optional if the same evidence is captured in PR description.
+
+**Checkpoint**: Spec Acceptance Scenarios US3#1, US3#2 and Success Criteria SC-002 verified empirically.
+
+---
+
+## Phase 6: User Story 4 — Diagnostics for the next incident (Priority: P3)
+
+**Goal**: Every `[IndexCalculationService]` log line (DEBUG and WARN) carries a stable caller identifier so a triage engineer can attribute the call path from the log line alone (spec FR-008, SC-004).
+
+**Independent Test**: Trigger each call site once (wizard query with `validate: true`, `updateTeam` mutation, `createTeams` mutation, `createEntry` mutation, `calculateIndex` mutation, and an `EventEntry.save()` that mutates `meta.competition`) and confirm each emits a log line of the form `[<CallerTag>] N input(s), M player ref(s), Xms` with the correct tag.
+
+### Tests for User Story 4
+
+- [ ] T017 [P] [US4] In `libs/backend/competition/enrollment/src/services/index-calculation/index-calculation.service.spec.ts`, add a test: when `calculate(inputs, { caller: "TestCaller" })` is invoked and the duration exceeds the 1000 ms slow threshold (simulate by stubbing `Date.now()`), the WARN log line includes `[TestCaller]`. Use `jest.spyOn(Logger.prototype, "warn")` to capture.
+- [ ] T018 [P] [US4] Same file: add a parallel test for the fast-path DEBUG log line including `[TestCaller]`.
+- [ ] T019 [P] [US4] Same file: add a test that when `options.caller` is omitted, both log lines render WITHOUT the bracketed tag (backwards-compatible format).
+- [ ] T020 [P] [US4] Same file: add a test that `calculateOne(input, { caller: "X" })` forwards `caller` to the underlying `calculate` invocation (so single-input call sites benefit from the same tagging).
+
+### Implementation for User Story 4
+
+- [ ] T021 [US4] In `libs/backend/competition/enrollment/src/services/index-calculation/index-calculation.service.ts`, extend the `calculate(inputs, options?)` signature so `options?: { transaction?: Transaction; caller?: string }`. Forward `caller` into the Sentry span attributes (`span?.setAttribute("index_calc.caller", options.caller)`) and inject it into both log lines: change the existing `this.logger.warn(\`Slow index calculation: ...\`)` and `this.logger.debug(\`Index calculation: ...\`)` to interpolate `${options?.caller ? \` [\${options.caller}]\` : ""}` after the level prefix.
+- [ ] T022 [US4] In the same file, update `calculateOne(input, options?)` to forward `options` unchanged when calling `this.calculate([input], options)`.
+- [ ] T023 [P] [US4] In `libs/backend/competition/enrollment/src/services/validate/enrollment.service.ts` at the `this.indexCalculationService.calculate(indexInputs)` call site (~line 278), pass `{ caller: "EnrollmentValidationService.fetchAndValidate" }` as the second argument.
+- [ ] T024 [P] [US4] In `libs/backend/graphql/src/resolvers/team/team.resolver.ts` at the two `indexCalculationService.calculate(...)` call sites (`updateTeam` ~line 375 and `createTeams` ~line 431), pass `{ caller: "TeamsResolver.updateTeam" }` and `{ caller: "TeamsResolver.createTeams" }` respectively.
+- [ ] T025 [P] [US4] In `libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts` at the `indexCalculationService.calculateOne(...)` call site (~line 131), pass `{ caller: "EnrollmentEntryService.createEntry" }`.
+- [ ] T026 [P] [US4] In `libs/backend/graphql/src/resolvers/event/competition/calculate-index/calculate-index.resolver.ts` at the `indexCalculationService.calculate(...)` call site (~line 85), pass `{ caller: "CalculateIndexResolver.calculateIndex" }`.
+- [ ] T027 [P] [US4] In `libs/backend/database/src/models/event/entry.model.ts` at the `EventEntry.recalculateCompetitionIndex` static hook (~line 243), update the `service.calculateOne(...)` invocation to pass `{ transaction: options?.transaction, caller: "EventEntry.recalculateCompetitionIndex" }`.
+
+**Checkpoint**: `nx test backend-enrollment` passes. Manual verification via Quickstart Test 4 in `specs/028-gate-enrollment-validation/quickstart.md` confirms every caller tag appears.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [ ] T028 [P] Run `nx affected:test` from repo root to confirm no other lib's tests regressed (in particular `backend-graphql`, `backend-enrollment`, `backend-database`).
+- [ ] T029 [P] Run `nx affected:lint` and fix any new ESLint warnings introduced by the resolver edit (most likely: unused imports if `ConfigService` is added but unused in one branch; `@Args` decorator placement).
+- [ ] T030 [P] Run `prettier --check libs/backend/graphql libs/backend/competition libs/backend/database libs/utils` and fix any drift with `prettier --write` on the same paths.
+- [ ] T031 Execute Quickstart Tests 1–5 from `specs/028-gate-enrollment-validation/quickstart.md` end-to-end against a local stack and record the evidence in the PR description.
+- [ ] T032 Add a one-line entry to `docs/tech-debt.md` under "Known compromises" documenting that cross-request caching of enrollment validation is a deferred follow-up (per spec Out of Scope and research R-003). Reference this feature spec by path.
+- [ ] T033 Verify the GraphQL schema dump (if any is checked in or generated by CI) reflects the new `validate: Boolean` argument on `EventEntry.enrollmentValidation`. If a `schema.gql` artifact exists, regenerate it via the existing codegen task; otherwise skip.
+
+**Checkpoint**: All affected tests/lints/format checks green. Spec Success Criteria SC-003 (parity), SC-004 (caller-tag triage), and SC-005 (no p95 regression) verifiable from the PR.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: T001 → T002 → T003 sequential (same file). No dependencies — can start immediately.
+- **Phase 2 (Foundational)**: Empty.
+- **Phase 3 (US1)**: Depends on Phase 1 complete (resolver reads `ConfigService` typed via the new `ConfigType` field). T004–T006 (tests) can run in parallel; T007 → T008 → T009 sequential (T008 edits the file T007 just changed; T009 runs them).
+- **Phase 4 (US2)**: Depends on Phase 3 complete. T010–T012 in parallel; T013 sequential after; T014 manual.
+- **Phase 5 (US3)**: Depends on Phase 3 complete (it's the same resolver edit observed from a different angle).
+- **Phase 6 (US4)**: Independent of Phases 3–5 in principle (different files), so MAY run in parallel with Phases 3–5 if staffed by a second engineer. Service signature change (T021) MUST land before the six call-site updates (T023–T027) so they compile.
+- **Phase 7 (Polish)**: After all stories.
+
+### User Story Dependencies
+
+- **US1**: Independent of others. Implements the gate.
+- **US2**: Reuses US1's resolver edit; the implementation tasks (T013, T014) verify the opt-in branch already produced by T007/T008.
+- **US3**: Pure verification of US1's behavior at the integration layer; no new code.
+- **US4**: Fully independent — different files (`IndexCalculationService` + six call sites). Can ship in the same PR or split into a follow-up if US1–US3 need to merge urgently.
+
+### Parallel Opportunities
+
+- T004, T005, T006 (US1 tests): same file, but each adds a separate `it(...)` block — author them in parallel and stage in one commit.
+- T010, T011, T012 (US2 tests): same file as above; parallel-author, single commit.
+- T017–T020 (US4 service-level tests): same file, parallel-author.
+- T023, T024, T025, T026, T027 (US4 call-site updates): different files, fully parallelizable once T021 lands.
+- T028, T029, T030 (Polish lint/test/format): different commands, parallelizable.
+
+---
+
+## Parallel Example: User Story 4 call-site updates
+
+After T021 (`IndexCalculationService.calculate` signature extension) is merged into the branch, run T023–T027 concurrently:
+
+```bash
+# Each touches a different file; safe to author in parallel:
+Task: "Add caller tag in libs/backend/competition/enrollment/src/services/validate/enrollment.service.ts"
+Task: "Add caller tags in libs/backend/graphql/src/resolvers/team/team.resolver.ts (updateTeam + createTeams)"
+Task: "Add caller tag in libs/backend/graphql/src/resolvers/event/competition/enrollment-entry.service.ts"
+Task: "Add caller tag in libs/backend/graphql/src/resolvers/event/competition/calculate-index/calculate-index.resolver.ts"
+Task: "Add caller tag in libs/backend/database/src/models/event/entry.model.ts (EventEntry hook)"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Phase 1 (T001–T003): config flag wired.
+2. Phase 3 (T004–T009): resolver gate + tests.
+3. **STOP**: deploy to staging behind the kill-switch defaulted to `false`. Validate that the API stays quiet during a simulated sync window.
+4. If the active frontend's wizard query has NOT yet shipped `(validate: true)`, set `ENROLLMENT_VALIDATION_DEFAULT_ENABLED=true` in production as the rollout-safety net (spec FR-010). Otherwise leave the flag unset (`false`).
+5. Deploy to production.
+
+### Incremental Delivery
+
+- Increment 1: Phases 1 + 3 → MVP shipped (US1, US3 observed in production).
+- Increment 2: Phase 4 → wizard parity validated in staging.
+- Increment 3: Phase 6 → caller-tag diagnostics deployed (US4).
+- Increment 4: Phase 7 → polish, lint, format, docs.
+
+### Parallel Team Strategy
+
+Two engineers can split:
+
+- Engineer A: Phases 1, 3, 4, 5 (resolver gate + verification).
+- Engineer B: Phase 6 in parallel (caller-tag plumbing in `IndexCalculationService` and call sites).
+- Both converge on Phase 7.
+
+---
+
+## Notes
+
+- [P] tasks = different files, no incomplete dependency.
+- [Story] label maps each task to a spec user story for traceability.
+- All tests follow the resolver-test convention referenced by Constitution Principle IV (`enrollmentSetting.resolver.spec.ts`).
+- No translations are touched — Constitution Principle II is not engaged.
+- No new mutation — Constitution Principle III is not engaged.
+- No legacy-frontend edits — Constitution Principle V satisfied by inspection.
+- Commit after each task or logical group; coordinate with [auto-commit hook](.specify/extensions/git/git-config.yml).


### PR DESCRIPTION
## Summary

Hotfix to **main** with feat-028 only (no develop work that hasn't been merged to main yet).

The \`enrollmentValidation\` field on \`EventEntry\` was running a full club-wide validation on **every** GraphQL request that selected it, flooding \`IndexCalculationService\` during the nightly ranking-sync window and causing health-check timeouts.

- Add a \`validate: Boolean\` argument to \`enrollmentValidation\` that defaults to returning \`null\`.
  - \`validate: false\` → always \`null\`
  - \`validate: true\` → always compute
  - omitted → falls back to \`ENROLLMENT_VALIDATION_DEFAULT_ENABLED\` env flag (rollout-safety net)
- Tag every \`IndexCalculationService.calculate\` call with a \`caller\` string so slow-warning logs attribute to a source.
- Add tech-debt entry for deferred cross-request caching.
- Ship spec under \`specs/028-gate-enrollment-validation/\`.

## Commits

- \`feat(graphql)\`: gate EventEntry.enrollmentValidation behind opt-in arg
- \`feat(enrollment)\`: tag IndexCalculationService callers in logs
- \`chore(028)\`: lint, format, and tech-debt note
- \`fix(graphql)\`: update dataloader spec for enrollmentValidation gate
- 4× Spec Kit commits (spec / plan / tasks / clarification)

## Test plan

- [x] \`libs/backend/graphql\` entry.resolver + entry.resolver.dataloader specs pass (31 tests)
- [x] \`libs/backend/competition/enrollment\` index-calculation specs pass (28 tests)
- [x] \`libs/backend/graphql\` team.resolver specs pass (22 tests)
- [ ] Deploy with \`ENROLLMENT_VALIDATION_DEFAULT_ENABLED=true\` initially, monitor health-checks for one ranking-sync window, then flip to \`false\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)