### PR TITLE
docs: restore backend encounter games generation estimate docs

### DIFF
--- a/docs/estimates/backend-encounter-games-generation/architecture.md
+++ b/docs/estimates/backend-encounter-games-generation/architecture.md
@@ -1,0 +1,178 @@
+# Architecture: Backend Encounter Games Generation
+
+**Feature:** Generate the 8 encounter games once on the backend from assemblies; frontend consumes `encounter.games` by id; preserve toernooi.nl sync (visualCode).
+
+**References:** [impact_map.md](./impact_map.md), [feature_overview.md](./feature_overview.md), [games-slot-order-and-matchName.md](./games-slot-order-and-matchName.md) (frontend matchName/order semantics).
+
+---
+
+## 1. High-Level Architecture Diagram
+
+```mermaid
+graph TB
+  subgraph Frontend["Frontend (Next.js 15, external repo)"]
+    EditEncounter["edit-encounter equivalent<br/><i>modified</i>"]
+    ResultsStep["Results step<br/>displays encounter.games"]
+  end
+
+  subgraph GraphQL["GraphQL API"]
+    EncounterResolver["EncounterCompetitionResolver<br/><i>modified</i>"]
+    GenerateMutation["generateEncounterGames mutation<br/><i>new</i>"]
+    EncounterQuery["encounterCompetition query"]
+  end
+
+  subgraph Backend["Backend Services"]
+    GenService["EncounterGamesGenerationService<br/><i>new</i>"]
+  end
+
+  subgraph DB["Database (event schema)"]
+    Encounter["EncounterCompetition"]
+    Game["Game"]
+    Assembly["Assembly"]
+    GPM["GamePlayerMembership"]
+  end
+
+  subgraph Worker["Sync Worker"]
+    EncProcessor["encounter.processor<br/><i>modified</i>"]
+    GameProcessor["game.processor<br/><i>modified</i>"]
+    VisualService["VisualService<br/>getGames(eventCode, encounterCode)"]
+  end
+
+  subgraph External["External"]
+    Toernooi["toernooi.nl<br/>matches / EnterScores"]
+  end
+
+  %% (a) Generate games flow
+  EditEncounter -->|"1a. open Results / trigger"| GenerateMutation
+  GenerateMutation -->|"2a. generateEncounterGames(encounterId)"| EncounterResolver
+  EncounterResolver --> GenService
+  GenService -->|"3a. read assemblies, match/create games"| Encounter
+  GenService --> Game
+  GenService --> GPM
+  GenService --> Assembly
+  EncounterResolver -->|"4a. return encounter with games"| ResultsStep
+
+  %% (b) Sync FROM toernooi.nl
+  Toernooi -->|"matches API"| VisualService
+  EncProcessor --> VisualService
+  EncProcessor -->|"queue ProcessSyncCompetitionGame per match"| GameProcessor
+  GameProcessor -->|"find/create by visualCode, set linkId/linkType"| Game
+  EncProcessor -->|"prune DB games not in visual list<br/>(exclude linkType competition)"| Game
+
+  %% (c) Sync TO toernooi.nl (EnterScores)
+  Game -->|"game.visualCode = matchId"| Worker
+  Worker -->|"EnterScores Puppeteer<br/>matchGamesToAssembly, enterGames"| Toernooi
+```
+
+**Legend:**  
+- **New:** `EncounterGamesGenerationService`, `generateEncounterGames` mutation.  
+- **Modified:** encounter resolver (optional auto-trigger), encounter processor (delete guard), game processor (linkId/linkType), Next.js 15 frontend edit-encounter equivalent (external repo; consume `encounter.games`, no client-side generation).
+
+---
+
+## 2. Component Inventory
+
+### New files to create
+
+| File | Type | Responsibility |
+|------|------|----------------|
+| `libs/backend/competition/encounter/src/services/encounter-games-generation.service.ts` (or under existing competition lib) | Service | Input: encounter id or loaded encounter with games, home/away, assemblies. Resolve 8 canonical slots (double1..4, single1..4; MX order from `ASSEMBLY_POSITION_ORDER`). Per slot: gameType, players from assemblies; match existing games by (gameType + player set) or (gameType + empty + visualCode); create missing games with `linkId` = encounter.id, `linkType` = `"competition"`; set `order` only when game has winner (completion order) or null; set matchName/slotIndex if field exists; set `visualCode` when available. Idempotent: no duplicate games per slot. |
+| GraphQL mutation `generateEncounterGames(encounterId: ID)` + resolver method | Resolver | Call `EncounterGamesGenerationService`; return encounter with games (or `{ games: [Game!]! }`). Optionally trigger when loading encounter for edit. |
+| Unit tests for `EncounterGamesGenerationService` | Test | Slot order M/F vs MX, player resolution from assemblies, idempotency, create-missing-only vs reassign. |
+| Integration tests for `generateEncounterGames` + sync/EnterScores | Test | Mutation for 0 vs 8 existing games; sync does not delete competition games; EnterScores with backend-generated games. |
+
+### Existing files to modify
+
+| File | Change |
+|------|--------|
+| `libs/backend/graphql/src/resolvers/event/competition/encounter.resolver.ts` | Add `generateEncounterGames(encounterId)` mutation; optionally auto-trigger generation when loading encounter for edit (product decision). |
+| `libs/backend/graphql/src/resolvers/game/game.resolver.ts` | Document or restrict `createGame` for competition encounters: create only for missing slot or extra games. |
+| `apps/worker/sync/src/app/processors/sync-events-v2/competition/processors/encounter.processor.ts` | When pruning DB games not in visual match list, exclude games where `linkType === "competition"` (or equivalent guard) so backend-generated games without visualCode are not deleted. |
+| `apps/worker/sync/src/app/processors/sync-events-v2/competition/processors/game.processor.ts` | For competition encounter jobs (e.g. job has `encounterId`): set `game.linkId = encounter.id`, `game.linkType = "competition"`. Ensure job payload includes `encounterId` where needed. |
+| `apps/worker/sync/src/app/processors/enter-scores/pupeteer/enterGames.ts`, `matchGamesToAssembly.ts` | Document that form row is found by assembly position (`findGameRowByAssemblyPosition`) and `game.visualCode` is persisted when missing; backend-generated games without visualCode already work. |
+| Next.js 15 frontend (external repo): edit-encounter equivalent | Remove any `createGameObjects` / `getMatchingDatabaseGame` logic; build form from `encounterCompetition.games` (sorted by `order`); bind each card to `game.id`; on save use `updateGame` for existing games by id. |
+| Next.js 15 frontend (external repo): Results step / edit-encounter flow | Add trigger for `generateEncounterGames` (explicit button or on Results step open); after success refetch encounter so `encounter.games` is updated. |
+| Slot order constant | Add shared constant or backend copy of 8-slot order (M/F and MX) aligned with `apps/worker/sync/src/app/processors/enter-scores/pupeteer/assemblyPositions.ts` (`ASSEMBLY_POSITION_ORDER`). |
+
+---
+
+## 3. Data Flow per Feature
+
+### Scenario 1: User opens Results step → generate games → frontend displays encounter.games
+
+1. **User action:** User opens the Results step of edit-encounter (or clicks “Prepare results” / “Generate games”).
+2. **Frontend:** Calls `generateEncounterGames(encounterId)` mutation (or generation is auto-triggered when loading encounter for edit).
+3. **HTTP/GraphQL:** `POST` (or equivalent) with mutation `generateEncounterGames(encounterId: ID)`.
+4. **Auth:** Standard GraphQL auth; user must have permission to edit the encounter/event.
+5. **Resolver:** `EncounterCompetitionResolver.generateEncounterGames(encounterId)` loads encounter with games, home/away, assemblies; calls `EncounterGamesGenerationService.generate(encounter)`.
+6. **Service:** For each of 8 canonical slots (from shared slot order): resolve gameType and player IDs from assemblies; match existing encounter game by (gameType + same player set) or (gameType + empty + visualCode); assign slot (matchName/slotIndex if field exists); do not use `order` for slot. For slots with no matched game: `Game.create(...)` with `linkId = encounter.id`, `linkType = "competition"`, gameType, `GamePlayerMembership`; set `order` only when game has winner (completion order) or null; set matchName/slotIndex if field exists; set `visualCode` if available.
+7. **DB:** Read `EncounterCompetition`, `Game`, `Assembly`; create/update `Game`, `GamePlayerMembership`; no new tables.
+8. **Response:** Return encounter (with games) or `{ games: [Game!]! }`; client refetches or merges.
+9. **Frontend:** Displays `encounter.games` sorted by `order`; each card bound to `game.id`; save uses `updateGame` by id.
+
+**Key:** `generateEncounterGames` mutation; `EncounterGamesGenerationService`; `EncounterCompetition`, `Game`, `Assembly`, `GamePlayerMembership`.
+
+---
+
+### Scenario 2: Sync from toernooi.nl → encounter processor → game processor → games with visualCode; backend generation can assign slot/players
+
+1. **Trigger:** Sync worker runs ProcessSyncCompetitionEncounter for an encounter.
+2. **Encounter processor** (`encounter.processor.ts`): Fetches matches from toernooi via `VisualService.getGames(eventCode, encounterCode)`. For each match, queues `ProcessSyncCompetitionGame` with `gameCode: match.Code`. Builds set of visual match codes present on toernooi.
+3. **Prune step:** Removes DB games whose `visualCode` is not in the visual list **except** games with `linkType === "competition"` (guard so backend-generated games without visualCode are not deleted).
+4. **Game processor** (`game.processor.ts`): For each job, finds or creates game by `visualCode` (gameCode). For competition encounter jobs (payload has `encounterId`): sets `game.linkId = encounter.id`, `game.linkType = "competition"` (not draw.id / "tournament"). Updates game fields from sync payload.
+5. **DB:** `Game` created/updated with `visualCode`, `linkId`, `linkType`; optionally `GamePlayerMembership` from sync if applicable.
+6. **Backend generation:** When `generateEncounterGames` runs later, it can match these games by visualCode (and gameType + empty players), assign slot (order/matchName) and players from assemblies, and create only missing slots.
+
+**Key:** Encounter processor (VisualService, queue game jobs, prune with competition guard); game processor (find/create by visualCode, set linkId/linkType for competition); `Game.visualCode`, `Game.linkId`, `Game.linkType`.
+
+---
+
+### Scenario 3: Sync to toernooi.nl (EnterScores) — form row by assembly position
+
+1. **Trigger:** EnterScores job runs for an encounter (Puppeteer).
+2. **Worker:** Loads encounter with games; `matchGamesToAssembly` maps DB games to assembly positions (by player set or visualCode).
+3. **enterGames:** For each game (by assembly position), `findGameRowByAssemblyPosition` finds the form row by header/position (does not require `game.visualCode`); fills players and scores; if `game.visualCode` was missing or wrong, sets it to the discovered matchId and persists to DB.
+4. **Toernooi.nl:** Form submitted with matchId; scores and winner updated. Games without visualCode can be pushed; visualCode is set and saved during EnterScores.
+
+**Key:** Form row resolved by assembly position; `enterGames.ts`, `matchGamesToAssembly.ts`, `findGameRowByAssemblyPosition`; visualCode persisted when missing.
+
+---
+
+## 4. Shared Utilities / Reusable Patterns
+
+| Item | API / location | Used by |
+|------|-----------------|--------|
+| Canonical slot order (M/F and MX) | Constant aligned with `ASSEMBLY_POSITION_ORDER` in `apps/worker/sync/src/app/processors/enter-scores/pupeteer/assemblyPositions.ts`; backend copy or shared util in competition lib | `EncounterGamesGenerationService`, sync worker (matchGamesToAssembly), frontend (display order) |
+| Encounter load with games + assemblies | Existing `EncounterCompetition.findByPk(id, { include: [Game, Assemblies, ...] })` | Encounter resolver, generation service, sync |
+| Game match by (gameType + players) or (gameType + empty + visualCode) | Logic inside `EncounterGamesGenerationService` | Generation only |
+| Competition link identity | `linkId = encounter.id`, `linkType = "competition"` | Generation service, game processor, encounter processor (guard) |
+
+---
+
+## 5. Integration Points
+
+| System | Integration | Pattern |
+|--------|-------------|---------|
+| toernooi.nl (sync FROM) | VisualService.getGames(eventCode, encounterCode) → match codes; encounter processor queues game jobs; game processor creates/updates Game by visualCode | Sync worker processors; linkId/linkType set for competition |
+| toernooi.nl (sync TO) | EnterScores Puppeteer finds form row by assembly position (findGameRowByAssemblyPosition); enterGames / matchGamesToAssembly; persists game.visualCode when missing | Games with or without visualCode can be pushed; visualCode set and saved when discovered |
+| GraphQL | encounterCompetition(id) returns encounter with games; generateEncounterGames(encounterId) mutation | Query unchanged; new mutation calls generation service |
+| Frontend edit-encounter | Consumes `encounter.games`; trigger generateEncounterGames; save via updateGame by id | Remove client-side slot generation; single source of truth from backend |
+| Assembly (personal) | Read-only formation (single1..4, double1..4) for resolving players per slot | Generation service reads assemblies; no write |
+
+---
+
+## 6. Key Technical Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| When to generate | Option A: Explicit “Prepare results” / “Generate games” button. Option B: Implicit on Results step open or when both assemblies complete. | Product decision; implementation can support both (mutation + optional auto-trigger in resolver). |
+| Idempotency | Create only for slots with no matched game; or “regenerate and reassign”. No duplicate games per slot. | Prevents ghost/duplicate games; policy must be documented and tested. |
+| linkId / linkType for competition | `linkId = encounter.id`, `linkType = "competition"` for all encounter-scoped games (generation and sync). | Unifies encounter games and prevents sync from treating them as tournament/draw games; required for prune guard. |
+| visualCode lifecycle | visualCode set from toernooi sync when available; backend generation does not invent visualCode. EnterScores finds form row by assembly position (`findGameRowByAssemblyPosition`) and persists visualCode when missing; games without visualCode can be pushed. | Preserves toernooi.nl sync both ways; guard in encounter processor protects backend-created games without visualCode from prune. |
+| Slot order source of truth | Single constant (backend or shared) aligned with `ASSEMBLY_POSITION_ORDER` (assemblyPositions.ts); M/F vs MX order documented. | Keeps backend, frontend, and sync worker aligned for slot index and display order. |
+| createGame for competition | Restrict or document: create only for missing slot or extra games; frontend uses updateGame for the 8 slots. | Avoids duplicate creates; rare extra-game flow still possible if product allows. |
+| Encounter processor prune | Do not delete games where `linkType === "competition"` when pruning DB games not in visual list. | Protects backend-generated games that do not yet have visualCode on toernooi. |
+
+---
+
+This architecture aligns with the [impact map](./impact_map.md) and [feature overview](./feature_overview.md) and is intended for use by the implementation agent and reviewers.

--- a/docs/estimates/backend-encounter-games-generation/complexity_analysis.md
+++ b/docs/estimates/backend-encounter-games-generation/complexity_analysis.md
@@ -1,0 +1,79 @@
+# Complexity & Risk Analysis: Backend Encounter Games Generation
+
+**References:** [impact_map.md](./impact_map.md), [games-slot-order-and-matchName.md](./games-slot-order-and-matchName.md) (frontend matchName/order semantics).
+
+## 1. Technical Risk
+
+### Findings
+
+- **Encounter Games Generation Service:** New service must implement canonical 8-slot logic (double1..4, single1..4 or MX equivalents) aligned with `ASSEMBLY_POSITION_ORDER` in sync worker (`apps/worker/sync/.../assemblyPositions.ts`). Slot semantics must match frontend and sync; any drift causes wrong game types or player assignments.
+- **Matching existing games:** Logic to match by (gameType + player set) or (gameType + empty players + visualCode) is non-trivial; edge cases (partial assemblies, re-formed teams) can produce wrong matches or duplicates.
+- **Idempotency:** "Generate" may be called on formation change or re-entry to Results step. Policy must be explicit: create-only-for-missing-slots vs full regenerate-and-reassign. Duplicate games for the same slot must be prevented; current impact map leaves the choice open.
+- **ORM/DB:** The frontend uses `order` as **completion order** (1 = first completed, 2 = second, …), not slot index. So we cannot use `order` for slot; a separate field (`matchName` or `slotIndex`) is needed if the backend stores slot identity. See [games-slot-order-and-matchName.md](./games-slot-order-and-matchName.md).
+
+### Risk: **Medium**
+
+---
+
+## 2. Integration Risk
+
+### Findings
+
+- **Toernooi.nl sync (high risk):**
+  - **Sync FROM toernooi.nl:** Encounter processor removes DB games whose `visualCode` is not in the visual match list. Backend-generated games without `visualCode` could be **deleted on next sync** unless sync explicitly excludes them (e.g. by `linkType === "competition"` or a "generated" flag). Must clarify and possibly change sync logic.
+  - **Sync TO toernooi.nl (EnterScores):** [CLARIFIED] EnterScores finds the form row by assembly position via `findGameRowByAssemblyPosition` and persists `game.visualCode` when missing; games without visualCode can be pushed. No change needed to EnterScores for backend-generated games without visualCode.
+- **linkId / linkType:** [CONFIRMED] Sync-events-v2 game processor uses `linkId = draw.id`, `linkType = "tournament"` for tournament flow; competition encounters use `linkId = encounter.id`, `linkType = "competition"`. Backend generation **must** set these correctly so sync does not overwrite or delete competition encounter games.
+- **GraphQL:** New mutation `generateEncounterGames(encounterId)` and optional auto-trigger when loading encounter for edit. Resolver must call generation service and return encounter with games; frontend depends on `encounter.games` as source of truth.
+- **Frontend (Next.js 15, external repo):** Edit-encounter equivalent must stop using client-side `createGameObjects` / `getMatchingDatabaseGame` and consume `encounter.games` by id; save uses `updateGame` for existing games. Coordination of when to call generate (explicit button vs implicit on Results step) affects UX and backend trigger points.
+
+### Risk: **High**
+
+---
+
+## 3. Data Risk
+
+### Findings
+
+- **visualCode lifecycle:** Games get `visualCode` from toernooi.nl (sync FROM). If Badman creates games before they exist on toernooi.nl, those games have no visualCode until sync or manual flow provides it. Sync-from logic that deletes "unknown" games would then remove valid backend-generated games. Data consistency depends on either: (1) never generating without visualCode when sync-from will run, or (2) excluding competition/generated games from the delete rule.
+- **Game–slot consistency:** Backend must assign exactly one game per logical slot (1..8). Duplicates or missing slots break frontend display and EnterScores matching. Idempotent generation and clear slot identity (order/matchName) are required.
+- **Assembly → players:** Generation reads assembly data (single1..4, double1..4) to resolve player IDs per slot. Stale or incomplete assembly data produces wrong GamePlayerMemberships; validation or guards may be needed.
+- **No new tables:** All changes are in existing `Games` and `GamePlayerMemberships`; `order` is completion order (not slot index). Optional `matchName` or `slotIndex` if backend needs to store slot identity; see games-slot-order-and-matchName.md.
+
+### Risk: **Medium–High**
+
+---
+
+## 4. Scope Risk
+
+### Findings
+
+- **In-scope:** Encounter games generation service; GraphQL mutation and resolver; sync adjustments for competition games and visualCode; frontend edit-encounter to use `encounter.games` and remove client-side generation; tests (unit for service, integration for resolver + generation, sync and frontend).
+- **Out of scope (per impact map):** Assembly validation/save, PDF export, ranking points, detail-encounter structure (only sort by order/matchName).
+- **Creep risks:** (1) Supporting "Badman-origin" games that don’t exist on toernooi.nl yet — may require EnterScores and sync-from changes beyond current assumptions. (2) Formalizing `matchName` or slot index in schema if `order` semantics are ambiguous. (3) Auto-trigger vs explicit "Generate games" — product decision affects resolver and frontend scope.
+
+### Risk: **Medium**
+
+---
+
+## 5. Uncertainty Risk
+
+### Findings
+
+- **Ordering with toernooi.nl:** Unclear whether encounter games are always created on toernooi.nl first (so visualCodes always exist after sync) or if Badman can create games that don’t exist on toernooi yet. Resolution drives whether we need sync-from safeguards for games without visualCode.
+- **Competition vs tournament sync path:** Impact map notes game processor uses draw.id / "tournament"; competition encounters may use a different path (encounter.id / "competition"). Confirmation needed so generation and sync use the same link contract.
+- **Idempotency policy:** "Create missing only" vs "regenerate and reassign" is not decided; implementation and tests depend on it.
+- **Slot order source of truth:** Single definition (e.g. assemblyPositions or shared constant) for slot order across backend, frontend, and sync worker; frontend slot identity (matchName) and iteration order are described in [games-slot-order-and-matchName.md](./games-slot-order-and-matchName.md).
+- **Frontend hooks:** Frontend is Next.js 15 in an external repo; createGameObjects / getMatchingDatabaseGame live there; conceptual change is to remove client-side generation and use `encounter.games` by id; exact file set is in that repo.
+
+### Risk: **High**
+
+---
+
+## Overall Risk Rating: **High**
+
+The primary risks are:
+
+1. **Toernooi.nl sync and visualCode:** Sync-from can delete backend-generated games without visualCode unless guarded (e.g. linkType === "competition"); sync-to (EnterScores) does **not** require visualCode (resolves row by assembly position and persists it). Implement sync-from guard so competition encounter games are never incorrectly removed; EnterScores already supports games without visualCode.
+2. **linkId / linkType consistency:** Ensure backend generation and all sync paths use `linkId = encounter.id`, `linkType = "competition"` for encounter games so tournament and competition flows do not conflict.
+3. **Idempotency and slot identity:** Define and implement a single policy for repeated "generate" calls and ensure one game per slot with stable identity (order/matchName) for display and EnterScores.
+4. **Unresolved assumptions:** Ordering with toernooi.nl, competition sync path, and slot order source of truth should be confirmed before or early in implementation so the breakdown sub-agent can size tasks accurately.

--- a/docs/estimates/backend-encounter-games-generation/feature_overview.md
+++ b/docs/estimates/backend-encounter-games-generation/feature_overview.md
@@ -1,0 +1,203 @@
+# Feature Overview: Backend Encounter Games Generation
+
+**Feature:** Generate the 8 encounter games once on the backend (from assemblies) so the frontend no longer "generates" them — avoiding ghost/duplicate games. Preserve toernooi.nl sync (visualCode).
+
+**References:** [impact_map.md](./impact_map.md), [complexity_analysis.md](./complexity_analysis.md), [games-slot-order-and-matchName.md](./games-slot-order-and-matchName.md) (frontend use of matchName and order). Architecture (if present) is in the same directory.
+
+---
+
+## 1. Task Breakdown Table
+
+| # | Task | Category | Complexity | Baseline Hours | AI-Adjusted Hours | Risk |
+|---|------|----------|------------|----------------|-------------------|------|
+| 1 | Define canonical slot order constant (shared or backend copy of ASSEMBLY_POSITION_ORDER); document M/F vs MX slot semantics for backend, frontend, sync | BE | S | 1 | 0.4 | Low |
+| 2 | Add EncounterGamesGenerationService: inputs (encounter id + loaded encounter/assemblies), resolve 8 slots, gameType + players per slot from assemblies, match existing games by (gameType + player set) or (gameType + empty + visualCode), create missing games with linkId=encounter.id, linkType="competition"; set order only when game has winner (completion order) or leave null; idempotency policy (create-only-for-missing vs regenerate) | BE | L | 12 | 12 | High |
+| 3 | Optional: DB migration for matchName or slotIndex if backend needs to store slot identity; order is completion order (not slot index) and cannot double as slot | DB | S | 2 | 0.8 | Low |
+| 4 | GraphQL: add generateEncounterGames(encounterId: ID) mutation and resolver; call EncounterGamesGenerationService; return encounter with games (or games list); wire in encounter module | BE | M | 4 | 4 | Medium |
+| 5 | Encounter resolver: optional auto-trigger generation when loading encounter for edit (or leave trigger to frontend only) | BE | S | 1.5 | 1.5 | Low |
+| 6 | Sync (worker): adjust encounter processor so games with linkType==="competition" (or without visualCode in visual list) are not deleted when pruning DB games not in toernooi.nl match list | BE | M | 4 | 4 | High |
+| 7 | Sync (worker): ensure ProcessSyncCompetitionGame sets linkId/linkType correctly for competition encounters (linkId=encounter.id, linkType="competition") when processing encounter games; align with game processor job payload (encounterId) | BE | M | 3 | 3 | High |
+| 8 | EnterScores (matchGamesToAssembly / enterGames): already handles missing visualCode via assembly-position lookup (findGameRowByAssemblyPosition) and persists visualCode; document/assert; no contract change needed | BE | S | 1 | 1 | Low |
+| 9 | Frontend (Next.js 15, external repo): edit-encounter equivalent — remove any createGameObjects/getMatchingDatabaseGame logic; consume encounter.games by id; build form from encounter.games (sorted by order); on save use updateGame for existing game id | FE | M | 5 | 5 | Medium |
+| 10 | Frontend (Next.js 15, external repo): add trigger for generateEncounterGames (explicit button or on Results step open); call mutation when needed; refetch encounter.games after generate | FE | S | 2 | 2 | Low |
+| 11 | GamesResolver.createGame: restrict or document for competition encounters (create only for missing slot / extra games) or leave as-is for rare extra-game flow | BE | S | 1 | 1 | Low |
+| 12 | Unit tests: EncounterGamesGenerationService — slot order M/F vs MX, player resolution from assemblies, idempotency, create-missing-only vs reassign, no duplicate per slot | QA | M | 4 | 4 | Medium |
+| 13 | Integration tests: generateEncounterGames mutation; encounter with 0 vs 8 existing games; assert 8 games, gameTypes and players per slot, linkId/linkType | QA | M | 4 | 4.8 | Medium |
+| 14 | Integration/sync tests: sync-from-toernooi does not delete backend-generated competition games (linkType competition or no visualCode); EnterScores with backend-generated games (with visualCode) | QA | M | 4 | 4.8 | High |
+| 15 | Frontend/e2e: edit-encounter after generation shows 8 cards; save updates by id; no duplicate create | QA | S | 2 | 2.4 | Low |
+| 16 | Migration strategy for existing encounters: one-time job or migration step to run generation for encounters that have 0–8 games so they get canonical 8 slots; document rollback | BE | M | 4 | 4 | Medium |
+| 17 | Documentation: API (generateEncounterGames), sync rules (competition vs tournament, visualCode lifecycle), slot order source of truth; inline comments for generation and sync guard logic | DOCS | S | 2 | 1.6 | Low |
+| 18 | PR review, integration testing, regression (sync + EnterScores + frontend); fix issues | QA | M | 4 | 4.8 | Medium |
+
+*AI adjustments: Boilerplate/scaffolding (task 3, 1, 17 partial) −60%; PR/review (task 18) +20%.*
+
+---
+
+## 2. Subtotals by Category
+
+| Category | Sum (AI-Adjusted Hours) |
+|----------|--------------------------|
+| BE       | 30.7 |
+| DB       | 0.8  |
+| FE       | 7    |
+| QA       | 16   |
+| DOCS     | 1.6  |
+| **Total**| **56.1** |
+
+---
+
+## 3. Grand Total and Sprint Suggestion
+
+- **Optimistic:** 48 h (no migration issues; sync path already supports competition; frontend has no extra createGame paths).
+- **Expected:** 56 h (~7 developer-days with AI).
+- **Pessimistic:** 68 h (sync competition vs tournament path clarification; idempotency edge cases; migration for many existing encounters).
+
+**Sprint allocation:** 1 sprint (2 weeks) with 1 dev + AI; or 2 sprints if risk mitigation (sync/visualCode) is done first.
+
+---
+
+## 4. Parallelization Notes
+
+- **Can run in parallel:**  
+  - Task 1 (slot constant) with task 3 (migration if any).  
+  - Task 2 (generation service) can start once task 1 is done.  
+  - Tasks 6–8 (sync/worker) can be done in parallel after task 2 design (linkId/linkType and delete rule) is fixed.  
+  - Task 12 (unit tests for service) in parallel with task 4 (mutation).  
+  - Frontend tasks 9–10 in parallel with backend after API contract (generateEncounterGames, encounter.games shape) is stable.
+- **Sequential:**  
+  - Task 4 (mutation) depends on task 2 (service).  
+  - Task 6–7 (sync) should be done before task 14 (sync tests).  
+  - Task 16 (migration) after task 2 and 4 are merged.
+
+---
+
+## 5. Critical Path
+
+1. **Define slot order** (task 1) → **EncounterGamesGenerationService** (task 2) → **generateEncounterGames mutation** (task 4).  
+2. **Sync adjustments** (tasks 6–7) depend on linkId/linkType and delete rule; they block **sync tests** (task 14) and **EnterScores** confidence (task 8).  
+3. **Frontend** (tasks 9–10) depends on **mutation and encounter.games** (task 4).  
+4. **Migration** (task 16) is last on the critical path after generation and mutation are stable.
+
+---
+
+## 6. Agent Execution Tasks
+
+Ordered, atomic instructions for a coding agent. Assume `architecture.md` is in the same output directory when referenced.
+
+1. **Canonical slot order**  
+   - Add a shared constant or backend copy of the 8-slot order (M/F and MX) aligned with `apps/worker/sync/src/app/processors/enter-scores/pupeteer/assemblyPositions.ts` (`ASSEMBLY_POSITION_ORDER`).  
+   - Output: Single source of truth (e.g. in backend competition lib or shared util) and short doc of slot index → gameType/matchName.
+
+2. **EncounterGamesGenerationService**  
+   - In `libs/backend/competition/` (e.g. encounter or new sub-lib), add `EncounterGamesGenerationService`.  
+   - Inputs: encounter id or loaded encounter with games, home/away, assemblies.  
+   - For each of 8 canonical slots: resolve gameType and player IDs from assemblies; match existing encounter game by (gameType + same player set) or (gameType + empty players + visualCode); if matchName/slotIndex field exists, assign it; do not use `order` for slot (order is completion order).  
+   - For slots with no matched game: create `Game` with `linkId = encounter.id`, `linkType = "competition"`, gameType, `GamePlayerMembership`; set `order` only when game has a winner (completion order) or leave null; if matchName/slotIndex exists set it to canonical slot; set `visualCode` if available.  
+   - Idempotency: implement chosen policy (create-only-for-missing or regenerate-and-reassign); prevent duplicate games per slot.  
+   - Output: Service class with tests (stub); no GraphQL yet.
+
+3. **Optional migration**  
+   - If backend needs to store slot identity: add migration and model field for `matchName` or `slotIndex`; `order` is confirmed as completion order and cannot be used as slot index. Otherwise skip.  
+   - Output: Migration file (if any) and rollback script.
+
+4. **generateEncounterGames mutation**  
+   - In `libs/backend/graphql/src/resolvers/event/competition/encounter.resolver.ts` (or appropriate resolver), add mutation `generateEncounterGames(encounterId: ID)` that calls `EncounterGamesGenerationService` and returns encounter with games (or list of games).  
+   - Register in schema and encounter module.  
+   - Output: Mutation, resolver method, schema update.
+
+5. **Optional auto-trigger**  
+   - In encounter resolver, when loading encounter for edit (e.g. by a flag or context), optionally call generation so encounter has 8 games before response; or leave trigger to frontend only.  
+   - Output: Resolver change (if product chooses auto-trigger).
+
+6. **Sync: do not delete competition games**  
+   - In `apps/worker/sync/src/app/processors/sync-events-v2/competition/processors/encounter.processor.ts`, in the loop that removes DB games not in the visual list, exclude games where `linkType === "competition"` (or equivalent guard so backend-generated games without visualCode are not deleted).  
+   - Output: Updated `processGames` (or equivalent) with guard and comment.
+
+7. **Sync: linkId/linkType for competition**  
+   - In `apps/worker/sync/src/app/processors/sync-events-v2/competition/processors/game.processor.ts`, when the job is for a competition encounter (e.g. job has `encounterId`), set `game.linkId = encounter.id` and `game.linkType = "competition"` instead of draw.id/"tournament".  
+   - Ensure job payload supports `encounterId` and processor uses it when present.  
+   - Output: Game processor and encounter processor job payload aligned; games for competition encounters have correct link.
+
+8. **EnterScores contract**  
+   - In `apps/worker/sync/src/app/processors/enter-scores/pupeteer/enterGames.ts` and `matchGamesToAssembly.ts`, document that the flow finds the form row by assembly position (`findGameRowByAssemblyPosition`) and persists `game.visualCode` when missing; no change needed for backend-generated games without visualCode.  
+   - Output: Comments documenting assembly-position resolution and visualCode persistence.
+
+9. **Frontend (Next.js 15, external repo): edit-encounter by id**  
+   - In the Next.js 15 frontend (external repo), edit-encounter equivalent: remove any createGameObjects/getMatchingDatabaseGame logic; build form from `encounterCompetition.games` (sorted by `order`); bind each card to `game.id`; on save call `updateGame` for existing games by id.  
+   - Output: Edit-encounter page and related components using `encounter.games` as source of truth.
+
+10. **Frontend (Next.js 15, external repo): trigger generate**  
+    - Add UI or flow to call `generateEncounterGames(encounterId)` (e.g. "Prepare results" button or on Results step open); after success refetch encounter so `encounter.games` is updated.  
+    - Output: Button or automatic trigger and refetch after generate.
+
+11. **createGame restriction**  
+    - In `libs/backend/graphql/src/resolvers/game/game.resolver.ts`, document or implement rule for competition encounters: createGame only for missing slot or extra games; reject or allow based on product rule.  
+    - Output: Resolver logic or comment and tests if changed.
+
+12. **Unit tests: EncounterGamesGenerationService**  
+    - Tests for slot order (M/F vs MX), player resolution from assemblies, idempotency (no duplicate per slot), create-missing-only vs reassign.  
+    - Output: Unit test file(s) for the service.
+
+13. **Integration tests: generateEncounterGames**  
+    - Call mutation for encounter with 0 games and with 8 existing games; assert 8 games, correct gameTypes and players per slot, linkId/linkType.  
+    - Output: Integration test(s) for mutation and encounter + games.
+
+14. **Sync/EnterScores tests**  
+    - Integration or e2e: sync-from-toernooi does not delete games with linkType "competition" (or without visualCode in list); EnterScores with backend-generated games that have visualCode still fills form.  
+    - Output: Test(s) covering sync delete rule and EnterScores.
+
+15. **Frontend/e2e: edit-encounter**  
+    - After generation, open edit-encounter; verify 8 cards; save; verify updates by id and no duplicate create.  
+    - Output: E2E or frontend test for edit-encounter flow.
+
+16. **Migration for existing encounters**  
+    - One-time script or migration step: for encounters with 0–8 games, call generation (or new service method) to ensure canonical 8 slots; document rollback.  
+    - Output: Script or migration and short runbook.
+
+17. **Documentation**  
+    - API doc for `generateEncounterGames`; sync rules (competition vs tournament, when games are deleted, visualCode lifecycle); slot order source of truth; inline comments for generation and sync guards.  
+    - Output: Updated API docs and inline comments.
+
+18. **PR review and regression**  
+    - Run full integration and regression (sync, EnterScores, frontend); address review and failures.  
+    - Output: Green CI and merged PR.
+
+---
+
+## 7. Definition of Done / Acceptance Criteria
+
+- **Generation:** Encounter has exactly 8 games (or MX equivalent) after `generateEncounterGames`; each game has correct gameType, players from assemblies, `linkId` = encounter.id, `linkType` = "competition"; `order` is completion order (set when game has winner) or null; if matchName/slotIndex exists, set per canonical slot.
+- **Idempotency:** Calling generate again does not create duplicate games for the same slot; existing games are matched and only missing slots get new games (or policy is clearly “reassign” and documented).
+- **Sync FROM toernooi.nl:** Backend-generated competition games are not deleted when they are not in the visual match list (guard by linkType or equivalent).
+- **Sync TO toernooi.nl (EnterScores):** Games with or without `visualCode` push correctly; EnterScores resolves form row by assembly position and persists visualCode when missing.
+- **Frontend:** Edit-encounter shows 8 cards from `encounter.games`; save uses `updateGame` by id; no client-side slot generation or duplicate create for the 8 slots.
+- **Migration:** Existing encounters can be normalized to 8 games via one-time run; rollback is documented.
+- **Tests:** Unit (service), integration (mutation + sync), and frontend/e2e (edit-encounter) pass.
+
+---
+
+## 8. Resolved and Open Questions
+
+**Resolved (from impact_map / complexity_analysis):**
+
+- Games for competition encounters use `linkId = encounter.id`, `linkType = "competition"`; sync must set and preserve these.
+- visualCode is **not** required for pushing to toernooi.nl: EnterScores finds the form row by assembly position via `findGameRowByAssemblyPosition` and persists the discovered matchId as `game.visualCode`; backend can create games with null visualCode.
+- Slot order is defined in one place (e.g. assemblyPositions or shared constant); backend uses same semantics as sync worker and frontend; see games-slot-order-and-matchName.md.
+- `order` is completion order (not slot index); add matchName/slotIndex migration only if backend needs to store slot identity.
+
+**Open (may change estimates):**
+
+- **Toernooi-first vs Badman-first:** Are encounter games always created on toernooi.nl first (so visualCodes exist after sync), or can Badman create games that don’t exist on toernooi yet? Affects whether sync must exclude competition games without visualCode from delete.
+- **Idempotency policy:** Create-only-for-missing vs full regenerate-and-reassign; confirm and document so implementation and tests are consistent.
+- **Competition sync path:** Confirm that competition encounter sync uses encounter.id + "competition" in game processor (not draw.id + "tournament") and that job payload includes encounterId where needed.
+- **Frontend hooks:** Frontend is Next.js 15 in an external repo; exact paths for createGameObjects/getMatchingDatabaseGame are in that repo; conceptual change is to remove client-side generation and use `encounter.games` by id.
+
+---
+
+## 9. Risk Summary
+
+- **High:** Sync deleting backend-generated games (mitigated by task 6); linkId/linkType wrong for competition (mitigated by task 7); idempotency and slot identity (mitigated by task 2 and 12).
+- **Medium:** Matching existing games (gameType + players / visualCode) edge cases; migration for many encounters; frontend refactor scope.
+- **Low:** Slot order drift (mitigated by task 1); EnterScores unchanged if visualCode present; documentation and comments.
+
+Keep toernooi.nl sync behavior, idempotency, and linkId/linkType consistency in mind during implementation and review.

--- a/docs/estimates/backend-encounter-games-generation/games-slot-order-and-matchName.md
+++ b/docs/estimates/backend-encounter-games-generation/games-slot-order-and-matchName.md
@@ -1,0 +1,290 @@
+# Games: matchName and order – backend reference
+
+This document is for **backend engineers**. It describes how the **frontend** uses **matchName** (slot identity) and **order** (completion order) for encounter games, what the frontend sends in create/update mutations, and what the backend is expected to store/return. No frontend codebase context is assumed.
+
+---
+
+## Context: encounter form and games
+
+- An **encounter** is a match between two teams (home vs away). Each encounter has up to **8 games** (4 singles + 4 doubles).
+- The frontend shows these as 8 fixed “slots” (e.g. “Single 1”, “Double 2”). The user fills in players and scores per slot and saves; the frontend then either **creates** a new game or **updates** an existing one.
+- The frontend does **not** receive a “slot id” from the backend. It **derives** which backend game belongs to which slot by matching: same game type (Single/Double) + same set of player IDs. So the frontend needs a stable notion of “slot” on its side – that’s **matchName**. The backend does **not** have a `matchName` field; it only has **order** (and e.g. `visualCode`) among the fields relevant here.
+
+---
+
+## 1. matchName (slot identity) – frontend-only
+
+### What it is
+
+**matchName** is the frontend’s label for each of the 8 fixed slots in an encounter. It is **never** sent to or stored by the backend.
+
+Allowed values (TypeScript type on the frontend):
+
+```ts
+type TMatchName =
+  | "single1"
+  | "single2"
+  | "single3"
+  | "single4"
+  | "double1"
+  | "double2"
+  | "double3"
+  | "double4";
+```
+
+### Slot order (iteration order)
+
+When the frontend builds the list of 8 slots from encounter data + team formations, it iterates in this order:
+
+```ts
+const gameTypes: TMatchName[] = [
+  "double1",
+  "double2",
+  "double3",
+  "double4",
+  "single1",
+  "single2",
+  "single3",
+  "single4",
+];
+```
+
+For **mixed teams** (MX), the frontend uses a different **display** order (e.g. single1, single3, single2, single4, double3, double4), but the set of matchNames and their meaning (which formation field maps to which slot) is the same.
+
+### Where matchName is used on the frontend
+
+- To know which “slot” we’re on (which card, which dialog).
+- To know which team-formation field to use for that slot (e.g. `single1` → formation.single1).
+- **Not** sent in any mutation.
+
+### Backend implications
+
+- The **GraphQL `Game` type** and the input types **`GameNewInput`** / **`GameUpdateInput`** do **not** have a `matchName` field. The frontend never sends it.
+- Slot identity on the backend is inferred by the frontend only by **matching**: same `gameType` + same set of players (and optionally fallback by `visualCode` for placeholder games). So if the backend ever needs to expose “which slot” a game is, it would have to be via a new field (e.g. `matchName` or `slot`) or via a convention (e.g. `order` 1–8 as slot index); currently there is no such field.
+
+---
+
+## 2. order (completion order) – stored and sent
+
+### What it is
+
+**order** is the “completion order” of a game: in which order games got a winner (1 = first completed game, 2 = second, etc.). It is **not** the slot index (that’s matchName on the frontend). The frontend computes it when the user saves a game and sends it in both create and update.
+
+### Backend schema (what the frontend expects)
+
+The frontend uses these types (from the GraphQL schema):
+
+**Game (output)** – the backend returns this when querying games (e.g. encounter games):
+
+```ts
+// Relevant fields only
+type Game = {
+  id: Scalars["ID"]["output"];
+  gameType: Maybe<Scalars["String"]["output"]>;
+  order: Maybe<Scalars["Int"]["output"]>;   // ← stored, returned
+  winner: Maybe<Scalars["Int"]["output"]>;
+  // ... set1Team1/2, set2..., set3..., players, visualCode, etc.
+};
+```
+
+**GameNewInput** – payload for **createGame**:
+
+```ts
+type GameNewInput = {
+  courtId?: InputMaybe<Scalars["ID"]["input"]>;
+  gameId?: InputMaybe<Scalars["ID"]["input"]>;
+  gameType?: InputMaybe<Scalars["String"]["input"]>;
+  linkId?: InputMaybe<Scalars["ID"]["input"]>;
+  linkType?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<Scalars["Int"]["input"]>;   // ← sent on create
+  playedAt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  players?: InputMaybe<Array<GameNewInputPlayers>>;
+  round?: InputMaybe<Scalars["String"]["input"]>;
+  set1Team1?: InputMaybe<Scalars["Int"]["input"]>;
+  set1Team2?: InputMaybe<Scalars["Int"]["input"]>;
+  set2Team1?: InputMaybe<Scalars["Int"]["input"]>;
+  set2Team2?: InputMaybe<Scalars["Int"]["input"]>;
+  set3Team1?: InputMaybe<Scalars["Int"]["input"]>;
+  set3Team2?: InputMaybe<Scalars["Int"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  winner?: InputMaybe<Scalars["Int"]["input"]>;
+};
+// No matchName, no visualCode.
+```
+
+**GameUpdateInput** – payload for **updateGame**:
+
+```ts
+type GameUpdateInput = {
+  courtId?: InputMaybe<Scalars["ID"]["input"]>;
+  gameId?: InputMaybe<Scalars["ID"]["input"]>;
+  gameType?: InputMaybe<Scalars["String"]["input"]>;
+  linkId?: InputMaybe<Scalars["ID"]["input"]>;
+  order?: InputMaybe<Scalars["Int"]["input"]>;   // ← sent on update
+  playedAt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  players?: InputMaybe<Array<GameNewInputPlayers>>;
+  round?: InputMaybe<Scalars["String"]["input"]>;
+  set1Team1?: InputMaybe<Scalars["Int"]["input"]>;
+  set2Team1?: InputMaybe<Scalars["Int"]["input"]>;
+  set2Team2?: InputMaybe<Scalars["Int"]["input"]>;
+  set3Team1?: InputMaybe<Scalars["Int"]["input"]>;
+  set3Team2?: InputMaybe<Scalars["Int"]["input"]>;
+  status?: InputMaybe<Scalars["String"]["input"]>;
+  winner?: InputMaybe<Scalars["Int"]["input"]>;
+};
+// No matchName, no visualCode.
+```
+
+### Mutations used
+
+```graphql
+mutation CreateGame($data: GameNewInput!) {
+  createGame(data: $data) {
+    id
+  }
+}
+
+mutation UpdateGame($data: GameUpdateInput!) {
+  updateGame(data: $data) {
+    id
+  }
+}
+```
+
+The frontend always sends a payload that includes `order` (see below). So the backend must accept `order` on create and update and persist it; the frontend then reads it back via the encounter query (games with `order` in the fragment).
+
+### How the frontend computes `order`
+
+When the user saves a game (create or update), the frontend computes `order` with this logic (TypeScript):
+
+```ts
+/**
+ * Determines the order value for a game based on completion status and existing completed games.
+ * Returns the order value (number) or null if game is not completed.
+ */
+function getOrderValue(
+  game: IFormData,
+  gamesData: IEncounterFormGame[]
+): number | null {
+  const isGameCompleted =
+    game.winner !== undefined && game.winner !== null && game.winner !== 0;
+
+  if (!isGameCompleted) {
+    return null;
+  }
+
+  const completedGames = gamesData.filter((existingGame) => {
+    const isCompleted =
+      existingGame.winner !== undefined &&
+      existingGame.winner !== null &&
+      existingGame.winner !== 0;
+    const isNotCurrentGame = existingGame.id !== game.id;
+    return isCompleted && isNotCurrentGame;
+  });
+
+  if (completedGames.length === 0) {
+    return 1;
+  }
+
+  const highestOrder = Math.max(...completedGames.map((g) => g.order || 0));
+  return highestOrder + 1;
+}
+```
+
+So:
+
+- If the game has **no winner** → `order` is **null**.
+- If the game has a **winner** → `order` is **1** when it’s the first completed game, otherwise **1 + max(order of other completed games)**.
+
+### When / where order is sent
+
+**Create (prepGameDataForCreation)**  
+The payload built for `createGame` always includes `order`:
+
+```ts
+const orderValue = getOrderValue(formData, gamesData);
+
+return {
+  playedAt: new Date().toISOString(),
+  linkId: formData.encounterId,
+  linkType: "competition",
+  set1Team1: formData.set1Team1,
+  set1Team2: formData.set1Team2,
+  set2Team1: formData.set2Team1,
+  set2Team2: formData.set2Team2,
+  set3Team1: formData.set3Team1,
+  set3Team2: formData.set3Team2,
+  gameType: formData.gameType,
+  winner: formData.winner,
+  order: orderValue,   // number or null
+  players: [...],
+  status: "NORMAL",
+};
+```
+
+So on **create**, the backend receives `order` as either a positive integer (when the game has a winner) or `null`.
+
+**Update (prepGameDataForUpdate)**  
+The payload built for `updateGame` includes `order` only when the game is being completed (has a winner):
+
+```ts
+const orderValue = getOrderValue(formData, gamesData);
+
+const updateData = {
+  playedAt: new Date().toISOString(),
+  linkId: formData.encounterId,
+  gameId: formData.id,
+  set1Team1: formData.set1Team1,
+  // ... other sets, gameType, players, winner
+  order: orderValue,
+};
+
+// Only include order when the game is being completed (has a winner)
+if (orderValue !== null) {
+  updateData.order = orderValue;
+}
+
+return updateData;
+```
+
+So on **update** the payload always includes the `order` key:
+
+- When the game has a **winner**, `order` is the computed integer (completion rank).
+- When the game has **no winner**, `order` is `null`. The backend can keep the existing value or clear it depending on your rules.
+
+### What the frontend expects from the backend
+
+- When the frontend **fetches** an encounter with games, it uses the fragment that requests `order` (and `visualCode`, etc.):
+
+```graphql
+fragment EncounterFormGame on Game {
+  id
+  gameType
+  winner
+  status
+  players { id slug fullName team player playerId single double mix }
+  rankingPoints { ... }
+  set1Team1
+  set1Team2
+  set2Team1
+  set2Team2
+  set3Team1
+  set3Team2
+  order
+  visualCode
+}
+```
+
+- So the backend must **return** `order` for each game (nullable int). When building form state, the frontend uses `databaseGame.order ?? 0` for display/ordering; when computing the next `order` on save, it uses the stored values of other completed games.
+
+---
+
+## 3. Summary for backend
+
+| Concept      | Meaning                         | In backend schema?     | Sent in createGame? | Sent in updateGame? |
+|-------------|----------------------------------|------------------------|----------------------|----------------------|
+| **matchName** | Slot id (single1…single4, double1…double4) | **No** (frontend-only) | **No**               | **No**               |
+| **order**     | Completion order (1 = first completed, 2 = second, …) | **Yes** (`Game.order`) | **Yes** (int or null) | **Yes** (only when game has winner; then int) |
+
+- **matchName:** The frontend never sends it. The backend does not need to store or expose it unless you add a new field for “slot” (e.g. for toernooi.nl or reporting).
+- **order:** The backend should accept `order` in `GameNewInput` and `GameUpdateInput`, persist it, and return it on `Game`. The frontend uses it as completion order (1-based); it is **not** the same as “slot index” (which is matchName on the frontend).

--- a/docs/estimates/backend-encounter-games-generation/impact_map.md
+++ b/docs/estimates/backend-encounter-games-generation/impact_map.md
@@ -1,0 +1,197 @@
+# Technical Impact Map: Backend Encounter Games Generation
+
+## Feature Summary
+
+Move encounter game "generation" from the frontend to the backend so that the 8 games per encounter (4 doubles + 4 singles, or MX equivalents) are created once on the server. This fixes "ghost" games and duplicate-game bugs caused by frontend-derived slot matching and ad-hoc create-on-save. The frontend will consume `encounter.games` as the source of truth and only update/create by id when the user edits.
+
+**Critical constraint:** Games have a `visualCode` that ties them to toernooi.nl. Sync **from** toernooi.nl creates/updates games by this code. Sync **to** toernooi.nl (EnterScores Puppeteer) can work **without** visualCode set in advance: it finds the form row by assembly position (see §3.2 and §6.1), then sets and persists `visualCode` when missing or wrong. Any backend generation should still set `visualCode` when available (e.g. from sync) so sync-from and future push runs stay aligned.
+
+---
+
+## 1. Database Layer
+
+### Tables Affected
+
+
+| Table                   | Schema     | Change Type                 | Description                                                                                                                                                                                                |
+| ----------------------- | ---------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Games`                 | `event`    | **Logic / optional schema** | Games already have `visualCode`, `linkId`, `linkType`, `order`. `order` is completion order (frontend sends it); it is **not** slot index. Backend generation will create/update rows. Optional: add `matchName` or `slotIndex` for slot identity (frontend currently infers slot by gameType + players). |
+| `GamePlayerMemberships` | `event`    | **Logic only**              | Backend will create memberships when generating games from assembly player data.                                                                                                                           |
+| `EncounterCompetitions` | `event`    | **No schema change**        | No new columns. Generation is triggered per encounter.                                                                                                                                                     |
+| `Assemblies` (personal) | `personal` | **No change**               | Read-only input for generation (formation: single1..4, double1..4).                                                                                                                                        |
+
+
+### New Tables
+
+**None required.** Existing schema supports games linked to encounter (`linkId` = encounter id, `linkType` = `"competition"`).
+
+### Migrations
+
+- **Optional:** Add `matchName` or `slotIndex` (e.g. `double1`, `single2`) for slot identity. **Do not** use `order` for slot: the frontend uses `order` as completion order (1 = first completed, 2 = second, …) and sends it on create/update. If we do not add a slot field, the frontend continues to infer slot by matching (gameType + players); backend generation can still align to the same canonical slots (e.g. assemblyPositions) for sync and future use.
+
+---
+
+## 2. ORM / Data Layer
+
+### Models Affected
+
+
+| Model                  | File (backend)                                                                      | Change                                                                                     |
+| ---------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `Game`                 | `libs/backend/database/src/models/event/game.model.ts`                              | No schema change expected. Optional: add `matchName` if product wants explicit slot names. |
+| `EncounterCompetition` | `libs/backend/database/src/models/event/competition/encounter-competition.model.ts` | No change. Has `getGames()`.                                                               |
+| `Assembly`             | Assembly model / personal schema                                                    | Read-only for generation.                                                                  |
+
+
+### Data Access Patterns
+
+- **Encounter + games:** Already loaded via `EncounterCompetition.findByPk(id, { include: [Game, Assemblies, ...] })` in encounter resolver and sync.
+- **Assemblies per encounter:** Fetched by encounter (home/away team) for formation data. Backend generation will need the same assembly shape (single1..4, double1..4) to resolve player IDs per slot.
+- **Game create:** Today `Game.create()` is used in `GamesResolver.createGame()` and in sync processors. A new service will create games in bulk (or one-by-one) with `linkId` = encounter id, `linkType` = `"competition"`, and optional `visualCode` when available from toernooi.nl.
+
+---
+
+## 3. Services / Business Logic
+
+### 3.1 New: Encounter Games Generation Service
+
+**Location (proposed):** e.g. `libs/backend/competition/encounter/src/services/encounter-games-generation.service.ts` (or under existing encounter/competition lib).
+
+**Responsibilities:**
+
+- **Inputs:** Encounter id (or encounter entity with games, home/away, assemblies loaded).
+- **Canonical slots:** Same 8 slots as frontend (M/F: double1..4, single1..4; MX: same logical slots, possibly different display order — see `ASSEMBLY_POSITION_ORDER` in `apps/worker/sync/.../assemblyPositions.ts`).
+- **Per slot:** Resolve gameType (Single/Double/Mix), slot identity (if matchName/slotIndex field exists), and player IDs from home/away assembly for that slot.
+- **Matching existing games:** If encounter already has games, match by (gameType + same player set) or by (gameType + empty players + visualCode) to avoid duplicates. If a slot field exists, assign it; do not use `order` for slot (order is completion order).
+- **Creating missing games:** For slots with no matched game, create a new Game with linkId = encounter.id, linkType = "competition", gameType, players (GamePlayerMembership). Set `order` only when the game has a winner (completion order), or leave null. If a matchName/slotIndex field exists, set it to the canonical slot (e.g. double1, single2). If visualCode is available (e.g. from toernooi.nl sync), set it; otherwise leave null until sync or user flow provides it.
+- **Idempotency:** "Generate" can be called multiple times (e.g. formation change); policy: create only for slots that still have no game, or "regenerate" and reassign. Must not create duplicate games for the same slot.
+
+**Dependencies:** EncounterCompetition, Game, Assembly (or assembly data), GamePlayerMembership, possibly VisualService if we need to fetch match codes from toernooi.nl before creating games.
+
+### 3.2 Toernooi.nl Sync (Critical)
+
+**Sync FROM toernooi.nl (sync-events-v2):**
+
+- **Encounter processor** (`apps/worker/sync/.../encounter.processor.ts`): Fetches matches via `VisualService.getGames(eventCode, encounterCode)`. For each match, queues `ProcessSyncCompetitionGame` with `gameCode: match.Code`. Removes DB games that are not in the visual list (by `visualCode`).
+- **Game processor** (`apps/worker/sync/.../game.processor.ts`): Finds or creates game by `visualCode` (gameCode). Sets `game.linkId = draw.id` and `linkType = "tournament"` in v2 — [ASSUMPTION] competition encounters may use a different path (e.g. sync-events competition-sync uses `linkId: encounter.id`, `linkType: "competition"`). Backend-generated games must use `linkId = encounter.id` and `linkType = "competition"` so they are not removed or overwritten incorrectly.
+- **Risk:** If sync deletes games that don’t have a `visualCode` present on toernooi.nl, then backend-created games without a visualCode could be deleted on next sync. **Must clarify:** Are encounter games always created on toernooi.nl first (so we always get visualCodes from sync), or can Badman create games that don’t exist on toernooi yet? If the latter, sync logic must not delete games that have `linkType === "competition"` and no visualCode, or we need another strategy (e.g. create placeholders on toernooi.nl).
+
+**Sync TO toernooi.nl (EnterScores):**
+
+- **enterGames.ts** does **not** require `game.visualCode` to be set beforehand to push a game. It uses an **assembly-position-based** flow:
+  1. **matchGamesToAssembly** maps each game to an assembly position (e.g. single1, double2) from player assignments.
+  2. For each assembly position in order, **findGameRowByAssemblyPosition** (in enterGames.ts) finds the correct form row **without using visualCode**: it gets the expected header for that position and team type from `getHeaderForAssemblyPosition` (e.g. "HD1" for M double1), scans the page for a table row with that header, and reads the `matchId` from the row’s form inputs (`match_<matchId>_t1p1` etc.). It also checks the row is empty (e.g. after clearFields).
+  3. The returned `matchId` is used as the form target for that game. If the game had no or wrong `visualCode`, the code sets `game.visualCode = correctMatchId` and **saves to the database** (when a transaction is provided), so future sync and push runs see the correct code.
+- So backend-generated games **without** visualCode can still be pushed: the worker resolves the row by assembly position and persists the discovered visualCode. Backend generation can create games with null visualCode; EnterScores will fill and persist it when pushing.
+
+**Recommendation:** Backend generation can create games with or without visualCode. When visualCode is available (e.g. from sync-from-toernooi), set it at creation; when not, EnterScores will resolve the row by assembly position and persist visualCode. Document this so sync-from does not delete such games (e.g. by linkType or by not treating missing visualCode as "not on toernooi" for competition encounters).
+
+### 3.3 Existing Game Create/Update
+
+- **GamesResolver.createGame** (`libs/backend/graphql/src/resolvers/game/game.resolver.ts`): Used by frontend when user saves a new game. After backend generation, frontend may only call this for rare "extra" games or we restrict to update-only for the 8 slots.
+- **Game update:** Existing update mutation remains for editing score/winner/players. Backend generation must not overwrite user-entered scores; only create/fill slot and players when game is new or empty.
+
+### 3.4 Assembly Validation
+
+- No change to assembly validation rules. Generation reads assembly data; it does not modify assemblies.
+
+---
+
+## 4. GraphQL Layer
+
+### New or Modified Operations
+
+
+| Operation                                    | Type               | Change                                                                                                                                                                            |
+| -------------------------------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `generateEncounterGames(encounterId: ID)`    | **Mutation (new)** | Calls EncounterGamesGenerationService, returns encounter (with games) or list of games. Optional: trigger implicitly when entering Results step or when assemblies are completed. |
+| `encounterCompetition(id)` / encounter query | Query              | No schema change. Response already includes `games`. Frontend will use `encounter.games` as the list to display (sorted by completion `order`; if backend adds matchName/slotIndex, display order can follow slot).                                      |
+| `createGame`                                 | Mutation           | May become "create only if slot has no game" or deprecated for the 8-slot flow; frontend uses update for existing slots.                                                          |
+| `updateGame`                                 | Mutation           | Unchanged.                                                                                                                                                                        |
+
+
+### Input/Return Types
+
+- **GenerateEncounterGamesInput:** `{ encounterId: ID }`.
+- **Return:** Encounter (with games) or `{ games: [Game!]! }` so client can refetch or merge.
+
+---
+
+## 5. Frontend Impact
+
+**Stack:** The current frontend is a Next.js 15 application in an external repo. This repo contains a legacy Angular frontend used only for reference. Frontend impact applies to the Next.js app (edit-encounter / Results step equivalent).
+
+### 5.1 Results Step / Edit Encounter
+
+- **Current:** Form builds 8 slots from `encounterCompetition?.games?.[i]` or empty object; frontend may have separate logic (e.g. `createGameObjects` / `getMatchingDatabaseGame`) that "generates" logical games from assemblies and matches to DB games. Saving a card can trigger `createGame` mutation.
+- **After backend generation:** Encounter already has up to 8 games from backend (or from sync). Frontend displays `encounter.games` (sorted by completion `order`; slot identity is still inferred by gameType + players unless backend adds matchName/slotIndex). No client-side slot generation or matching; each card is bound to `game.id`. On save, frontend calls **updateGame** for existing id (including `order` when game is completed); **createGame** only if product allows ad-hoc extra games.
+- **Files to simplify/change:** Next.js 15 frontend (external repo) — edit-encounter / Results step equivalent and any hook/component that implements `createGameObjects` / `getMatchingDatabaseGame`; same conceptual change: remove client-side generation, consume `encounter.games`.
+
+### 5.2 When to Call Generate
+
+- Option A: Explicit "Prepare results" / "Generate games" button that calls `generateEncounterGames(encounterId)`.
+- Option B: Implicit when user opens Results step (or when both assemblies are complete) — frontend or backend triggers generation so that by the time the user sees the form, `encounter.games` is populated.
+- Product decision; implementation can support both (e.g. mutation + optional auto-trigger in resolver when loading encounter for edit).
+
+### 5.3 Detail Encounter (Read-only)
+
+- Already iterates `encounterCompetition?.games`; no structural change. Sorting by backend `order` (completion order) keeps display consistent; if matchName/slotIndex is added, display can follow slot order.
+
+---
+
+## 6. Worker / Sync Impact
+
+### 6.1 EnterScores (Puppeteer)
+
+- **matchGamesToAssembly:** Matches DB games to assembly positions by player IDs (and fallback by empty placeholder + visualCode). If backend has already assigned one game per slot, matching can simplify to: order games by slot, map by position index.
+- **enterGames and visualCode:** The flow does **not** depend on `game.visualCode` to find the form row. For each game (by assembly position), it calls **findGameRowByAssemblyPosition(page, teamType, assemblyPosition, logger)** which:
+  - Uses `getHeaderForAssemblyPosition(teamType, assemblyPosition)` (from assemblyPositions.ts) to get the toernooi.nl header for that slot (e.g. "HD1", "DD2").
+  - Finds the table row on the page with that header and reads the `matchId` from the row’s match inputs.
+  - Verifies the row is empty via **isGameRowEmpty** (so we don’t overwrite filled rows).
+  - Returns the matchId; if none or row not empty, returns null and enterGames throws.
+- After obtaining the matchId, enterGames uses it for the rest of the step (select players, enter scores, enter winner). It then **validates/corrects** visualCode: if `game.visualCode` was missing or differed from the discovered matchId, it sets `game.visualCode = correctMatchId` and **saves to the database** (when transaction is provided). So games without visualCode or with a wrong one are still pushed, and the correct visualCode is persisted for future runs.
+- **Impact for backend generation:** No change required in EnterScores for backend-generated games without visualCode; the existing assembly-position-based resolution and visualCode correction already support them.
+
+### 6.2 Sync FROM toernooi.nl (ProcessSyncCompetitionEncounter / ProcessSyncCompetitionGame)
+
+- Encounter processor removes DB games whose `visualCode` is not in the visual match list. Backend-generated games must either have a visualCode that exists on toernooi.nl or be excluded from this delete (e.g. by linkType or a "generated" flag). See §3.2.
+
+---
+
+## 7. Testing Impact
+
+- **Unit:** New EncounterGamesGenerationService: test slot order (M/F vs MX), player resolution from assemblies, idempotency, and "create missing only" vs "reassign" policy.
+- **Integration:** Encounter resolver + generation: call generateEncounterGames, assert 8 games, correct gameTypes and players per slot.
+- **Sync:** Ensure sync-from-toernooi does not delete backend-generated games that have no visualCode (or that we never generate without visualCode when sync will run). EnterScores E2E or integration: encounter with backend-generated games (with visualCode) still fills form correctly.
+- **Frontend:** Edit-encounter: load encounter after generation, verify 8 cards, save updates by id, no duplicate create.
+
+---
+
+## 8. Files Changed Summary
+
+### New
+
+- Service: Encounter games generation (e.g. `encounter-games-generation.service.ts`).
+- GraphQL: Mutation `generateEncounterGames` and resolver method.
+- Tests: Unit for generation service; integration for encounter + generation.
+
+### Modified
+
+- **Backend:** Encounter resolver (optional auto-trigger or call to generation service), possibly game resolver (restrict createGame for competition encounters to "missing slot only" or leave as-is).
+- **Sync (worker):** Possibly adjust encounter/game processor so backend-generated games (linkType competition, or without visualCode) are not deleted by sync-from-toernooi; and ensure linkId/linkType are correct for competition.
+- **Frontend (Next.js 15, external repo):** Edit-encounter equivalent and any game-generation hook: remove createGameObjects/getMatchingDatabaseGame; consume `encounter.games` by id; call generateEncounterGames when needed; use updateGame for saves on existing games.
+
+### Unchanged
+
+- Assembly validation, assembly save flow, PDF export, ranking points (games still exist and are updated as today).
+
+---
+
+## 9. Assumptions Log
+
+- [CONFIRMED] Games for competition encounters use `linkId = encounter.id` and `linkType = "competition"`. Sync-events-v2 game processor uses draw.id/linkType "tournament" for a different flow; competition encounters use the encounter link. Backend generation must use the correct link (encounter.id + "competition").
+- [CLARIFIED] visualCode is **not** required for pushing to toernooi.nl. EnterScores finds the form row by assembly position via `findGameRowByAssemblyPosition` and persists the discovered matchId as `game.visualCode`. Backend can create games with null visualCode; they can still be pushed and will get visualCode set and saved during EnterScores.
+- [CLARIFIED] **Slot order and match names:** On the frontend, **matchName** (single1..4, double1..4) is the slot identity and is **never** sent to the backend; the frontend iterates slots in a fixed order (double1..4, single1..4; MX uses same set with different display order). The backend has no matchName field; the sync worker uses `ASSEMBLY_POSITION_ORDER` / `getHeaderForAssemblyPosition` in `assemblyPositions.ts` for the same logical slots. Backend generation must use the **same canonical slot set and order** (e.g. shared constant or assemblyPositions) so frontend, backend, and sync worker stay aligned; the frontend will continue to infer which game is which slot by matching gameType + players (and optionally visualCode). **Reference:** [games-slot-order-and-matchName.md](./games-slot-order-and-matchName.md).
+- [CLARIFIED] **order vs slot:** The frontend sends and expects **order** as **completion order** (1 = first game completed, 2 = second, …); it is **not** slot index. So we **cannot** use `order` (1..8) for slot index. A **schema migration adding `matchName` or `slotIndex`** is required if the backend is to store which slot a game belongs to; otherwise the frontend keeps inferring slot by matching. Generation service: when creating games, leave `order` null (or set only when game is completed); if a slot field is added, set it per canonical slot. **Reference:** [games-slot-order-and-matchName.md](./games-slot-order-and-matchName.md).
+- [CLARIFIED] The frontend that works with the API in this repo is the one targeted by the frontend analysis (createGameObjects, getMatchingDatabaseGame, useEncounterFormGames). The conceptual change is to remove client-side generation and use server-generated games by id. This repo also contains a **legacy** Angular frontend used only for reference (e.g. to see how features were implemented in the legacy codebase when building them in the current frontend); changes apply to the current frontend that consumes the API, not to the legacy one.
+

--- a/docs/estimates/backend-encounter-games-generation/samenvatting.md
+++ b/docs/estimates/backend-encounter-games-generation/samenvatting.md
@@ -1,0 +1,31 @@
+# Samenvatting: Backend Encounter Games Generation
+
+## Overzicht
+
+We verplaatsen de aanmaak van de 8 wedstrijden per encounter van de frontend naar de backend. Nu worden deze games aan de client-kant gegenereerd, wat leidt tot “spook”-games en dubbele wedstrijden. Door ze **eenmalig op de server** te creëren, ontstaat één duidelijke bron van waarheid: de encounter heeft precies 8 games met vastgelegde spelers en volgorde. Dat verbetert de stabiliteit en voorkomt de huidige bugs. De bestaande synchronisatie met toernooi.nl (inclusief visualCode) blijft gewaarborgd.
+
+## Aanpak
+
+- **Backend:** Een nieuwe service berekent voor een encounter de 8 slots (dubbel 1–4, enkel 1–4 of MX-equivalent) op basis van de assemblies, koppelt bestaande games waar mogelijk en maakt alleen ontbrekende games aan. Een GraphQL-mutatie `generateEncounterGames(encounterId)` roept deze service aan; de frontend kan dit expliciet (knop) of bij het openen van de Resultaten-stap doen.
+- **Frontend:** De edit-encounter pagina stopt met eigen “createGameObjects”-logica en gebruikt uitsluitend `encounter.games` (op id). Het formulier wordt opgebouwd uit deze lijst (gesorteerd op volgorde); bij opslaan worden bestaande games via `updateGame` bijgewerkt. Er worden geen extra games meer client-side aangemaakt voor de 8 slots.
+- **Sync (toernooi.nl):** De worker wordt aangepast zodat games die bij een competition encounter horen (`linkId` = encounter.id, `linkType` = "competition") niet worden verwijderd wanneer ze niet in de visuele matchlijst van toernooi.nl staan. Bij het verwerken van encounter-games worden `linkId` en `linkType` correct gezet. EnterScores vindt de formulierrij op basis van assembly-positie (`findGameRowByAssemblyPosition`) en slaat `game.visualCode` op wanneer die ontbreekt; backend-gegenereerde games met of zonder visualCode kunnen dus worden weggeschreven.
+
+**Toernooi.nl-integratie** (sync van en naar toernooi.nl) is een belangrijke randvoorwaarde. De inschatting houdt expliciet rekening met aanpassingen in de worker en, waar nodig, met de afstemming van `linkId`/`linkType` voor competition encounters.
+
+## Hoofdrisico
+
+Het grootste risico zit in de **sync met toernooi.nl en het gebruik van visualCode**. Games krijgen hun visualCode vanuit toernooi.nl; als we server-side games aanmaken vóór sync, kunnen ze (zonder visualCode) ten onrechte worden verwijderd bij een volgende sync-from, tenzij de worker competition-games uitsluit van die opruimlogica. EnterScores werkt al met games zonder visualCode (vindt rij op assembly-positie en slaat visualCode op); backend-gegenereerde games met of zonder visualCode kunnen worden weggeschreven. De voorgestelde sync-aanpassingen (guard op linkType, correct zetten van linkId/linkType) mitigeren dit; de exacte volgorde “toernooi eerst” vs “Badman eerst” beïnvloedt de randgevallen.
+
+## Inschatting inspanning
+
+| Scenario      | Uren  | Toelichting |
+|---------------|-------|-------------|
+| Optimistisch  | 48 u  | Geen migratieproblemen; sync ondersteunt competition al; frontend heeft geen extra create-paden. |
+| Verwachting   | **56 u** | Circa 7 dev-dagen met AI; standaard aannames. |
+| Pessimistisch | 68 u  | Verduidelijking competition vs tournament sync; idempotency randgevallen; migratie voor veel bestaande encounters. |
+
+**Doorlooptijd:** 1 sprint (2 weken) met 1 developer + AI, of 2 sprints als eerst sync/visualCode wordt uitgerijpt.
+
+---
+
+Deze samenvatting ondersteunt de beslissing om de feature te doen: één duidelijke generatie op de backend, stabielere encounters en behoud van toernooi.nl-sync, met een realistische bandbreedte rond 56 uur.


### PR DESCRIPTION
## Summary

- Partial revert of 595473afe restoring `docs/estimates/backend-encounter-games-generation/` (6 markdown files).
- Lib `libs/backend/competition/encounter-games` lives on develop and arrives on main when develop merges; this PR front-runs the docs so they exist on main independent of merge timing.
- No code paths touched; documentation only.

## Test plan

- [ ] Verify the six markdown files render correctly on GitHub
- [ ] Confirm no other files are modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)