### PR TITLE
revert: restore CP export feature on main

### DIFF
--- a/.github/workflows/generate-cp.yml
+++ b/.github/workflows/generate-cp.yml
@@ -1,0 +1,74 @@
+name: Generate CP File
+
+on:
+  workflow_dispatch:
+    inputs:
+      payload:
+        description: "CpPayload JSON (base64-encoded)"
+        required: true
+      callback_url:
+        description: "Backend webhook URL for completion notification"
+        required: true
+      requesting_user_id:
+        description: "User ID to notify via email"
+        required: true
+
+jobs:
+  generate:
+    runs-on: windows-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Decode payload
+        shell: bash
+        run: |
+          node --input-type=module -e "
+            import fs from 'node:fs';
+            const decoded = Buffer.from(process.env.PAYLOAD_B64, 'base64').toString('utf-8');
+            fs.writeFileSync('payload.json', decoded);
+            console.log('Payload decoded, size:', decoded.length, 'bytes');
+          "
+        env:
+          PAYLOAD_B64: ${{ inputs.payload }}
+
+      - name: Build file writer
+        run: npx nx build backend-generator
+
+      - name: Generate CP file
+        run: node dist/libs/backend/generator/src/scripts/cp-file-writer.js payload.json
+        env:
+          CP_PASS: ${{ secrets.CP_PASS }}
+
+      - name: Upload CP file artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cp-file
+          path: "*.cp"
+          retention-days: 30
+
+      - name: Notify backend (success)
+        if: success()
+        shell: bash
+        run: |
+          curl -s -X POST "${{ inputs.callback_url }}" \
+            -H "Content-Type: application/json" \
+            -H "X-Webhook-Secret: ${{ secrets.CP_WEBHOOK_SECRET }}" \
+            -d "{\"run_id\": \"${{ github.run_id }}\", \"user_id\": \"${{ inputs.requesting_user_id }}\", \"status\": \"completed\"}"
+
+      - name: Notify backend (failure)
+        if: failure()
+        shell: bash
+        run: |
+          curl -s -X POST "${{ inputs.callback_url }}" \
+            -H "Content-Type: application/json" \
+            -H "X-Webhook-Secret: ${{ secrets.CP_WEBHOOK_SECRET }}" \
+            -d "{\"run_id\": \"${{ github.run_id }}\", \"user_id\": \"${{ inputs.requesting_user_id }}\", \"status\": \"failed\"}"

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -4,6 +4,7 @@ import { APP_FILTER } from "@nestjs/core";
 import { SentryModule } from "@sentry/nestjs/setup";
 import { PrematureCloseFilter } from "./filters/premature-close.filter";
 import { AppController, ImageController } from "./controllers";
+import { CpController } from "./controllers/cp.controller";
 
 import { AuthorizationModule } from "@badman/backend-authorization";
 import { DatabaseModule } from "@badman/backend-database";
@@ -82,7 +83,7 @@ const envFilePath = join(projectRoot, envFileName);
     SocketModule,
     TransferLoanModule,
   ],
-  controllers: [AppController, ImageController, CalendarController],
+  controllers: [AppController, ImageController, CalendarController, CpController],
   providers: [
     Logger,
     { provide: APP_FILTER, useClass: PrematureCloseFilter },

--- a/apps/api/src/app/controllers/cp.controller.spec.ts
+++ b/apps/api/src/app/controllers/cp.controller.spec.ts
@@ -1,0 +1,336 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigService } from "@nestjs/config";
+import { UnauthorizedException, NotFoundException } from "@nestjs/common";
+import { CpController } from "./cp.controller";
+import { CpDataCollector } from "@badman/backend-generator";
+import { Player } from "@badman/backend-database";
+import { CpPayload } from "@badman/backend-generator";
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+function mockUser(overrides = {}): Player {
+  return {
+    id: "user-1",
+    email: "user@test.be",
+    fullName: "Test User",
+    hasAnyPermission: jest.fn().mockResolvedValue(true),
+    ...overrides,
+  } as unknown as Player;
+}
+
+function minimalPayload(): CpPayload {
+  return {
+    event: { name: "Test", season: 2025 },
+    subEvents: [],
+    clubs: [],
+    locations: [],
+    teams: [],
+    players: [],
+    teamPlayers: [],
+    entries: [],
+    memos: [],
+    settings: { tournamentName: "Test" },
+  };
+}
+
+describe("CpController", () => {
+  let controller: CpController;
+  let mockDataCollector: jest.Mocked<CpDataCollector>;
+  let mockConfigService: Record<string, any>;
+
+  beforeEach(async () => {
+    mockDataCollector = {
+      collect: jest.fn().mockResolvedValue(minimalPayload()),
+    } as any;
+
+    mockConfigService = {
+      GITHUB_TOKEN_CP: "ghp_test_token",
+      GITHUB_REPO_OWNER: "Badminton-Apps",
+      GITHUB_REPO_NAME: "badman",
+      CP_CALLBACK_URL: "https://api.test.com/cp/webhook",
+      CP_WEBHOOK_SECRET: "test-secret",
+      CLIENT_URL: "https://badman.app",
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CpController],
+      providers: [
+        { provide: CpDataCollector, useValue: mockDataCollector },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => mockConfigService[key]),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<CpController>(CpController);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("POST /cp/generate", () => {
+    it("should reject unauthenticated requests", async () => {
+      const noUser = { id: undefined } as unknown as Player;
+
+      await expect(controller.generate(noUser, { eventId: "event-1" })).rejects.toThrow(
+        UnauthorizedException
+      );
+    });
+
+    it("should reject users without export-cp:competition permission", async () => {
+      const user = mockUser({
+        hasAnyPermission: jest.fn().mockResolvedValue(false),
+      });
+
+      await expect(controller.generate(user, { eventId: "event-1" })).rejects.toThrow(
+        UnauthorizedException
+      );
+    });
+
+    it("should call CpDataCollector and trigger workflow_dispatch", async () => {
+      const user = mockUser();
+      mockFetch.mockResolvedValue({ status: 204 });
+
+      const result = await controller.generate(user, {
+        eventId: "event-1",
+      });
+
+      expect(mockDataCollector.collect).toHaveBeenCalledWith("event-1");
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("actions/workflows/generate-cp.yml/dispatches"),
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            Authorization: "Bearer ghp_test_token",
+          }),
+        })
+      );
+      expect(result.message).toContain("started");
+      expect(result.trackingId).toBeDefined();
+    });
+
+    it("should return 400 if eventId is missing", async () => {
+      const user = mockUser();
+
+      await expect(controller.generate(user, { eventId: "" })).rejects.toThrow();
+    });
+
+    it("should base64-encode the payload in the workflow dispatch", async () => {
+      const user = mockUser();
+      mockFetch.mockResolvedValue({ status: 204 });
+
+      await controller.generate(user, { eventId: "event-1" });
+
+      const fetchCall = mockFetch.mock.calls[0];
+      const body = JSON.parse(fetchCall[1].body);
+
+      // Verify payload input is base64
+      const decoded = Buffer.from(body.inputs.payload, "base64").toString("utf-8");
+      const payload = JSON.parse(decoded);
+      expect(payload.event.name).toBe("Test");
+    });
+
+    it("should return 502 if GitHub API fails", async () => {
+      const user = mockUser();
+      mockFetch.mockResolvedValue({
+        status: 422,
+        text: jest.fn().mockResolvedValue("Validation failed"),
+      });
+
+      await expect(controller.generate(user, { eventId: "event-1" })).rejects.toThrow(/502/);
+    });
+
+    it("should return 503 if GITHUB_TOKEN_CP is not configured", async () => {
+      mockConfigService.GITHUB_TOKEN_CP = undefined;
+      const user = mockUser();
+
+      await expect(controller.generate(user, { eventId: "event-1" })).rejects.toThrow(/503/);
+    });
+
+    it("should return 409 if generation is already in progress for same event", async () => {
+      const user = mockUser();
+      mockFetch.mockResolvedValue({ status: 204 });
+
+      // First call succeeds
+      await controller.generate(user, { eventId: "event-1" });
+
+      // Second call should be rejected
+      await expect(controller.generate(user, { eventId: "event-1" })).rejects.toThrow(/409/);
+    });
+  });
+
+  describe("POST /cp/webhook", () => {
+    it("should reject requests with invalid webhook secret", async () => {
+      await expect(
+        controller.webhook("wrong-secret", {
+          run_id: "123",
+          user_id: "user-1",
+          status: "completed",
+        })
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("should reject requests with missing webhook secret", async () => {
+      await expect(
+        controller.webhook("", {
+          run_id: "123",
+          user_id: "user-1",
+          status: "completed",
+        })
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("should accept valid webhook and update generation record", async () => {
+      // First, trigger a generation to create a pending record
+      const user = mockUser();
+      mockFetch.mockResolvedValue({ status: 204 });
+      await controller.generate(user, { eventId: "event-1" });
+
+      jest.spyOn(Player, "findByPk").mockResolvedValue({
+        email: "user@test.be",
+        fullName: "Test User",
+      } as any);
+
+      const result = await controller.webhook("test-secret", {
+        run_id: "gh-run-456",
+        user_id: "user-1",
+        status: "completed",
+      });
+
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("should handle failed status", async () => {
+      const user = mockUser();
+      mockFetch.mockResolvedValue({ status: 204 });
+      await controller.generate(user, { eventId: "event-1" });
+
+      jest.spyOn(Player, "findByPk").mockResolvedValue({
+        email: "user@test.be",
+        fullName: "Test User",
+      } as any);
+
+      const result = await controller.webhook("test-secret", {
+        run_id: "gh-run-789",
+        user_id: "user-1",
+        status: "failed",
+      });
+
+      expect(result).toEqual({ ok: true });
+    });
+  });
+
+  describe("GET /cp/download/:runId", () => {
+    it("should reject unauthenticated requests", async () => {
+      const noUser = { id: undefined } as unknown as Player;
+      const mockRes = {} as any;
+
+      await expect(controller.download(noUser, "run-123", mockRes)).rejects.toThrow(
+        UnauthorizedException
+      );
+    });
+
+    it("should reject users without permission", async () => {
+      const user = mockUser({
+        hasAnyPermission: jest.fn().mockResolvedValue(false),
+      });
+      const mockRes = {} as any;
+
+      await expect(controller.download(user, "run-123", mockRes)).rejects.toThrow(
+        UnauthorizedException
+      );
+    });
+
+    it("should return 404 for unknown runId", async () => {
+      const user = mockUser();
+      const mockRes = {} as any;
+
+      await expect(controller.download(user, "unknown-run", mockRes)).rejects.toThrow(
+        NotFoundException
+      );
+    });
+
+    it("should return 410 for failed generation", async () => {
+      // Set up a completed webhook first
+      const user = mockUser();
+      mockFetch.mockResolvedValue({ status: 204 });
+      await controller.generate(user, { eventId: "event-1" });
+
+      jest.spyOn(Player, "findByPk").mockResolvedValue({
+        email: "user@test.be",
+        fullName: "Test User",
+      } as any);
+
+      await controller.webhook("test-secret", {
+        run_id: "gh-run-failed",
+        user_id: "user-1",
+        status: "failed",
+      });
+
+      const mockRes = {} as any;
+
+      await expect(controller.download(user, "gh-run-failed", mockRes)).rejects.toThrow(/failed/i);
+    });
+
+    it("should fetch artifact from GitHub and stream to response", async () => {
+      // Set up a completed generation
+      const user = mockUser();
+      mockFetch
+        .mockResolvedValueOnce({ status: 204 }) // workflow dispatch
+        .mockResolvedValueOnce({
+          // artifacts list
+          ok: true,
+          json: jest.fn().mockResolvedValue({
+            artifacts: [
+              {
+                id: 1,
+                name: "cp-file",
+                archive_download_url:
+                  "https://api.github.com/repos/test/test/actions/artifacts/1/zip",
+              },
+            ],
+          }),
+        })
+        .mockResolvedValueOnce({
+          // artifact download
+          ok: true,
+          arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(100)),
+        });
+
+      await controller.generate(user, { eventId: "event-1" });
+
+      jest.spyOn(Player, "findByPk").mockResolvedValue({
+        email: "user@test.be",
+        fullName: "Test User",
+      } as any);
+
+      await controller.webhook("test-secret", {
+        run_id: "gh-run-ok",
+        user_id: "user-1",
+        status: "completed",
+      });
+
+      const mockRes = {
+        header: jest.fn(),
+        type: jest.fn().mockReturnThis(),
+        send: jest.fn(),
+      } as any;
+
+      await controller.download(user, "gh-run-ok", mockRes);
+
+      expect(mockRes.header).toHaveBeenCalledWith(
+        "Content-Disposition",
+        expect.stringContaining("cp-file")
+      );
+      expect(mockRes.type).toHaveBeenCalledWith("application/zip");
+      expect(mockRes.send).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/app/controllers/cp.controller.ts
+++ b/apps/api/src/app/controllers/cp.controller.ts
@@ -1,0 +1,340 @@
+import { User } from "@badman/backend-authorization";
+import { Player } from "@badman/backend-database";
+import { CpDataCollector } from "@badman/backend-generator";
+import { MailingService } from "@badman/backend-mailing";
+import { ConfigType } from "@badman/utils";
+import {
+  Body,
+  Controller,
+  Get,
+  Headers,
+  HttpException,
+  Logger,
+  NotFoundException,
+  Param,
+  Post,
+  Query,
+  Res,
+  UnauthorizedException,
+} from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { AllowAnonymous } from "@badman/backend-authorization";
+import { FastifyReply } from "fastify";
+
+interface CpGenerationRecord {
+  runId: string;
+  userId: string;
+  eventId: string;
+  status: "pending" | "completed" | "failed";
+  createdAt: Date;
+}
+
+@Controller("cp")
+export class CpController {
+  private readonly logger = new Logger(CpController.name);
+
+  /**
+   * In-memory store for generation records.
+   * For a once-a-year operation, this is sufficient.
+   * Records auto-expire after 24 hours.
+   */
+  private generations = new Map<string, CpGenerationRecord>();
+  private pendingByEvent = new Map<string, string>();
+
+  constructor(
+    private dataCollector: CpDataCollector,
+    private configService: ConfigService<ConfigType>,
+    private mailingService: MailingService
+  ) {}
+
+  @Post("generate")
+  async generate(@User() user: Player, @Body() body: { eventId: string }) {
+    if (!user?.id) {
+      throw new UnauthorizedException("Authentication required");
+    }
+
+    const hasPermission = await user.hasAnyPermission(["export-cp:competition"]);
+    if (!hasPermission) {
+      throw new UnauthorizedException("You do not have permission to export CP files");
+    }
+
+    const { eventId } = body;
+    if (!eventId) {
+      throw new HttpException("eventId is required", 400);
+    }
+
+    // Prevent concurrent generation for the same event
+    const existingPending = this.pendingByEvent.get(eventId);
+    if (existingPending) {
+      const record = this.generations.get(existingPending);
+      if (record && record.status === "pending") {
+        const ageMinutes = (Date.now() - record.createdAt.getTime()) / 1000 / 60;
+        if (ageMinutes < 15) {
+          throw new HttpException(
+            "A CP generation is already in progress for this event. Please wait for it to complete.",
+            409
+          );
+        }
+        // Expired pending record, clean up
+        this.generations.delete(existingPending);
+        this.pendingByEvent.delete(eventId);
+      }
+    }
+
+    // Collect data from PostgreSQL
+    this.logger.log(`Collecting CP data for event ${eventId}`);
+    const payload = await this.dataCollector.collect(eventId);
+
+    // Base64 encode
+    const payloadJson = JSON.stringify(payload);
+    const payloadBase64 = Buffer.from(payloadJson).toString("base64");
+
+    // Validate size (GitHub workflow_dispatch input limit is 65535 chars)
+    if (payloadBase64.length > 65535) {
+      throw new HttpException(
+        `Competition data is too large for export (${payloadBase64.length} chars, max 65535). Contact support.`,
+        413
+      );
+    }
+
+    // Trigger GitHub Actions workflow
+    const githubToken = this.configService.get("GITHUB_TOKEN_CP");
+    const repoOwner = this.configService.get("GITHUB_REPO_OWNER") || "Badminton-Apps";
+    const repoName = this.configService.get("GITHUB_REPO_NAME") || "badman";
+    const callbackUrl = this.configService.get("CP_CALLBACK_URL");
+
+    if (!githubToken) {
+      throw new HttpException("CP export is not configured (missing GITHUB_TOKEN_CP)", 503);
+    }
+    if (!callbackUrl) {
+      throw new HttpException("CP export is not configured (missing CP_CALLBACK_URL)", 503);
+    }
+
+    const workflowUrl = `https://api.github.com/repos/${repoOwner}/${repoName}/actions/workflows/generate-cp.yml/dispatches`;
+
+    const response = await fetch(workflowUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${githubToken}`,
+        Accept: "application/vnd.github.v3+json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        ref: "develop",
+        inputs: {
+          payload: payloadBase64,
+          callback_url: callbackUrl,
+          requesting_user_id: user.id,
+        },
+      }),
+    });
+
+    if (response.status !== 204) {
+      const errorBody = await response.text();
+      this.logger.error(`GitHub API error: ${response.status} ${errorBody}`);
+      throw new HttpException(
+        `Failed to trigger CP generation: GitHub API returned ${response.status}`,
+        502
+      );
+    }
+
+    // Track pending generation (we don't get a run_id from dispatch, the webhook will provide it)
+    const trackingId = `${eventId}-${Date.now()}`;
+    const record: CpGenerationRecord = {
+      runId: trackingId,
+      userId: user.id,
+      eventId,
+      status: "pending",
+      createdAt: new Date(),
+    };
+    this.generations.set(trackingId, record);
+    this.pendingByEvent.set(eventId, trackingId);
+
+    this.logger.log(`CP generation triggered for event ${eventId} by user ${user.id}`);
+
+    return {
+      message:
+        "CP generation started. You will receive an email when the file is ready for download.",
+      trackingId,
+    };
+  }
+
+  @Post("webhook")
+  @AllowAnonymous()
+  async webhook(
+    @Headers("x-webhook-secret") webhookSecret: string,
+    @Body() body: { run_id: string; user_id: string; status: string }
+  ) {
+    const expectedSecret = this.configService.get("CP_WEBHOOK_SECRET");
+    if (!webhookSecret || webhookSecret !== expectedSecret) {
+      throw new UnauthorizedException("Invalid webhook secret");
+    }
+
+    this.logger.log(
+      `CP webhook received: run_id=${body.run_id}, status=${body.status}, user_id=${body.user_id}`
+    );
+
+    // Find the pending record for this user and update it with the real run_id
+    let matchedTrackingId: string | undefined;
+    for (const [trackingId, record] of this.generations) {
+      if (record.userId === body.user_id && record.status === "pending") {
+        record.runId = body.run_id;
+        record.status = body.status === "completed" ? "completed" : "failed";
+        matchedTrackingId = trackingId;
+
+        // Clean up pending-by-event
+        this.pendingByEvent.delete(record.eventId);
+        break;
+      }
+    }
+
+    // Also store by run_id for download lookups
+    if (matchedTrackingId) {
+      const record = this.generations.get(matchedTrackingId)!;
+      this.generations.set(body.run_id, record);
+    }
+
+    // Send email notification
+    if (body.status === "completed") {
+      await this._sendCompletionEmail(body.user_id, body.run_id);
+    } else {
+      await this._sendFailureEmail(body.user_id);
+    }
+
+    return { ok: true };
+  }
+
+  @Get("download/:runId")
+  async download(@User() user: Player, @Param("runId") runId: string, @Res() res: FastifyReply) {
+    if (!user?.id) {
+      throw new UnauthorizedException("Authentication required");
+    }
+
+    const hasPermission = await user.hasAnyPermission(["export-cp:competition"]);
+    if (!hasPermission) {
+      throw new UnauthorizedException("You do not have permission to download CP files");
+    }
+
+    // Verify ownership (or admin)
+    const record = this.generations.get(runId);
+    if (!record) {
+      throw new NotFoundException("Generation not found or expired");
+    }
+
+    if (record.status === "failed") {
+      throw new HttpException("This generation failed. Please try again.", 410);
+    }
+
+    if (record.status === "pending") {
+      throw new HttpException(
+        "This generation is still in progress. Please wait for the email notification.",
+        202
+      );
+    }
+
+    // Fetch artifact from GitHub
+    const githubToken = this.configService.get("GITHUB_TOKEN_CP");
+    const repoOwner = this.configService.get("GITHUB_REPO_OWNER") || "Badminton-Apps";
+    const repoName = this.configService.get("GITHUB_REPO_NAME") || "badman";
+
+    const artifactsUrl = `https://api.github.com/repos/${repoOwner}/${repoName}/actions/runs/${runId}/artifacts`;
+
+    const artifactsRes = await fetch(artifactsUrl, {
+      headers: {
+        Authorization: `Bearer ${githubToken}`,
+        Accept: "application/vnd.github.v3+json",
+      },
+    });
+
+    if (!artifactsRes.ok) {
+      if (artifactsRes.status === 404) {
+        throw new HttpException(
+          "CP file has expired (artifacts are kept for 30 days). Please regenerate.",
+          410
+        );
+      }
+      throw new HttpException(
+        `Failed to fetch artifact: GitHub API returned ${artifactsRes.status}`,
+        502
+      );
+    }
+
+    const artifactsData = (await artifactsRes.json()) as {
+      artifacts: { id: number; name: string; archive_download_url: string }[];
+    };
+    const cpArtifact = artifactsData.artifacts.find((a) => a.name === "cp-file");
+
+    if (!cpArtifact) {
+      throw new HttpException("CP file artifact not found. It may have expired.", 410);
+    }
+
+    // Download the artifact zip
+    const downloadRes = await fetch(cpArtifact.archive_download_url, {
+      headers: {
+        Authorization: `Bearer ${githubToken}`,
+        Accept: "application/vnd.github.v3+json",
+      },
+    });
+
+    if (!downloadRes.ok) {
+      throw new HttpException(`Failed to download artifact: ${downloadRes.status}`, 502);
+    }
+
+    // GitHub returns a zip file containing the .cp file
+    // Stream the zip directly -- the frontend/user can extract it
+    const buffer = Buffer.from(await downloadRes.arrayBuffer());
+
+    res.header("Content-Disposition", `attachment; filename="cp-file-${runId}.zip"`);
+    res.type("application/zip").send(buffer);
+  }
+
+  private async _sendCompletionEmail(userId: string, runId: string): Promise<void> {
+    const player = await Player.findByPk(userId);
+    if (!player?.email) {
+      this.logger.warn(`Cannot send CP completion email: user ${userId} has no email`);
+      return;
+    }
+
+    const clientUrl = this.configService.get("CLIENT_URL") || "";
+    const downloadUrl = `${clientUrl}/cp/download/${runId}`;
+
+    this.logger.log(
+      `CP file ready for user ${player.fullName} (${player.email}). Download: ${downloadUrl}`
+    );
+
+    await this.mailingService.sendCpExportReadyMail(
+      { fullName: player.fullName, email: player.email, slug: player.slug },
+      downloadUrl
+    );
+  }
+
+  private async _sendFailureEmail(userId: string): Promise<void> {
+    const player = await Player.findByPk(userId);
+    if (!player?.email) {
+      this.logger.warn(`Cannot send CP failure email: user ${userId} has no email`);
+      return;
+    }
+
+    await this.mailingService.sendCpExportFailedMail({
+      fullName: player.fullName,
+      email: player.email,
+      slug: player.slug,
+    });
+  }
+
+  /**
+   * Clean up expired generation records (older than 24 hours).
+   * Called lazily -- not on a timer, just when new requests come in.
+   */
+  private _cleanupExpiredRecords(): void {
+    const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+    for (const [key, record] of this.generations) {
+      if (record.createdAt.getTime() < cutoff) {
+        this.generations.delete(key);
+        if (this.pendingByEvent.get(record.eventId) === key) {
+          this.pendingByEvent.delete(record.eventId);
+        }
+      }
+    }
+  }
+}

--- a/docs/estimates/export-reports-migration/architecture.md
+++ b/docs/estimates/export-reports-migration/architecture.md
@@ -1,0 +1,259 @@
+# Architecture Overview: Export/Report Migration
+
+## High-Level Architecture
+
+```mermaid
+graph TB
+    subgraph "New Frontend (Next.js 15 / Vercel)"
+        FE_Menu["Export MUI Menu<br/>(client component)"]
+        FE_AvgPage["Average Level Page<br/>(client component + charts)"]
+        FE_Download["Download Hooks/Utils"]
+        FE_Apollo["Apollo Client"]
+    end
+
+    subgraph "Backend (NestJS + Fastify)"
+        subgraph "NEW"
+            ExportCtrl["ExportController<br/>/excel/teams<br/>/excel/exceptions<br/>/excel/locations"]
+            ExportSvc["CompetitionExportService"]
+            XlsxUtil["Shared XLSX Utility"]
+        end
+        subgraph "EXISTING (to be secured)"
+            EnrollCtrl["EnrollemntController<br/>/excel/enrollment"]
+            EnrollSvc["ExcelService<br/>(enrollment)"]
+            CpCtrl["AppController.getCp<br/>/cp"]
+            CpSvc["CpGeneratorService"]
+        end
+        subgraph "EXISTING (no changes)"
+            GqlResolver["SubEvent Resolver<br/>averageLevel field"]
+            AuthUtils["canExecute() + @User()"]
+        end
+    end
+
+    subgraph "Database (PostgreSQL)"
+        DB[(EventCompetitions<br/>SubEventCompetitions<br/>DrawCompetitions<br/>EventEntries<br/>Teams / Clubs<br/>Locations / Availabilities<br/>Players / Rankings)]
+    end
+
+    subgraph "External"
+        ADODB["node-adodb<br/>(Windows only)"]
+        CPFile[".cp file<br/>(Competition Planner)"]
+    end
+
+    FE_Menu -->|"fetch GET (blob)"| ExportCtrl
+    FE_Menu -->|"fetch GET (blob)"| EnrollCtrl
+    FE_Menu -->|"fetch GET (blob)"| CpCtrl
+    FE_Menu --> FE_Download
+    FE_AvgPage -->|"GraphQL query"| FE_Apollo
+    FE_Apollo -->|"HTTP POST /graphql"| GqlResolver
+
+    ExportCtrl --> AuthUtils
+    ExportCtrl --> ExportSvc
+    ExportSvc --> XlsxUtil
+    EnrollCtrl --> AuthUtils
+    EnrollCtrl --> EnrollSvc
+    EnrollSvc --> XlsxUtil
+    CpCtrl --> AuthUtils
+    CpCtrl --> CpSvc
+    CpSvc --> ADODB
+    ADODB --> CPFile
+
+    ExportSvc --> DB
+    EnrollSvc --> DB
+    CpSvc --> DB
+    GqlResolver --> DB
+```
+
+## Component Inventory
+
+### New Files
+
+| File | Type | Responsibility |
+|------|------|----------------|
+| `libs/backend/utils/xlsx/src/xlsx.util.ts` | BE Utility | Shared XLSX generation: workbook creation, sheet building with auto-sized columns + autofilter, buffer output |
+| `libs/backend/utils/xlsx/src/index.ts` | BE Module | Barrel export for shared XLSX utility |
+| `libs/backend/competition/export/src/services/export.service.ts` | BE Service | `CompetitionExportService` with `getTeamsExport()`, `getExceptionsExport()`, `getLocationsExport()` |
+| `libs/backend/competition/export/src/controllers/export.controller.ts` | BE Controller | REST endpoints: `GET /excel/teams`, `GET /excel/exceptions`, `GET /excel/locations` |
+| `libs/backend/competition/export/src/export.module.ts` | BE Module | NestJS module registering controller + service |
+| `libs/backend/competition/export/src/index.ts` | BE Module | Barrel export |
+| *FE app*`/competition/[id]/avg-level/page.tsx` | FE Page | Next.js App Router page for average level charts |
+| *FE app*`/components/competition/export-menu.tsx` | FE Component | MUI Menu with download buttons, permission-gated |
+| *FE app*`/hooks/use-export-download.ts` (or `utils/export-download.ts`) | FE Hook/Util | Fetch + blob download functions for all 5 REST endpoints |
+
+### Existing Files to Modify
+
+| File | Change |
+|------|--------|
+| `libs/backend/competition/enrollment/src/controllers/excel.controller.ts` | Add auth check (`@User()` + `canExecute`) |
+| `libs/backend/competition/enrollment/src/services/excel.services.ts` | Refactor to use shared XLSX utility |
+| `apps/api/src/app/controllers/app.controller.ts` | Add auth check on `getCp()` method |
+| `apps/api/src/app/app.module.ts` | Import new `CompetitionExportModule` |
+
+## Data Flow per Feature
+
+### Report 1: Average Level (Gemiddeld Niveau)
+
+```
+User navigates to /competition/[id]/avg-level
+  → Next.js client component renders
+  → Apollo Client sends GraphQL query GetAvgLevel
+  → Backend GraphQL resolver: SubEventCompetition.averageLevel
+    → Sequelize: traverse draws → encounters → games → players → rankings
+    → Calculate weighted averages by gender per discipline
+    → Return cached result (cache key: subevent-competition-average-level-{id})
+  → Frontend renders charts (recharts/nivo/apexcharts)
+  → User clicks "Download CSV" → client-side CSV generation → blob download
+```
+
+**Auth:** `edit:competition` permission checked on frontend (route guard).
+**Response:** GraphQL JSON → rendered as charts.
+
+### Report 2: Download Base Players (Basis Spelers)
+
+```
+User clicks "Download basis spelers" in export menu
+  → fetch GET /api/v1/excel/enrollment?eventId={id}
+  → EnrollemntController.getBaseplayersEnrollment()
+    → canExecute(user, { anyPermissions: ['edit:competition'] })
+    → ExcelService.GetEnrollment(eventId)
+      → EventCompetition.findByPk(eventId)
+      → Traverse subEvents → draws → entries → players
+      → Build XLSX via shared utility (headers: Naam, Voornaam, Lidnummer, Geslacht, etc.)
+    → Return buffer with Content-Disposition header
+  → Frontend receives blob → triggers download as {event.name}.xlsx
+```
+
+**Auth:** `edit:competition` (currently missing — to be added).
+**Response:** XLSX blob, `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`.
+
+### Report 3: Download Teams (Ploegen)
+
+```
+User clicks "Download ploegen" in export menu
+  → fetch GET /api/v1/excel/teams?eventId={id}
+  → ExportController.getTeamsExport()
+    → canExecute(user, { anyPermissions: ['export-teams:competition'] })
+    → CompetitionExportService.getTeamsExport(eventId)
+      → EventCompetition.findByPk(eventId) (validate exists)
+      → Traverse subEvents → draws → entries (include Team → Club)
+      → Deduplicate by team.id
+      → Build XLSX via shared utility
+        Headers: Club ID, Clubnaam, Ploegnaam, Voorkeur speelmoment (dag), Voorkeur speelmoment (tijdstip)
+    → Return buffer with Content-Disposition header
+  → Frontend receives blob → triggers download as {event.name}-teams.xlsx
+```
+
+**Auth:** `export-teams:competition`.
+**Response:** XLSX blob.
+
+### Report 4: Download Exceptions (Uitzonderingen)
+
+```
+User clicks "Download uitzonderingen" in export menu
+  → fetch GET /api/v1/excel/exceptions?eventId={id}
+  → ExportController.getExceptionsExport()
+    → canExecute(user, { anyPermissions: ['export-exceptions:competition'] })
+    → CompetitionExportService.getExceptionsExport(eventId)
+      → EventCompetition.findByPk(eventId) (validate exists)
+      → Traverse subEvents → draws → entries → Club → Location → Availability → exceptions
+      → For each exception: generate date range (start → end, one row per day)
+      → Format dates: Belgian locale (DD/MM/YYYY, Europe/Brussels)
+      → Deduplicate by composite key: (clubId, locationName, date)
+      → Build XLSX via shared utility
+        Headers: Club ID, Clubnaam, Locatie, Datum, Velden
+    → Return buffer with Content-Disposition header
+  → Frontend receives blob → triggers download as {event.name}-exceptions.xlsx
+```
+
+**Auth:** `export-exceptions:competition`.
+**Response:** XLSX blob.
+
+### Report 5: Download Locations (Locaties)
+
+```
+User clicks "Download locaties" in export menu
+  → fetch GET /api/v1/excel/locations?eventId={id}
+  → ExportController.getLocationsExport()
+    → canExecute(user, { anyPermissions: ['export-locations:competition'] })
+    → CompetitionExportService.getLocationsExport(eventId)
+      → EventCompetition.findByPk(eventId) (validate exists)
+      → Traverse subEvents → draws → entries → Club → Location → Availability → days
+      → Build address: [street, streetNumber, postalcode, city].filter(Boolean).join(' ')
+      → Translate day names EN → NL (monday → Maandag, etc.)
+      → Deduplicate by composite key: (clubId, locationName, day)
+      → Build XLSX via shared utility
+        Headers: Club ID, Clubnaam, Locatie, Adres, Dag, Aantal Velden
+    → Return buffer with Content-Disposition header
+  → Frontend receives blob → triggers download as {event.name}-locations.xlsx
+```
+
+**Auth:** `export-locations:competition`.
+**Response:** XLSX blob.
+
+### Report 6: Download CP File
+
+```
+User clicks "Download cp file" in export menu
+  → fetch GET /api/v1/cp?eventId={id}
+  → AppController.getCp()
+    → canExecute(user, { anyPermissions: ['change:job'] })
+    → CpGeneratorService.generateCpFile(eventId)
+      → Fetch event, prepare ADODB connection to template
+      → Sequentially add: events, clubs, locations, teams, entries, players, memos
+      → Write to .cp file (Microsoft Access format via node-adodb)
+    → Stream file with Content-Disposition header
+  → Frontend receives blob → triggers download as {event.name}.cp
+```
+
+**Auth:** `change:job` (currently missing — to be added).
+**Response:** `.cp` binary blob. Only works on Windows servers (node-adodb dependency). Target: Competition Planner desktop software.
+
+## Shared Utilities / Reusable Patterns
+
+### Shared XLSX Utility (`libs/backend/utils/xlsx/`)
+
+Extracts the recurring XLSX generation pattern used across enrollment, teams, exceptions, and locations exports:
+
+```typescript
+// Core API surface:
+createWorkbook(): XLSX.WorkBook
+addSheet(workbook: XLSX.WorkBook, name: string, headers: string[], rows: any[][]): void
+  // Internally: aoa_to_sheet, auto-sized columns, autofilter on header row
+toBuffer(workbook: XLSX.WorkBook): Buffer
+```
+
+**Used by:**
+- `ExcelService.GetEnrollment()` (refactored)
+- `CompetitionExportService.getTeamsExport()`
+- `CompetitionExportService.getExceptionsExport()`
+- `CompetitionExportService.getLocationsExport()`
+- Future export services
+
+### Blob Download Pattern (Frontend)
+
+Reusable download utility for the Next.js frontend:
+
+```typescript
+async function downloadBlob(url: string, filename: string): Promise<void>
+  // fetch(url) → response.blob() → URL.createObjectURL → anchor click → cleanup
+```
+
+## Integration Points
+
+| System | Integration | Pattern |
+|--------|-------------|---------|
+| **Authentication** | All REST export endpoints | `@User() user: Player` decorator extracts authenticated user from request |
+| **Authorization** | Permission checks per endpoint | `canExecute(user, { anyPermissions: [...] })` utility from `libs/backend/graphql/src/utils/can-exexcute.ts` |
+| **GraphQL** | Average level data | Existing `SubEventCompetition.averageLevel` resolver field — no changes needed |
+| **Sequelize ORM** | All data access | Direct model imports (`EventCompetition.findByPk()`, eager loading with `include`) — follows existing codebase pattern |
+| **Fastify** | Response streaming | `FastifyReply` for setting Content-Type, Content-Disposition headers and sending buffers |
+| **NestJS modules** | New module registration | `CompetitionExportModule` imported in `apps/api/src/app/app.module.ts` |
+
+## Key Technical Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| REST vs. GraphQL for exports | **REST** | File downloads are a poor fit for GraphQL. Existing export endpoints (enrollment, CP) already use REST. Consistent with established pattern. |
+| Server-side vs. client-side XLSX generation | **Server-side** | Legacy app generated XLSX in the browser. Moving to server-side is better for: (1) keeping business logic in one place, (2) not shipping the xlsx library to the client, (3) consistency with the enrollment export which is already server-side. |
+| Shared XLSX utility | **Extract into reusable module** | The same autosize + autofilter pattern is used in 4+ places. A shared utility reduces duplication and makes future exports faster to build. |
+| Charting library (FE) | **TBD (recharts / nivo / react-apexcharts)** | Legacy used ApexCharts (Angular wrapper). For Next.js/React, evaluate recharts (lightweight, good MUI integration), nivo (rich but heavier), or react-apexcharts (closest to legacy). Decision should be made at implementation time based on dual Y-axis support and dark theme compatibility. |
+| Permission model | **Per-user assignment** | Permissions already exist in the database and are assigned to individual users (not roles). No seeding or role mapping needed. |
+| CP file platform | **Windows-only (accepted)** | The .cp file targets Competition Planner desktop software which itself only runs on Windows. The node-adodb Windows dependency is an accepted constraint. |

--- a/docs/estimates/export-reports-migration/complexity_analysis.md
+++ b/docs/estimates/export-reports-migration/complexity_analysis.md
@@ -1,0 +1,80 @@
+# Complexity & Risk Analysis: Export/Report Feature Migration
+
+## 1. Security
+
+### Findings
+- **Existing enrollment endpoint (`EnrollemntController`) has NO authentication or authorization guard.** Any unauthenticated request to `GET /excel/enrollment?eventId={id}` can download player enrollment data (names, member IDs, gender). This is a pre-existing vulnerability that MUST be fixed during this migration.
+- **Existing CP endpoint (`AppController.getCp`) also has NO authentication guard.** The `queue-job` endpoint in the same controller does check `change:job` permission, but `getCp` does not.
+- The authorization pattern in this codebase is inline: `@User() user: Player` decorator extracts the authenticated user, then `user.hasAnyPermission([...])` or the `canExecute()` utility (`libs/backend/graphql/src/utils/can-exexcute.ts`) performs the check. There is no route-level guard on REST controllers -- only on GraphQL mutations.
+- **New endpoints (teams, exceptions, locations)** need the correct permissions: `export-teams:competition`, `export-exceptions:competition`, `export-locations:competition`. These permission strings already exist in the database and are assigned to individual users.
+- Input validation: `eventId` is passed as a query parameter with no validation (no UUID format check, no existence check before heavy DB queries). All new and existing endpoints should validate this.
+
+### Risk: HIGH
+Two existing endpoints are completely unprotected. Permission strings already exist in the database but need to be enforced on the endpoints.
+
+---
+
+## 2. Privacy
+
+### Findings
+- **Report 1 (Average Level):** Aggregated/anonymized data only (averages per subevent). No PII concern.
+- **Report 2 (Base Players):** Contains player first name, last name, member ID, and gender. This is PII. The endpoint is currently unprotected.
+- **Report 3 (Teams):** Contains club names, team names, preferred play times. Low PII risk (organizational data).
+- **Report 4 (Exceptions):** Contains club names and location names with date ranges. Low PII risk.
+- **Report 5 (Locations):** Contains addresses (street, number, postal code, city). This is location data tied to clubs -- could be considered sensitive for smaller clubs using private venues.
+- **Report 6 (CP File):** Contains player data, team data, club data, locations -- full competition data. This is a comprehensive data export with high PII content.
+- No audit logging is present on any export endpoint. For compliance, downloads of PII-containing reports should be logged.
+- [ASSUMPTION] GDPR applies (Belgian/Flemish badminton context). No data retention or consent mechanism is currently in place for exports.
+
+### Risk: MEDIUM
+PII is exposed in reports 2 and 6, and partially in report 5. Adding auth gates mitigates the most critical risk. Audit logging is recommended but could be deferred.
+
+---
+
+## 3. Data Consistency
+
+### Findings
+- **Average Level calculation** is computationally expensive (traverses draws -> encounters -> games -> players -> ranking places) but is cached for `CACHE_TTL` (likely 1 week based on the comment). No race condition risk since it's read-only and the cache key is per-subevent.
+- **Teams/Exceptions/Locations exports** traverse the `EventCompetition -> SubEventCompetition -> DrawCompetition -> EventEntry -> Team -> Club -> Location -> Availability` hierarchy. This is a deeply nested read query. If data changes mid-generation (e.g., a team is removed), the output could be inconsistent, but this is acceptable for a point-in-time report.
+- **CP file generation** is an 817-line service that performs many sequential database reads and ADODB writes. It uses no transaction for the read side. If competition data changes during generation, the CP file could be inconsistent. This is a pre-existing risk, not introduced by the migration.
+- **Deduplication logic** in the frontend excel service (teams by team.id, exceptions by clubId+locationName+date, locations by clubId+locationName+day) must be faithfully replicated in the backend. Any deviation will produce different output than the legacy app.
+- The frontend `EVENT_TEAMS_EXPORT_QUERY` in `excel.service.ts` includes `club.clubId` but the query in `export.query.ts` does NOT include `clubId` -- only `club.id` and `club.name`. There is a discrepancy between the two query definitions. The `excel.service.ts` version is authoritative since it generates the actual export.
+
+### Risk: MEDIUM
+The main risk is faithfully replicating the deduplication and data transformation logic from the frontend to the backend. The GraphQL query discrepancy needs resolution.
+
+---
+
+## 4. SOLID Principles
+
+### Findings
+- **Single Responsibility:** The existing `ExcelService` in the enrollment module handles only enrollment exports -- good. The new export services (teams, exceptions, locations) should each be in their own service or a single `CompetitionExportService` with clearly separated methods. The frontend `ExcelService` currently handles all three in one class (lines 156-471), which is acceptable for a service with related methods.
+- **Open/Closed:** The existing `EnrollmentModule` registers its own controller and service. New export endpoints should be in a new module (e.g., `CompetitionExportModule`) rather than stuffing more controllers into the enrollment module, which is specifically for enrollment validation.
+- **Dependency Inversion:** The backend services directly import Sequelize models (`EventCompetition.findByPk(...)`) -- this is the established pattern across the entire codebase. No repository abstraction exists. Consistent with existing architecture; introducing a new pattern would violate consistency.
+- **Interface Segregation:** The `ExcelService` in the frontend bundles three unrelated export methods. In the backend, keeping them in one service class is acceptable given they share the same data access pattern (event -> subevent -> draw -> entry -> team -> club hierarchy).
+
+### Risk: LOW
+No architectural compromises needed. Follow existing patterns.
+
+---
+
+## 5. Operational Risk
+
+### Findings
+- **ADODB / CP Generator:** The `CpGeneratorService` dynamically imports `node-adodb` (`this._getAdob()`), which is a Windows-only library that shells out to a VBScript process to interact with Microsoft Access databases. The `.cp` file is specifically for the "Competition Planner" desktop software, which itself only runs on Windows. The code gracefully returns `undefined` if ADODB is not available (line 63-66). This is a pre-existing and accepted limitation — no cross-platform concern since the target users run Windows.
+- **Performance at scale:** The deeply nested GraphQL queries (4-5 levels of nesting) could be slow for large competitions with many teams. The enrollment export does N+1 queries (`Player.findByPk` in a loop, line 49). This is a pre-existing performance issue.
+- **Deployment:** No feature flag mechanism was observed. If the new frontend is deployed independently from the backend, there is no coordination risk -- the backend endpoints are additive.
+- **Rollback:** All new endpoints are additive (new controller, new services). Rollback = revert the deployment. No database migration is needed for these features, so no migration rollback is required.
+- **File size:** XLSX generation happens in-memory. For very large competitions, this could cause memory pressure. The enrollment export already works this way, so the pattern is established and presumably tested at production scale.
+
+### Risk: MEDIUM
+ADODB cross-platform limitation is the biggest operational concern. Memory usage for large exports is a secondary concern. No database migrations reduce deployment risk.
+
+---
+
+## Overall Risk Rating: MEDIUM
+
+The primary risks are:
+1. **Security gaps** on existing endpoints (HIGH individual risk, but straightforward to fix)
+2. **ADODB Windows dependency** (pre-existing, not solvable in this scope)
+3. **Faithful replication** of frontend data transformation logic to backend (MEDIUM, requires careful testing)

--- a/docs/estimates/export-reports-migration/cp-export-migration-explained.md
+++ b/docs/estimates/export-reports-migration/cp-export-migration-explained.md
@@ -1,0 +1,102 @@
+# CP File Export: What's Changing and Why
+
+## The Current Situation
+
+The CP file is a special file used by **Competition Planner**, the desktop software that schedules badminton competitions. This file contains all the competition data: events, clubs, teams, players, locations, and validation notes.
+
+Currently, generating this file **only works on a Windows computer**. This is because the file format (Microsoft Access database) requires a Windows-specific technology to create. In practice, this means:
+
+- A developer with a Windows machine had to generate the file manually
+- It could not be done from the website
+- If that person was unavailable, the export couldn't happen
+- There was no way to automate or self-service this process
+
+## What We're Moving To
+
+The new approach lets anyone with the right permissions **generate the CP file directly from the website**, without needing a Windows computer or developer involvement.
+
+### How It Works (simplified)
+
+When you click "Export CP" on the website:
+
+1. The backend server collects all the competition data from the database
+2. It sends that data to a temporary Windows machine in the cloud (provided free by GitHub)
+3. That cloud machine creates the CP file
+4. You receive an email with a download link when it's ready
+5. You click the link and download the file
+
+The whole process takes a few minutes.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        NEW SITUATION                        │
+│                                                             │
+│  ┌──────────┐    ┌──────────────┐    ┌───────────────────┐  │
+│  │          │    │              │    │  Cloud Machine    │  │
+│  │ Website  │───>│   Backend    │───>│  (Windows)        │  │
+│  │          │    │   Server     │    │                   │  │
+│  │ Click    │    │              │    │  Creates the      │  │
+│  │ "Export" │    │ Collects all │    │  .cp file         │  │
+│  │          │    │ competition  │    │                   │  │
+│  └──────────┘    │ data         │    └────────┬──────────┘  │
+│                  └──────────────┘             │             │
+│                                               │             │
+│                  ┌──────────────┐             │             │
+│                  │              │<────────────┘             │
+│                  │  Email with  │  File ready!              │
+│                  │  download    │                           │
+│                  │  link        │                           │
+│                  │              │                           │
+│                  └──────┬───────┘                           │
+│                         │                                   │
+│                  ┌──────▼───────┐                           │
+│                  │              │                           │
+│                  │  Download    │                           │
+│                  │  .cp file    │                           │
+│                  │              │                           │
+│                  └──────────────┘                           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Advantages
+
+- **Self-service:** No developer needed. Anyone with the right permissions can generate the file.
+- **Available from anywhere:** Works from any computer with a browser -- no Windows required on your end.
+- **Reliable:** The process is automated and tested. No manual steps that could introduce human error.
+- **Secure:** Only authorized users can trigger the export and download the file.
+- **Auditable:** Every generation is logged, so you can see who generated what and when.
+
+## Possible Drawbacks
+
+- **Not instant:** The generation takes a few minutes (typically 2-5 minutes) because the cloud machine needs to start up and process the data. You receive an email when it's done.
+- **Download expires after 30 days:** The generated file is available for download for 30 days. After that, you would need to generate it again.
+- **Internet required:** Since the generation happens in the cloud, you need an internet connection. The old process (running locally on a Windows machine) could theoretically work offline.
+
+## What Data Is in the CP File?
+
+The CP file contains everything Competition Planner needs to schedule a competition:
+
+| Data | Description | Example |
+|------|-------------|---------|
+| **Events** | The competition categories | "Heren A", "Dames B", "Gemengd C" |
+| **Clubs** | All participating clubs | Club name, club number, abbreviation |
+| **Locations** | Playing venues | Address, postal code, city, phone number |
+| **Teams** | All enrolled teams | Team name, contact person, phone, email, preferred playing day and time, preferred location |
+| **Players** | All registered players per team | First name, last name, gender, member ID, ranking levels (single/double/mixed) |
+| **Entries** | Which team plays in which event | Links teams to their competition category |
+| **Validation Notes** | Automated checks on team enrollment | Errors found during validation (e.g., ranking issues), club comments, availability information |
+| **Settings** | Competition metadata | Tournament name, director contact details |
+
+## Frequently Asked Questions
+
+**Q: Will the generated file be different from before?**
+A: The file contains the same data in the same format. Competition Planner will read it exactly the same way.
+
+**Q: What if the generation fails?**
+A: You'll receive an email letting you know it failed. You can try again, or contact support if the problem persists.
+
+**Q: Can multiple people generate the file at the same time?**
+A: To prevent confusion, only one generation per competition can run at a time. If someone else already started one, you'll be asked to wait.
+
+**Q: How often can I generate the file?**
+A: As often as you need. There are no limits. Typically this is done once per season when all enrollments are finalized.

--- a/docs/estimates/export-reports-migration/feature_overview.md
+++ b/docs/estimates/export-reports-migration/feature_overview.md
@@ -1,0 +1,362 @@
+# Feature Overview: Export/Report Migration (6 Reports)
+
+## Step 1: Technical Impact Map
+
+### Database
+- **No new tables, migrations, or schema changes required.** All data already exists in the database.
+- Tables read (not modified): `EventCompetitions`, `SubEventCompetitions`, `DrawCompetitions`, `EventEntries`, `Teams`, `Clubs`, `Locations`, `Availabilities`, `Players`, `RankingLastPlaces`, `RankingSystems`
+- Permission strings (`export-teams:competition`, `export-exceptions:competition`, `export-locations:competition`) already exist in the database. Permissions are assigned to individual users (not roles).
+
+### ORM / Data Layer
+- **Sequelize models already exist** for all entities involved. No new models needed.
+- Key access patterns: `EventCompetition.findByPk()` -> `getSubEventCompetitions()` -> `getDrawCompetitions()` -> `getEventEntries()` with includes for `Team`, `Club`, `Location`, `Availability`.
+- The enrollment `ExcelService` uses N+1 pattern (`Player.findByPk` in loop) -- not ideal but out of scope unless refactoring is explicitly requested.
+
+### Services / Business Logic
+- **New:** `CompetitionExportService` (or similar) in a new backend library or within the enrollment library. Three methods needed:
+  1. `getTeamsExport(eventId)` -- flatten team data, deduplicate by team ID, generate XLSX
+  2. `getExceptionsExport(eventId)` -- expand date ranges, deduplicate by composite key, generate XLSX
+  3. `getLocationsExport(eventId)` -- translate day names, deduplicate, generate XLSX
+- **Existing (verify):** `ExcelService.GetEnrollment()` at `libs/backend/competition/enrollment/src/services/excel.services.ts`
+- **Existing (verify):** `CpGeneratorService.generateCpFile()` at `libs/backend/generator/src/services/cp_generator.ts`
+
+### GraphQL Layer
+- **No changes needed.** The `averageLevel` resolver field already exists on `SubEventCompetition` and works correctly.
+- The new export endpoints will be REST controllers (following the existing pattern of `EnrollemntController` and `AppController`), not GraphQL mutations.
+
+### Frontend (New Application — Next.js 15)
+The new frontend uses **TypeScript, Next.js 15 (App Router), Material UI, GraphQL (Apollo Client), React Hook Form, Biome (linting/formatting), deployed on Vercel**. Architecture uses heavy client-side components.
+
+- **Average Level Page (Report 1):** Full client component page with a React-compatible charting library (e.g., recharts, nivo, or ApexCharts React wrapper). Requires:
+  - GraphQL query via Apollo Client for `eventCompetition` -> `subEventCompetitions` -> `averageLevel`
+  - Line charts with dual Y-axis (average level reversed 1-12, player count)
+  - Filters: gender (M/F), chart type (single/double/mix), event type (M/F/MX)
+  - CSV download button
+- **Download Buttons (Reports 2-6):** Client components using MUI:
+  - MUI Menu or button group on the competition detail page
+  - Each button triggers a `fetch` GET to the respective endpoint
+  - Response is a blob that triggers browser download
+  - Permission-gated: buttons should only be visible if the user has the required permission
+- **Permission-based visibility:** The frontend needs to check user permissions to conditionally render download buttons. Permissions are assigned per user.
+
+---
+
+## Step 2: Complexity & Risk Analysis
+
+See `complexity_analysis.md` for the full analysis.
+
+**Overall Risk Rating: MEDIUM**
+
+---
+
+## Step 3: Functional Breakdown & Estimation
+
+### Task Table
+
+| # | Task | Category | Complexity | Baseline Hours | AI-Adjusted Hours | Risk |
+|---|------|----------|------------|----------------|-------------------|------|
+| **Backend: New Export Endpoints** | | | | | | |
+| 1 | Create `CompetitionExportModule` with controller and service skeleton | BE | S | 1.5 | 0.6 | Low |
+| 2 | Implement `getTeamsExport()` service method (port from FE lines 156-240) | BE | M | 3 | 1.5 | Medium |
+| 3 | Implement `getExceptionsExport()` service method (port from FE lines 242-350, includes date range generation, dedup, Belgian date formatting) | BE | M | 4 | 2.0 | Medium |
+| 4 | Implement `getLocationsExport()` service method (port from FE lines 352-471, includes day name translation, dedup) | BE | M | 3 | 1.5 | Medium |
+| 5 | Create REST controller with 3 GET endpoints (`/excel/teams`, `/excel/exceptions`, `/excel/locations`) following `EnrollemntController` pattern | BE | S | 2 | 0.8 | Low |
+| 6 | Register module in API app module | BE | S | 0.5 | 0.2 | Low |
+| **Backend: Security Fixes** | | | | | | |
+| 7 | Add authentication + permission check to existing `EnrollemntController` (`edit:competition`) | BE | S | 1 | 0.5 | Low |
+| 8 | Add authentication + permission check to existing `AppController.getCp` (`change:job`) | BE | S | 1 | 0.5 | Low |
+| 9 | Add permission checks to new export controller (teams/exceptions/locations with respective permissions) | BE | S | 1.5 | 0.6 | Low |
+| **Backend: Shared XLSX Utility** | | | | | | |
+| 10 | Extract shared XLSX utility (autosize columns, autofilter, buffer generation) from existing patterns into a reusable module | BE | M | 2.5 | 1.2 | Low |
+| **Backend: Validation & Error Handling** | | | | | | |
+| 11 | Add `eventId` UUID validation and existence check to all export endpoints (new + existing) | BE | S | 1.5 | 0.6 | Low |
+| 12 | Standardize error responses (404 for missing event, 403 for unauthorized, 500 for generation failure) | BE | S | 1 | 0.5 | Low |
+| **Backend: Verification** | | | | | | |
+| 13 | Manual verification: existing enrollment endpoint still works correctly | QA | S | 1 | 1.2 | Low |
+| 14 | Manual verification: existing CP endpoint still works correctly (Windows environment) | QA | S | 1.5 | 1.8 | Medium |
+| **Frontend: Average Level Page (Report 1)** | | | | | | |
+| 15 | Create average level page (Next.js App Router client component with route) | FE | M | 3.5 | 1.8 | Low |
+| 16 | Implement GraphQL query via Apollo Client and data transformation for average level | FE | S | 1.5 | 0.6 | Low |
+| 17 | Implement chart rendering with React charting library (line charts with dual Y-axis, 3 event types x 2 genders x 3 disciplines = up to 18 charts) | FE | L | 8 | 4.0 | Medium |
+| 18 | Implement CSV download from chart data | FE | S | 1 | 0.4 | Low |
+| 19 | Add permission guard on route (user permission check for `edit:competition`) | FE | S | 0.5 | 0.2 | Low |
+| **Frontend: Download Buttons (Reports 2-6)** | | | | | | |
+| 20 | Create export MUI Menu component on competition detail page | FE | M | 2 | 0.8 | Low |
+| 21 | Implement download service (fetch GET to all 5 REST endpoints) | FE | M | 2.5 | 1.0 | Low |
+| 22 | Implement blob download handling (anchor click / URL.createObjectURL pattern) | FE | S | 1 | 0.4 | Low |
+| 23 | Add per-user permission-based visibility for each download button | FE | S | 1.5 | 0.6 | Low |
+| 24 | Loading states and error handling for downloads (MUI CircularProgress, Snackbar on error) | FE | S | 1.5 | 0.6 | Low |
+| **Testing** | | | | | | |
+| 25 | Unit tests for `getTeamsExport()` service (data transformation, dedup, XLSX output verification) | QA | M | 3 | 1.8 | Low |
+| 26 | Unit tests for `getExceptionsExport()` service (date range generation, dedup, formatting) | QA | M | 3 | 1.8 | Medium |
+| 27 | Unit tests for `getLocationsExport()` service (day translation, dedup) | QA | M | 2.5 | 1.5 | Low |
+| 28 | Unit tests for permission checks on all export endpoints | QA | S | 2 | 1.2 | Low |
+| 29 | Integration tests: end-to-end controller tests for new endpoints (authenticated + unauthenticated) | QA | M | 4 | 2.4 | Medium |
+| 30 | Regression test: compare output of new backend exports vs. legacy frontend exports for same event | QA | M | 3 | 3.6 | High |
+| **Documentation** | | | | | | |
+| 31 | API documentation for new export endpoints (request/response, permissions, error codes) | DOCS | S | 1.5 | 0.6 | Low |
+| 32 | Inline code comments for complex logic (date range generation, dedup, day translation) | DOCS | S | 0.5 | 0.2 | Low |
+
+### Subtotals by Category
+
+| Category | Baseline Hours | AI-Adjusted Hours |
+|----------|----------------|-------------------|
+| **BE** (Backend, incl. shared XLSX utility) | 24.0 | 11.0 |
+| **FE** (Frontend — Next.js 15) | 23.0 | 10.4 |
+| **QA** (Testing) | 20.0 | 15.3 |
+| **DOCS** (Documentation) | 2.0 | 0.8 |
+| **TOTAL** | **69.0** | **37.5** |
+
+### Grand Total
+
+- **AI-Adjusted Total: ~38 hours** (approximately 5 working days)
+- **Suggested Sprint Allocation:** 1 sprint (2-week cadence) with 1 developer, accounting for meetings, code review, and context switching overhead
+- **Range estimate:**
+  - Optimistic: 30 hours (charting library integration is straightforward, no surprises)
+  - Expected: 38 hours (as estimated above)
+  - Pessimistic: 50 hours (React charting library differences cause rework, permission check integration on the Next.js side is more complex than expected)
+
+### Parallelization Notes
+
+- **Can be parallelized:**
+  - Tasks 2, 3, 4 (three export service methods) are independent of each other
+  - Tasks 15-19 (FE average level page) can be done in parallel with tasks 2-6 (BE export endpoints)
+  - Tasks 25, 26, 27 (unit tests per service method) can be done in parallel
+  - Tasks 7, 8 (security fixes) can be done in parallel with new endpoint development
+
+- **Must be sequential:**
+  - Task 1 (module skeleton) before Tasks 2-6
+  - Task 5 (controller) after Tasks 2, 3, 4 (services)
+  - Task 6 (module registration) after Task 5
+  - Tasks 20-24 (FE download buttons) after Tasks 2-6 (BE endpoints are ready)
+  - Task 29 (integration tests) after Tasks 5, 9 (controller + auth)
+  - Task 30 (regression tests) after all BE and FE work is complete
+
+### Critical Path
+`Task 1 -> Tasks 2/3/4 (parallel) -> Task 5 -> Task 6 -> Task 9 -> Tasks 29/30`
+
+---
+
+## Agent Execution Tasks
+
+> **Reference:** See `architecture.md` for the high-level architecture diagram, component inventory, data flow per feature, shared utilities, and integration points. All tasks below should follow the patterns and file locations defined there.
+
+### Backend Work
+
+1. **[BE] Extract shared XLSX utility module.**
+   See `architecture.md` → "Shared Utilities / Reusable Patterns" for the target API surface.
+   Create a reusable utility at `libs/backend/utils/xlsx/` with:
+   - `createWorkbook()` — wraps `xlsx.utils.book_new()`
+   - `addSheet(workbook, name, headers, rows)` — creates sheet from AOA with auto-sized columns and autofilter
+   - `toBuffer(workbook)` — writes workbook to buffer
+   - Barrel export via `index.ts`
+   - Refactor existing `ExcelService.GetEnrollment()` (`libs/backend/competition/enrollment/src/services/excel.services.ts`) to use the shared utility
+   - **Expected output:** Reusable XLSX utility module, existing enrollment service refactored to use it
+
+2. **[BE] Create the `CompetitionExportModule` skeleton.**
+   See `architecture.md` → "Component Inventory → New Files" for exact file locations.
+   Create a new NestJS module at `libs/backend/competition/export/`:
+   - `libs/backend/competition/export/src/controllers/export.controller.ts` — empty controller with `@Controller({ path: 'excel' })` decorator
+   - `libs/backend/competition/export/src/services/export.service.ts` — empty injectable service class `CompetitionExportService`
+   - `libs/backend/competition/export/src/export.module.ts` — registers controller + service
+   - `libs/backend/competition/export/src/index.ts` — barrel export
+   - Import `CompetitionExportModule` in `apps/api/src/app/app.module.ts` (see `architecture.md` → "Existing Files to Modify")
+   - **Expected output:** Module compiles, controller is reachable (returns 404 on undefined routes)
+
+3. **[BE] Implement `getTeamsExport(eventId: string)` method in `CompetitionExportService`.**
+   See `architecture.md` → "Data Flow per Feature → Report 3: Download Teams" for the full request/response flow.
+   Port logic from `libs/frontend/modules/excel/src/services/excel.service.ts` lines 156-240:
+   - Query `EventCompetition.findByPk(eventId)` then traverse `getSubEventCompetitions()` → `getDrawCompetitions()` → `getEventEntries({ include: [{ model: Team, include: [{ model: Club }] }] })`
+   - Extract unique teams (deduplicate by `team.id`) with fields: `club.clubId`, `club.name`, `team.name`, `team.preferredDay`, `team.preferredTime`
+   - Generate XLSX via shared utility (task #1) with headers: `["Club ID", "Clubnaam", "Ploegnaam", "Voorkeur speelmoment (dag)", "Voorkeur speelmoment (tijdstip)"]`
+   - Return `{ buffer, event }` matching the enrollment service pattern
+   - **Expected output:** `CompetitionExportService.getTeamsExport()` method that returns an XLSX buffer
+
+4. **[BE] Implement `getExceptionsExport(eventId: string)` method in `CompetitionExportService`.**
+   See `architecture.md` → "Data Flow per Feature → Report 4: Download Exceptions" for the full request/response flow.
+   Port logic from `libs/frontend/modules/excel/src/services/excel.service.ts` lines 242-350:
+   - Traverse same hierarchy as teams but include `Club` → `Location` → `Availability` (with `exceptions` field)
+   - For each exception with `start` and `end` dates, generate one row per day in the range (use `generateDateRange` helper)
+   - Format dates to Belgian locale (`DD/MM/YYYY`, timezone `Europe/Brussels`) using `toLocaleDateString('nl-BE', ...)`
+   - Deduplicate by composite key: `(clubId, locationName, date)`
+   - Generate XLSX via shared utility (task #1) with headers: `["Club ID", "Clubnaam", "Locatie", "Datum", "Velden"]`
+   - **Expected output:** `CompetitionExportService.getExceptionsExport()` method
+
+5. **[BE] Implement `getLocationsExport(eventId: string)` method in `CompetitionExportService`.**
+   See `architecture.md` → "Data Flow per Feature → Report 5: Download Locations" for the full request/response flow.
+   Port logic from `libs/frontend/modules/excel/src/services/excel.service.ts` lines 352-471:
+   - Traverse hierarchy to `Location` → `Availability` → `days` (array of `{ day, courts }`)
+   - Build address from `location.street`, `location.streetNumber`, `location.postalcode`, `location.city` (filter falsy, join with space)
+   - Translate English day names to Dutch: `{ monday: "Maandag", tuesday: "Dinsdag", wednesday: "Woensdag", thursday: "Donderdag", friday: "Vrijdag", saturday: "Zaterdag", sunday: "Zondag" }`
+   - Deduplicate by composite key: `(clubId, locationName, day)`
+   - Generate XLSX via shared utility (task #1) with headers: `["Club ID", "Clubnaam", "Locatie", "Adres", "Dag", "Aantal Velden"]`
+   - **Expected output:** `CompetitionExportService.getLocationsExport()` method
+
+6. **[BE] Create the export controller with 3 GET endpoints.**
+   See `architecture.md` → "Component Inventory" for file location and "Data Flow per Feature" for endpoint patterns.
+   In `libs/backend/competition/export/src/controllers/export.controller.ts`:
+   - `GET /excel/teams?eventId={id}` → calls `competitionExportService.getTeamsExport(eventId)`
+   - `GET /excel/exceptions?eventId={id}` → calls `competitionExportService.getExceptionsExport(eventId)`
+   - `GET /excel/locations?eventId={id}` → calls `competitionExportService.getLocationsExport(eventId)`
+   - Follow the response pattern from `EnrollemntController`: set `Content-Disposition` and `Content-Type` headers, send buffer
+   - Use `@Res() res: FastifyReply` and `@Query() query: { eventId: string }` like the existing controller
+   - **Expected output:** Three working endpoints that return XLSX files
+
+7. **[BE] Add authentication and permission checks to all export endpoints.**
+   See `architecture.md` → "Integration Points" for the auth pattern (`@User()` + `canExecute()`).
+   - In the NEW export controller: add `@User() user: Player` parameter to each handler. Call `canExecute(user, { anyPermissions: ['export-teams:competition'] })` (or respective permission) before processing. Import from `@badman/backend-authorization` and `libs/backend/graphql/src/utils/can-exexcute.ts`.
+   - In the EXISTING `EnrollemntController` (`libs/backend/competition/enrollment/src/controllers/excel.controller.ts`): add `@User() user: Player` and `canExecute(user, { anyPermissions: ['edit:competition'] })`.
+   - In the EXISTING `AppController.getCp` (`apps/api/src/app/controllers/app.controller.ts` line 139): add `@User() user: Player` and `canExecute(user, { anyPermissions: ['change:job'] })`.
+   - Permissions are assigned per user (not roles) and already exist in the database.
+   - **Expected output:** All 5 export endpoints require authentication and check per-user permissions
+
+8. **[BE] Add input validation to all export endpoints.**
+   - Validate `eventId` is provided (400 if missing)
+   - Validate `eventId` format (UUID regex, 400 if invalid)
+   - Check `EventCompetition.findByPk(eventId)` returns a result (404 if not found) — do this in the service layer before traversing the hierarchy
+   - **Expected output:** Proper error responses for invalid/missing eventId
+
+### Frontend Work (Next.js 15 / App Router)
+
+9. **[FE] Create the average level page as a Next.js client component.**
+   See `architecture.md` → "Data Flow per Feature → Report 1: Average Level" for the full flow.
+   Create a new page in the Next.js app:
+   - Route: `/competition/[id]/avg-level` (App Router dynamic segment)
+   - `'use client'` directive (heavy interactivity with charts)
+   - Permission check: only accessible if user has `edit:competition`
+   - Implement the GraphQL query via Apollo Client from the legacy component (lines 236-256 of `detail-avg.page.ts`):
+     ```graphql
+     query GetAvgLevel($id: ID!) {
+       eventCompetition(id: $id) {
+         id
+         subEventCompetitions {
+           id, name, eventType
+           averageLevel { gender, single, singleCount, double, doubleCount, mix, mixCount }
+         }
+       }
+     }
+     ```
+   - **Expected output:** Next.js page component that fetches and displays average level data
+
+10. **[FE] Implement chart rendering for the average level page.**
+    See `architecture.md` → "Key Technical Decisions" for charting library considerations.
+    Replicate the charting logic from `detail-avg.page.ts` using a React-compatible charting library (e.g., recharts, nivo, or react-apexcharts):
+    - For each combination of `eventType` (M/F/MX) x `gender` (M/F) x `chartType` (single/double/mix), render a chart if data exists
+    - Chart config: dual Y-axis (left: average level 1-12 reversed with integer ticks; right: player count), straight line, data labels with 2 decimal places, dark theme
+    - X-axis: subevent names filtered by event type
+    - Series: "Average" (level values) and "Players" (count values)
+    - Title format: `Reeks: {eventType}, Geslacht: {gender}, Dicipline: {chartType}`
+    - **Expected output:** Up to 18 charts rendered on the page, matching legacy output
+
+11. **[FE] Implement CSV download on the average level page.**
+    Port the `downloadData()` and `convertToCSV()` methods from `detail-avg.page.ts` lines 194-229:
+    - Headers: `name, gender, single, singleCount, double, doubleCount, mix, mixCount`
+    - Rows: for each subevent, for each averageLevel entry, output `{name} - {eventType}, {gender}, {single}, ...`
+    - Trigger download as `data.csv` via `URL.createObjectURL(new Blob(...))`
+    - **Expected output:** CSV download button that exports chart data
+
+12. **[FE] Create export download hooks/utility for REST endpoints.**
+    See `architecture.md` → "Shared Utilities → Blob Download Pattern" for the reusable download utility pattern, and "Component Inventory" for file location.
+    Create a custom hook or utility module with functions for each download:
+    - `downloadEnrollment(eventId: string)` → `fetch({apiUrl}/excel/enrollment?eventId={id})`
+    - `downloadTeams(eventId: string)` → `fetch({apiUrl}/excel/teams?eventId={id})`
+    - `downloadExceptions(eventId: string)` → `fetch({apiUrl}/excel/exceptions?eventId={id})`
+    - `downloadLocations(eventId: string)` → `fetch({apiUrl}/excel/locations?eventId={id})`
+    - `downloadCp(eventId: string)` → `fetch({apiUrl}/cp?eventId={id})`
+    - All functions: use the shared `downloadBlob(url, filename)` pattern
+    - **Expected output:** React hook or utility with 5 download functions
+
+13. **[FE] Create export MUI Menu on competition detail page.**
+    See `architecture.md` → "Component Inventory" for file location and "Integration Points" for permission checking.
+    Add a MUI `Menu` component (client component) on the competition detail page:
+    - Menu items: "Gemiddeld level" (Next.js `Link` to avg-level page), "Download basis spelers", "Download ploegen", "Download uitzonderingen", "Download locaties", "Download cp file"
+    - Each download item: calls the corresponding download function, shows `CircularProgress` during download, shows `Snackbar` on error
+    - Per-user permission-gated visibility:
+      - "Gemiddeld level" + "Download basis spelers": visible if user has `edit:competition`
+      - "Download ploegen": visible if user has `export-teams:competition`
+      - "Download uitzonderingen": visible if user has `export-exceptions:competition`
+      - "Download locaties": visible if user has `export-locations:competition`
+      - "Download cp file": visible if user has `change:job`
+    - **Expected output:** Functional MUI export menu with per-user permission-based rendering
+
+### Testing
+
+14. **[QA] Write unit tests for shared XLSX utility.**
+    Test the utility created in task #1:
+    - Test: `createWorkbook()` returns valid workbook
+    - Test: `addSheet()` produces correct headers, rows, autofilter, and auto-sized columns
+    - Test: `toBuffer()` returns a valid XLSX buffer that can be parsed back
+    - **Expected output:** Passing test suite for shared utility
+
+15. **[QA] Write unit tests for `CompetitionExportService.getTeamsExport()`.**
+    Test file: alongside the service file.
+    - Test: correct XLSX output for a known input (mock Sequelize models)
+    - Test: deduplication works (same team appearing in multiple draws produces one row)
+    - Test: empty event (no sub-events) produces XLSX with only headers
+    - Test: missing club data handles gracefully (empty strings in output)
+    - **Expected output:** Passing test suite
+
+16. **[QA] Write unit tests for `CompetitionExportService.getExceptionsExport()`.**
+    - Test: date range generation (single day, multi-day range, start-only with no end)
+    - Test: Belgian date formatting
+    - Test: deduplication by composite key (clubId + locationName + date)
+    - Test: empty exceptions array produces headers-only XLSX
+    - **Expected output:** Passing test suite
+
+17. **[QA] Write unit tests for `CompetitionExportService.getLocationsExport()`.**
+    - Test: day name translation (all 7 days EN → NL)
+    - Test: address construction from parts
+    - Test: deduplication by composite key
+    - **Expected output:** Passing test suite
+
+18. **[QA] Write unit tests for permission checks on export endpoints.**
+    See `architecture.md` → "Integration Points" for the auth pattern being tested.
+    - Test: unauthenticated request returns 401
+    - Test: authenticated user without required permission returns 403
+    - Test: authenticated user with correct permission returns 200
+    - Cover all 5 endpoints (enrollment, teams, exceptions, locations, CP)
+    - **Expected output:** Passing test suite
+
+19. **[QA] Write integration tests for new export controller.**
+    Following existing test patterns in `libs/backend/competition/enrollment/src/services/validate/enrollment.service.spec.ts`:
+    - Test: end-to-end request through controller → service → XLSX response
+    - Test: correct Content-Type and Content-Disposition headers
+    - Test: 404 for non-existent eventId
+    - Test: 400 for missing/invalid eventId
+    - **Expected output:** Passing integration test suite
+
+20. **[QA] Regression testing: compare new backend exports vs. legacy frontend exports.**
+    For a known test event:
+    - Generate teams/exceptions/locations XLSX from both the legacy frontend and the new backend endpoint
+    - Compare row counts, column values, and formatting
+    - Document any intentional differences
+    - **Expected output:** Regression test report confirming output parity
+
+### Documentation
+
+21. **[DOCS] Document new export API endpoints.**
+    Refer to `architecture.md` → "Data Flow per Feature" for the authoritative endpoint specs.
+    Add documentation (inline JSDoc on controller methods or a separate API doc):
+    - Endpoint URLs, HTTP methods, query parameters
+    - Required permissions per endpoint
+    - Response format (Content-Type, file naming convention)
+    - Error codes: 400 (bad request), 401 (not authenticated), 403 (forbidden), 404 (event not found), 500 (generation failure)
+    - **Expected output:** API documentation for 5 export endpoints
+
+22. **[DOCS] Add inline code comments for ported business logic.**
+    In the `CompetitionExportService`:
+    - Comment the date range generation algorithm
+    - Comment the deduplication strategy and composite key fields
+    - Comment the day name translation map
+    - Reference the original frontend source locations for traceability
+    - **Expected output:** Well-commented service methods
+
+---
+
+## Resolved Questions
+
+1. **New frontend framework:** Next.js 15 (App Router) with TypeScript, Material UI, Apollo Client, React Hook Form, Biome, deployed on Vercel. FE estimates adjusted accordingly.
+2. **Permission seeding:** Permissions already exist in the database. They are assigned to individual users (not roles). No seeding task needed.
+3. **CP file cross-platform requirement:** The `.cp` file is for the "Competition Planner" desktop software. It only needs to work on OS's that can run that software. No cross-platform concern — the existing Windows-only ADODB approach is fine.
+4. **Data volume:** Unknown. Keeping current approach (in-memory XLSX generation, matching existing patterns). If performance issues surface at scale, this can be optimized later.
+5. **Shared XLSX utility:** Yes — extract into a reusable module. This will be needed again for future exports. Added as task #10.

--- a/docs/estimates/export-reports-migration/samenvatting.md
+++ b/docs/estimates/export-reports-migration/samenvatting.md
@@ -1,0 +1,40 @@
+# Samenvatting voor de klant
+
+## Overzicht
+
+We bouwen de zes export- en rapportfuncties die eerder beschikbaar waren in de oude applicatie opnieuw in voor de nieuwe omgeving. Het gaat om rapporten die gekoppeld zijn aan een competitie-afdeling: een interactief overzicht van het gemiddeld niveau, en vijf downloadbare bestanden (basisspelers, ploegen, uitzonderingen, locaties, en het CP-bestand voor de competitieplanner). Een deel van de achterliggende logica bestaat al in de huidige backend, maar drie van de zes exports draaien vandaag volledig in de browser van de gebruiker — die logica moet verhuizen naar de server om betrouwbaar en veilig te werken in de nieuwe applicatie. De nieuwe frontend wordt gebouwd in Next.js 15 met Material UI.
+
+## Werkstromen
+
+- **Drie nieuwe backend-endpoints bouwen (~6u):** De exports voor ploegen, uitzonderingen en locaties worden vandaag in de browser gegenereerd. We verplaatsen die logica naar de server zodat de nieuwe frontend er eenvoudig gebruik van kan maken. Dit omvat het correct ophalen van de data, het toepassen van de juiste filtering en deduplicatie, en het genereren van Excel-bestanden.
+- **Herbruikbare Excel-module (~1.2u):** We bouwen een gedeelde utility voor het genereren van Excel-bestanden (kolombreedte, filters, buffer-generatie). Dit voorkomt code-duplicatie en maakt toekomstige exports veel sneller te bouwen.
+- **Beveiliging op orde brengen (~2u):** Twee bestaande download-endpoints (basisspelers en CP-bestand) hebben op dit moment géén inlogcontrole — iedereen met de juiste URL kan gevoelige spelergegevens downloaden. We voegen authenticatie en autorisatie toe aan alle vijf de endpoints. De benodigde rechten bestaan al in de database en worden per gebruiker toegekend. Dit is niet alleen nodig voor de nieuwe app, maar dicht ook een bestaand beveiligingslek.
+- **Invoervalidatie en foutafhandeling (~1u):** Alle endpoints krijgen correcte validatie (bestaat de competitie? is de ID geldig?) en duidelijke foutmeldingen, zodat de frontend-gebruiker bij problemen een begrijpelijke melding krijgt in plaats van een technische fout.
+- **Frontend: interactieve pagina Gemiddeld Niveau (~7u):** Dit is geen simpele download maar een volledige pagina met grafieken (gemiddeld niveau per reeks, geslacht en discipline), filtermogelijkheden en een CSV-export. De data komt via de bestaande GraphQL API die al correct werkt. Wordt gebouwd als Next.js client component met een React charting library en Material UI.
+- **Frontend: downloadmenu met 5 exportknoppen (~3.5u):** Een MUI Menu op de competitiepagina met knoppen voor elke export. Elke knop is alleen zichtbaar voor gebruikers met de juiste rechten, toont een laadindicator tijdens het downloaden, en geeft een melding bij fouten.
+- **Testen en kwaliteitsborging (~15u):** We schrijven geautomatiseerde tests voor alle nieuwe backend-logica (datatransformaties, deduplicatie, datumformattering) en voor de beveiligingscontroles. Daarnaast vergelijken we de output van de nieuwe exports met die van de oude applicatie om te garanderen dat de bestanden identiek zijn. Deze stap is cruciaal om regressies te voorkomen en vertrouwen te geven dat de migratie correct is verlopen.
+- **Documentatie (~1u):** API-documentatie voor de nieuwe endpoints en inline commentaar bij complexe logica, zodat toekomstig onderhoud vlot verloopt.
+
+## Complexiteit: Gemiddeld
+
+De benodigde data en businesslogica bestaan al — we bouwen geen nieuwe functionaliteit maar verplaatsen en beveiligen bestaande logica. Er zijn geen databasewijzigingen nodig. De complexiteit zit vooral in het zorgvuldig repliceren van de bestaande datatransformaties en het grondig testen van de output.
+
+## Tijdsinschatting
+
+| Categorie | Uren |
+|-----------|------|
+| Backend (incl. gedeelde Excel-module) | 11.0 |
+| Frontend (Next.js 15) | 10.4 |
+| Testen | 15.3 |
+| Documentatie | 0.8 |
+| **Totaal** | **~38 uur** |
+
+**Doorlooptijd:** Past binnen één sprint van twee weken met één ontwikkelaar. Bij twee ontwikkelaars (backend + frontend parallel) kan de doorlooptijd teruggebracht worden tot ~1 week.
+
+**Bandbreedte:** Optimistisch 30 uur — verwacht 38 uur — pessimistisch 50 uur, afhankelijk van de complexiteit van de React charting library en de permissie-integratie in Next.js.
+
+## Top 3 Risico's
+
+1. **Beveiligingslekken in bestaande endpoints:** Twee huidige endpoints zijn toegankelijk zonder inloggen. Dit wordt als onderdeel van dit werk opgelost, maar het is belangrijk te weten dat dit een bestaand probleem is dat prioriteit verdient.
+2. **Output moet exact overeenkomen:** De Excel-bestanden die de nieuwe backend genereert moeten identiek zijn aan wat de oude applicatie produceerde. Kleine verschillen in datumnotatie of deduplicatielogica kunnen voor verwarring zorgen bij eindgebruikers. We mitigeren dit door zij-aan-zij vergelijkingstests uit te voeren.
+3. **CP-bestand werkt alleen op Windows:** De generator voor het competitieplanner-bestand gebruikt een Windows-specifieke bibliotheek (Microsoft Access). Dit is een bestaande beperking — het CP-bestand is bedoeld voor de "Competition Planner" desktopsoftware die zelf ook alleen op Windows draait, dus dit is geen probleem maar wel goed om te weten.

--- a/docs/guides/cp-export-deployment.md
+++ b/docs/guides/cp-export-deployment.md
@@ -1,0 +1,164 @@
+# CP Export: Deployment Guide
+
+Step-by-step guide for deploying the CP file export feature end-to-end.
+
+---
+
+## 1. GitHub Setup
+
+### Create a Personal Access Token (PAT)
+- [ ] Go to GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens
+- [ ] Click "Generate new token"
+- [ ] **Name:** `badman-cp-export`
+- [ ] **Expiration:** Set to 1 year (add a calendar reminder to rotate!)
+- [ ] **Repository access:** Select "Only select repositories" → choose `Badminton-Apps/badman`
+- [ ] **Permissions:**
+  - Actions: Read and write (triggers workflows, fetches artifacts)
+- [ ] Copy the token value -- you'll need it for Render
+
+### Add Repository Secrets
+- [ ] Go to the repo → Settings → Secrets and variables → Actions
+- [ ] Add secret: `CP_PASS` = the Access database password (ask the team / check existing env config for the value)
+- [ ] Add secret: `CP_WEBHOOK_SECRET` = generate a random string (e.g., `openssl rand -hex 32`)
+
+### Verify Workflow
+- [ ] Push the `feat/cp-export-cross-platform` branch to the repo
+- [ ] Go to Actions tab → confirm "Generate CP File" workflow appears in the left sidebar
+- [ ] Click on it → verify it shows `workflow_dispatch` trigger with the 3 inputs
+
+---
+
+## 2. Render Backend Setup
+
+### Add Environment Variables
+- [ ] Go to Render dashboard → your API service → Environment
+- [ ] Add the following environment variables:
+
+| Variable | Value | Notes |
+|----------|-------|-------|
+| `GITHUB_TOKEN_CP` | The PAT created above | Fine-grained token with actions:read+write |
+| `CP_WEBHOOK_SECRET` | Same value as the GitHub repo secret | Must match exactly! |
+| `CP_CALLBACK_URL` | `https://<your-api-domain>/api/cp/webhook` | Must be publicly accessible |
+| `GITHUB_REPO_OWNER` | `Badminton-Apps` | Optional -- defaults to this value |
+| `GITHUB_REPO_NAME` | `badman` | Optional -- defaults to this value |
+
+### Verify Callback URL
+- [ ] Ensure `CP_CALLBACK_URL` is reachable from the public internet (not behind VPN/firewall)
+- [ ] Test with: `curl -s -o /dev/null -w "%{http_code}" https://<your-api-domain>/api/cp/webhook` (should return 401, not timeout or 404)
+
+---
+
+## 3. Email Setup
+
+- [ ] Verify `MAIL_ENABLED` is `true` on Render env vars
+- [ ] Verify `MAIL_HOST`, `MAIL_USER`, `MAIL_PASS` are configured
+- [ ] **Note:** The current implementation logs email content but doesn't use the `MailingService` template system yet. To fully enable email:
+  - [ ] Create a Pug template for CP notifications (e.g., `cpExportReady.pug`)
+  - [ ] Add a `sendCpExportReadyMail` method to `MailingService`
+  - [ ] Update `CpController._sendCompletionEmail` to use the MailingService instead of logging
+
+---
+
+## 4. Test Run
+
+### Manual Test via GitHub UI
+- [ ] Go to Actions → "Generate CP File" → "Run workflow"
+- [ ] For `payload`, paste a base64-encoded test payload:
+  ```bash
+  echo '{"event":{"name":"Test","season":2025},"subEvents":[],"clubs":[],"locations":[],"teams":[],"players":[],"teamPlayers":[],"entries":[],"memos":[],"settings":{"tournamentName":"Test"}}' | base64
+  ```
+- [ ] For `callback_url`, use your staging API URL + `/api/cp/webhook`
+- [ ] For `requesting_user_id`, use your own player ID from the database
+- [ ] Click "Run workflow"
+- [ ] Verify:
+  - [ ] Workflow completes successfully (green check)
+  - [ ] Artifact "cp-file" appears in the run's artifacts section
+  - [ ] Backend logs show webhook received
+
+### End-to-End Test via API
+- [ ] Use curl or Postman to call the generate endpoint:
+  ```bash
+  curl -X POST https://<api-domain>/api/cp/generate \
+    -H "Authorization: Bearer <your-jwt>" \
+    -H "Content-Type: application/json" \
+    -d '{"eventId": "<real-event-id>"}'
+  ```
+- [ ] Verify:
+  - [ ] Response: `{ "message": "CP generation started...", "trackingId": "..." }`
+  - [ ] GitHub Actions workflow starts
+  - [ ] Webhook callback reaches the backend
+  - [ ] Email/log notification is sent
+  - [ ] Download endpoint returns the zip file
+
+### Security Tests
+- [ ] Test unauthenticated request → 401:
+  ```bash
+  curl -X POST https://<api-domain>/api/cp/generate \
+    -H "Content-Type: application/json" \
+    -d '{"eventId": "test"}'
+  ```
+- [ ] Test user without permission → 403 (use a regular user JWT, not admin)
+- [ ] Test duplicate generation → 409 (call generate twice quickly)
+
+### CP File Validation
+- [ ] Download the artifact zip from GitHub Actions
+- [ ] Extract the `.cp` file
+- [ ] Open it in Competition Planner
+- [ ] Verify: events, teams, players, clubs, locations are all present and correct
+
+---
+
+## 5. Production Deployment
+
+- [ ] Merge the `feat/cp-export-cross-platform` branch to `develop`
+- [ ] Deploy to staging and run the end-to-end test above
+- [ ] If staging passes, merge to `main` via the normal release process
+- [ ] After production deploy:
+  - [ ] Run one final end-to-end test with a real competition event
+  - [ ] Confirm the old `GET /cp` endpoint still works (deprecated but available)
+
+---
+
+## Pitfalls & Troubleshooting
+
+### PAT Expiration
+The GitHub PAT expires after the duration you set. When it expires:
+- CP generation will fail with a 502 error
+- **Fix:** Create a new PAT and update `GITHUB_TOKEN_CP` on Render
+- **Prevention:** Set a calendar reminder for 2 weeks before expiry
+
+### Webhook Secret Mismatch
+If `CP_WEBHOOK_SECRET` doesn't match between GitHub secrets and Render env vars:
+- The webhook callback will be rejected (401)
+- The generation will complete but the user won't get an email
+- The download endpoint won't have a record for the run_id
+- **Fix:** Ensure both values are identical
+
+### Callback URL Not Reachable
+If the Render API is behind a VPN or the URL is wrong:
+- GitHub Actions will complete but the curl callback will fail
+- The user won't get an email
+- **Fix:** Ensure the URL is publicly accessible
+
+### Private Repo Artifact Downloads
+If the repo is private:
+- The PAT must have `actions:read` permission to download artifacts
+- This is already included in the recommended permissions above
+
+### Windows Runner Changes
+Microsoft occasionally updates the `windows-latest` runner image. If a runner update removes Jet OLEDB:
+- The file writer will fail with an ADODB error
+- **Fix:** Pin the runner to a specific version: `runs-on: windows-2022`
+- **Monitor:** Check the [GitHub Actions runner images changelog](https://github.com/actions/runner-images)
+
+### The `empty.cp` Template
+The template file at `libs/backend/generator/assets/empty.cp` must be present in the repo:
+- The GitHub Actions checkout includes it automatically
+- If it's gitignored or deleted, generation will fail
+- **Verify:** `git ls-files libs/backend/generator/assets/empty.cp` should return the path
+
+### In-Memory Generation Records
+Generation records are stored in-memory on the backend. If the backend restarts between triggering and the webhook callback:
+- The webhook will still succeed (it creates a new record)
+- But the `pendingByEvent` guard will be lost (allowing duplicate triggers)
+- This is acceptable for a once-a-year operation

--- a/docs/guides/cp-export-frontend-integration.md
+++ b/docs/guides/cp-export-frontend-integration.md
@@ -1,0 +1,131 @@
+# CP Export: Frontend Integration Guide
+
+This guide walks through integrating the CP file export into the NextJS frontend.
+
+## API Endpoints
+
+### 1. Trigger Generation
+
+```
+POST /api/cp/generate
+```
+
+**Headers:**
+- `Authorization: Bearer <JWT token>`
+- `Content-Type: application/json`
+
+**Body:**
+```json
+{
+  "eventId": "<uuid of the EventCompetition>"
+}
+```
+
+**Success Response (200):**
+```json
+{
+  "message": "CP generation started. You will receive an email when the file is ready for download.",
+  "trackingId": "event-1-1712345678000"
+}
+```
+
+**Error Responses:**
+
+| Status | Meaning | When |
+|--------|---------|------|
+| 400 | Bad Request | `eventId` is missing |
+| 401 | Unauthorized | No valid JWT token |
+| 403 | Forbidden | User lacks `export-cp:competition` permission |
+| 404 | Not Found | Event with given ID doesn't exist |
+| 409 | Conflict | A generation is already in progress for this event |
+| 413 | Payload Too Large | Competition data exceeds 65K character limit |
+| 502 | Bad Gateway | GitHub Actions API failed |
+| 503 | Service Unavailable | Backend not configured for CP export (missing env vars) |
+
+### 2. Download File
+
+```
+GET /api/cp/download/:runId
+```
+
+**Headers:**
+- `Authorization: Bearer <JWT token>`
+
+**Success Response:** Binary file stream (`application/zip`) with `Content-Disposition: attachment` header.
+
+**Error Responses:**
+
+| Status | Meaning | When |
+|--------|---------|------|
+| 401 | Unauthorized | No valid JWT token |
+| 403 | Forbidden | User lacks permission |
+| 202 | Accepted | Generation still in progress |
+| 404 | Not Found | Unknown runId |
+| 410 | Gone | Generation failed, or artifact expired (>30 days) |
+| 502 | Bad Gateway | GitHub API error |
+
+---
+
+## Tasks
+
+### Permission Check
+- [ ] Check if the user has the `export-cp:competition` permission before showing the export button
+- [ ] Use the existing permission check pattern from your auth context/hook
+
+### UI Components
+- [ ] Add an "Export CP" button on the competition detail page (only visible to users with the right permission)
+- [ ] On click, call `POST /api/cp/generate` with the `eventId`
+- [ ] Show a success toast/message: "CP file generation started. You'll receive an email when it's ready."
+- [ ] Handle error responses with appropriate user-friendly messages:
+  - 409: "A generation is already in progress. Please wait."
+  - 413: "Competition is too large for export. Contact support."
+  - 503: "CP export is not configured. Contact an administrator."
+
+### Download Page/Route
+- [ ] Create a route like `/cp/download/:runId` that the email download link points to
+- [ ] On this page, call `GET /api/cp/download/:runId`
+- [ ] Trigger a browser download of the returned zip file
+- [ ] Handle 202 (still processing): show a "still generating, please wait" message
+- [ ] Handle 410 (expired/failed): show "file expired or generation failed" message
+
+### Error Handling
+- [ ] Wrap API calls in try/catch with proper error extraction
+- [ ] Map HTTP status codes to user-friendly messages (see tables above)
+- [ ] Consider adding a retry button for transient failures (502)
+
+---
+
+## Environment Variables
+
+The frontend only needs the API base URL -- no secrets:
+
+| Variable | Value | Notes |
+|----------|-------|-------|
+| `API_BASE_URL` | `https://api.badman.app` (prod) | Already configured |
+
+---
+
+## User Flow
+
+```
+1. User navigates to competition detail page
+2. User sees "Export CP" button (only if they have permission)
+3. User clicks button
+4. Frontend calls POST /api/cp/generate
+5. User sees "Generation started" message
+6. User receives email with download link (2-5 minutes later)
+7. User clicks download link → opens /cp/download/:runId
+8. Frontend calls GET /api/cp/download/:runId
+9. Browser downloads the .cp zip file
+10. User extracts .cp file and opens in Competition Planner
+```
+
+---
+
+## Pitfalls
+
+- **Don't poll for status.** The flow is email-based. There is no polling endpoint.
+- **Download link expires after 30 days.** The `.cp` file artifact is kept for 30 days on GitHub. After that, the user needs to regenerate.
+- **Only one generation per event at a time.** If the user (or anyone else) already triggered a generation, subsequent attempts get a 409 until it completes or times out (15 min).
+- **The download returns a zip file**, not a `.cp` file directly. GitHub Actions artifacts are always zipped. The zip contains the `.cp` file.
+- **Base URL differs between staging and production.** Make sure the `API_BASE_URL` is environment-specific.

--- a/libs/backend/generator/src/generator.module.ts
+++ b/libs/backend/generator/src/generator.module.ts
@@ -1,13 +1,13 @@
 import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
-import { PlannerService } from "./services";
+import { CpDataCollector, PlannerService } from "./services";
 import { EnrollmentModule } from "@badman/backend-enrollment";
 import { TranslateModule } from "@badman/backend-translate";
 
 @Module({
   imports: [EnrollmentModule, ConfigModule, TranslateModule],
   controllers: [],
-  providers: [PlannerService],
-  exports: [PlannerService],
+  providers: [CpDataCollector, PlannerService],
+  exports: [CpDataCollector, PlannerService],
 })
 export class GeneratorModule {}

--- a/libs/backend/generator/src/index.ts
+++ b/libs/backend/generator/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./generator.module";
+export * from "./interfaces/cp-payload.interface";
 export * from "./services";

--- a/libs/backend/generator/src/interfaces/cp-payload.interface.ts
+++ b/libs/backend/generator/src/interfaces/cp-payload.interface.ts
@@ -1,0 +1,110 @@
+/**
+ * CpPayload: The JSON contract between CpDataCollector (TypeScript/PostgreSQL)
+ * and CpFileWriter (standalone script running on Windows via GitHub Actions).
+ *
+ * All entities use `refId` (PostgreSQL UUID) for cross-referencing.
+ * The CpFileWriter resolves these to auto-increment MDB IDs internally.
+ */
+
+export interface CpPayload {
+  event: CpEvent;
+  subEvents: CpSubEvent[];
+  clubs: CpClub[];
+  locations: CpLocation[];
+  teams: CpTeam[];
+  players: CpPlayer[];
+  teamPlayers: CpTeamPlayer[];
+  entries: CpEntry[];
+  memos: CpMemo[];
+  settings: CpSettings;
+}
+
+export interface CpEvent {
+  name: string;
+  season: number;
+}
+
+export interface CpSubEvent {
+  refId: string;
+  name: string;
+  /** 1 = Male, 2 = Female, 3 = Mixed */
+  gender: number | null;
+  /** Sort order in the event list */
+  sortOrder: number;
+}
+
+export interface CpClub {
+  refId: string;
+  name: string;
+  clubId: number | string;
+  /** Country code, hardcoded to 19 (Belgium) */
+  country: number;
+  abbreviation: string;
+}
+
+export interface CpLocation {
+  refId: string;
+  clubRefId: string;
+  name: string;
+  address: string;
+  postalcode: string;
+  city: string;
+  phone: string | null;
+}
+
+export interface CpTeam {
+  refId: string;
+  clubRefId: string;
+  subEventRefId: string;
+  name: string;
+  /** Country code, hardcoded to 19 (Belgium) */
+  country: number;
+  /** Formatted as MM/DD/YYYY HH:MM:ss */
+  entryDate: string;
+  contact: string | null;
+  phone: string | null;
+  email: string | null;
+  /** 1=monday through 7=sunday, or null */
+  dayOfWeek: number | string | null;
+  /** Time string like "HH:MM" or null */
+  planTime: string | null;
+  /** refId of the preferred Location, or null */
+  preferredLocationRefId: string | null;
+}
+
+export interface CpPlayer {
+  refId: string;
+  clubRefId: string;
+  lastName: string;
+  firstName: string;
+  /** 1 = Male, 2 = Female, 3 = Mixed */
+  gender: number | null;
+  memberId: string | null;
+  levels: CpPlayerLevels;
+}
+
+export interface CpPlayerLevels {
+  single: number;
+  double: number;
+  mix: number;
+}
+
+export interface CpTeamPlayer {
+  teamRefId: string;
+  playerRefId: string;
+  status: number;
+}
+
+export interface CpEntry {
+  teamRefId: string;
+  subEventRefId: string;
+}
+
+export interface CpMemo {
+  teamRefId: string;
+  memo: string;
+}
+
+export interface CpSettings {
+  tournamentName: string;
+}

--- a/libs/backend/generator/src/scripts/cp-file-writer.spec.ts
+++ b/libs/backend/generator/src/scripts/cp-file-writer.spec.ts
@@ -1,0 +1,341 @@
+/**
+ * Test Suite 2: CpFileWriter
+ *
+ * Split into two parts:
+ *
+ * 1. CROSS-PLATFORM UNIT TESTS (run anywhere, including macOS/Linux)
+ *    - Tests for jetEscape, jetString, validatePayload
+ *    - No ADODB dependency
+ *
+ * 2. WINDOWS-ONLY INTEGRATION TESTS (run only on windows-latest in CI)
+ *    - End-to-end: payload → .cp file → verify with ADODB queries
+ *    - Skipped automatically on non-Windows platforms
+ */
+
+import { CpPayload } from "../interfaces/cp-payload.interface";
+import { jetEscape, jetString, validatePayload } from "./cp-file-writer";
+
+// ─── Cross-platform unit tests ────────────────────────────────────
+
+describe("jetEscape", () => {
+  it("should return empty string for null/undefined", () => {
+    expect(jetEscape(null)).toBe("");
+    expect(jetEscape(undefined)).toBe("");
+  });
+
+  it("should escape double quotes by doubling them", () => {
+    expect(jetEscape('Sporthal "De Grote" Hal')).toBe('Sporthal ""De Grote"" Hal');
+  });
+
+  it("should trim whitespace", () => {
+    expect(jetEscape("  hello  ")).toBe("hello");
+  });
+
+  it("should handle Belgian names with accents", () => {
+    expect(jetEscape("Degrève")).toBe("Degrève");
+    expect(jetEscape("Müller")).toBe("Müller");
+  });
+
+  it("should handle single quotes (pass through, not escaped)", () => {
+    expect(jetEscape("O'Brien")).toBe("O'Brien");
+  });
+
+  it("should handle empty string", () => {
+    expect(jetEscape("")).toBe("");
+  });
+});
+
+describe("jetString", () => {
+  it("should wrap in double quotes", () => {
+    expect(jetString("hello")).toBe('"hello"');
+  });
+
+  it("should return empty quoted string for null", () => {
+    expect(jetString(null)).toBe('""');
+  });
+
+  it("should escape inner double quotes", () => {
+    expect(jetString('say "hi"')).toBe('"say ""hi"""');
+  });
+});
+
+describe("validatePayload", () => {
+  function minimalPayload(): CpPayload {
+    return {
+      event: { name: "Test", season: 2025 },
+      subEvents: [],
+      clubs: [],
+      locations: [],
+      teams: [],
+      players: [],
+      teamPlayers: [],
+      entries: [],
+      memos: [],
+      settings: { tournamentName: "Test" },
+    };
+  }
+
+  it("should accept a valid minimal payload", () => {
+    expect(() => validatePayload(minimalPayload())).not.toThrow();
+  });
+
+  it("should reject payload without event.name", () => {
+    const payload = minimalPayload();
+    payload.event.name = "";
+    expect(() => validatePayload(payload)).toThrow("event.name");
+  });
+
+  it("should reject payload without settings.tournamentName", () => {
+    const payload = minimalPayload();
+    payload.settings.tournamentName = "";
+    expect(() => validatePayload(payload)).toThrow("settings.tournamentName");
+  });
+
+  it("should reject payload with non-array subEvents", () => {
+    const payload = minimalPayload();
+    (payload as any).subEvents = "not an array";
+    expect(() => validatePayload(payload)).toThrow("subEvents");
+  });
+
+  it("should reject payload with non-array clubs", () => {
+    const payload = minimalPayload();
+    (payload as any).clubs = null;
+    expect(() => validatePayload(payload)).toThrow("clubs");
+  });
+
+  it("should reject payload with non-array teams", () => {
+    const payload = minimalPayload();
+    (payload as any).teams = {};
+    expect(() => validatePayload(payload)).toThrow("teams");
+  });
+
+  it("should reject payload with non-array players", () => {
+    const payload = minimalPayload();
+    (payload as any).players = undefined;
+    expect(() => validatePayload(payload)).toThrow("players");
+  });
+
+  it("should reject payload with non-array entries", () => {
+    const payload = minimalPayload();
+    (payload as any).entries = 42;
+    expect(() => validatePayload(payload)).toThrow("entries");
+  });
+});
+
+// ─── Windows-only integration tests ───────────────────────────────
+
+const isWindows = process.platform === "win32";
+const describeIfWindows = isWindows ? describe : describe.skip;
+
+function createTestPayload(): CpPayload {
+  return {
+    event: { name: "Test Event 2025", season: 2025 },
+    subEvents: [
+      { refId: "se-1", name: "Heren A", gender: 1, sortOrder: 0 },
+      { refId: "se-2", name: "Dames A", gender: 2, sortOrder: 1 },
+    ],
+    clubs: [
+      {
+        refId: "club-1",
+        name: "BC Test",
+        clubId: "12345",
+        country: 19,
+        abbreviation: "BCT",
+      },
+      {
+        refId: "club-2",
+        name: "BC O'Brien",
+        clubId: "67890",
+        country: 19,
+        abbreviation: "BCO",
+      },
+    ],
+    locations: [
+      {
+        refId: "loc-1",
+        clubRefId: "club-1",
+        name: "Sporthal Test",
+        address: "Teststraat 42",
+        postalcode: "1000",
+        city: "Brussel",
+        phone: "02 123 45 67",
+      },
+    ],
+    teams: [
+      {
+        refId: "team-1",
+        clubRefId: "club-1",
+        subEventRefId: "se-1",
+        name: "BC Test (1)",
+        country: 19,
+        entryDate: "01/15/2025 10:00:00",
+        contact: "Jan Janssens",
+        phone: "0123456789",
+        email: "jan@test.be",
+        dayOfWeek: 3,
+        planTime: "20:00",
+        preferredLocationRefId: "loc-1",
+      },
+      {
+        refId: "team-2",
+        clubRefId: "club-2",
+        subEventRefId: "se-2",
+        name: "BC O'Brien (1)",
+        country: 19,
+        entryDate: "01/16/2025 11:00:00",
+        contact: "Marie O'Brien",
+        phone: null,
+        email: null,
+        dayOfWeek: 5,
+        planTime: null,
+        preferredLocationRefId: null,
+      },
+    ],
+    players: [
+      {
+        refId: "player-1",
+        clubRefId: "club-1",
+        lastName: "Janssens",
+        firstName: "Jan",
+        gender: 1,
+        memberId: "50001",
+        levels: { single: 5, double: 4, mix: 3 },
+      },
+      {
+        refId: "player-2",
+        clubRefId: "club-2",
+        lastName: "O'Brien",
+        firstName: "Marie",
+        gender: 2,
+        memberId: "50002",
+        levels: { single: 8, double: 7, mix: -1 },
+      },
+    ],
+    teamPlayers: [
+      { teamRefId: "team-1", playerRefId: "player-1", status: 1 },
+      { teamRefId: "team-2", playerRefId: "player-2", status: 1 },
+    ],
+    entries: [
+      { teamRefId: "team-1", subEventRefId: "se-1" },
+      { teamRefId: "team-2", subEventRefId: "se-2" },
+    ],
+    memos: [
+      {
+        teamRefId: "team-1",
+        memo: "--==[Fouten]==--\nTest error message\n\n",
+      },
+    ],
+    settings: { tournamentName: "Test Event 2025" },
+  };
+}
+
+describeIfWindows("CpFileWriter integration (Windows-only)", () => {
+  const { existsSync } = require("fs");
+  const { unlink, writeFile } = require("fs/promises");
+  const { join } = require("path");
+
+  const outputPath = join(process.cwd(), "test-output.cp");
+  const payloadPath = join(process.cwd(), "test-payload.json");
+  const templatePath = join(process.cwd(), "libs/backend/generator/assets/empty.cp");
+
+  beforeAll(async () => {
+    if (!existsSync(templatePath)) {
+      throw new Error(`Template file not found: ${templatePath}. Run tests from repo root.`);
+    }
+    if (!process.env["CP_PASS"]) {
+      throw new Error("CP_PASS environment variable is required for these tests.");
+    }
+  });
+
+  afterAll(async () => {
+    for (const f of [outputPath, payloadPath]) {
+      if (existsSync(f)) await unlink(f);
+    }
+  });
+
+  it("should generate a valid .cp file from a test payload", async () => {
+    const payload = createTestPayload();
+    await writeFile(payloadPath, JSON.stringify(payload));
+
+    const { execSync } = require("child_process");
+    execSync(
+      `node dist/libs/backend/generator/scripts/cp-file-writer.js ${payloadPath} --output ${outputPath}`,
+      {
+        env: { ...process.env },
+        stdio: "pipe",
+      }
+    );
+
+    expect(existsSync(outputPath)).toBe(true);
+  });
+
+  it("should have correct row counts", async () => {
+    const ADODB = require("node-adodb");
+    const conn = ADODB.open(
+      `Provider=Microsoft.Jet.OLEDB.4.0;Data Source=${outputPath};Jet OLEDB:Database Password=${process.env["CP_PASS"]}`
+    );
+
+    const events = await conn.query("SELECT COUNT(*) as cnt FROM Event");
+    expect(events[0].cnt).toBe(2);
+
+    const clubs = await conn.query("SELECT COUNT(*) as cnt FROM Club");
+    expect(clubs[0].cnt).toBe(2);
+
+    const locations = await conn.query("SELECT COUNT(*) as cnt FROM Location");
+    expect(locations[0].cnt).toBe(1);
+
+    const teams = await conn.query("SELECT COUNT(*) as cnt FROM Team");
+    expect(teams[0].cnt).toBe(2);
+
+    const players = await conn.query("SELECT COUNT(*) as cnt FROM Player");
+    expect(players[0].cnt).toBe(2);
+
+    const entries = await conn.query("SELECT COUNT(*) as cnt FROM Entry");
+    expect(entries[0].cnt).toBe(2);
+
+    const leagues = await conn.query("SELECT COUNT(*) as cnt FROM League");
+    expect(leagues[0].cnt).toBe(3);
+  });
+
+  it("should have correct cross-references", async () => {
+    const ADODB = require("node-adodb");
+    const conn = ADODB.open(
+      `Provider=Microsoft.Jet.OLEDB.4.0;Data Source=${outputPath};Jet OLEDB:Database Password=${process.env["CP_PASS"]}`
+    );
+
+    const locs = await conn.query(
+      "SELECT l.clubid, c.name FROM Location l INNER JOIN Club c ON l.clubid = c.id"
+    );
+    expect(locs).toHaveLength(1);
+    expect(locs[0].name).toBe("BC Test");
+
+    const tps = await conn.query(
+      "SELECT tp.team, tp.player, t.name as teamName, p.name as playerName FROM TeamPlayer tp INNER JOIN Team t ON tp.team = t.id INNER JOIN Player p ON tp.player = p.id"
+    );
+    expect(tps).toHaveLength(2);
+  });
+
+  it("should have settings written correctly", async () => {
+    const ADODB = require("node-adodb");
+    const conn = ADODB.open(
+      `Provider=Microsoft.Jet.OLEDB.4.0;Data Source=${outputPath};Jet OLEDB:Database Password=${process.env["CP_PASS"]}`
+    );
+
+    const settings = await conn.query('SELECT [value] FROM settings WHERE [name] = "tournament"');
+    expect(settings[0].value).toBe("Test Event 2025");
+  });
+
+  it("should have memos written on the correct team", async () => {
+    const ADODB = require("node-adodb");
+    const conn = ADODB.open(
+      `Provider=Microsoft.Jet.OLEDB.4.0;Data Source=${outputPath};Jet OLEDB:Database Password=${process.env["CP_PASS"]}`
+    );
+
+    const teamsWithMemo = await conn.query(
+      "SELECT name, memo FROM Team WHERE memo IS NOT NULL AND LEN(memo) > 0"
+    );
+    expect(teamsWithMemo).toHaveLength(1);
+    expect(teamsWithMemo[0].name).toContain("BC Test");
+    expect(teamsWithMemo[0].memo).toContain("Fouten");
+  });
+});

--- a/libs/backend/generator/src/scripts/cp-file-writer.ts
+++ b/libs/backend/generator/src/scripts/cp-file-writer.ts
@@ -1,0 +1,384 @@
+/**
+ * CpFileWriter: Standalone script for writing CpPayload data to a .cp (Access MDB) file.
+ *
+ * Runs ONLY on Windows (requires node-adodb / Jet OLEDB 4.0).
+ * Intended to be executed on a GitHub Actions windows-latest runner.
+ *
+ * Usage: node cp-file-writer.js <payload.json> [--template <path>] [--output <path>]
+ *
+ * Environment:
+ *   CP_PASS - Access database password
+ */
+
+import { existsSync } from "fs";
+import { copyFile, readFile } from "fs/promises";
+import { join, resolve } from "path";
+import {
+  CpClub,
+  CpEntry,
+  CpLocation,
+  CpMemo,
+  CpPayload,
+  CpPlayer,
+  CpSubEvent,
+  CpTeam,
+  CpTeamPlayer,
+} from "../interfaces/cp-payload.interface";
+
+interface AdodbConnection {
+  query<T>(sql: string): Promise<T>;
+  execute<T>(sql: string, scalar?: string): Promise<T>;
+  transaction<T>(sql: string[]): Promise<T>;
+}
+
+type Identity = { id: number }[];
+
+type StageNames = "Main Draw" | "Reserves" | "Uitloten";
+
+const STAGES: { name: StageNames; displayOrder: number; stagetype: number }[] = [
+  { name: "Main Draw", displayOrder: 1, stagetype: 1 },
+  { name: "Reserves", displayOrder: 9998, stagetype: 9998 },
+  { name: "Uitloten", displayOrder: 9999, stagetype: 9999 },
+];
+
+function jetEscape(str?: string | null): string {
+  if (str == null) return "";
+  return str.replace(/"/g, '""').trim();
+}
+
+function jetString(str?: string | null): string {
+  return `"${jetEscape(str)}"`;
+}
+
+/**
+ * Validate that the payload has the minimum required structure.
+ * Catches corrupted/truncated JSON early with a clear message.
+ */
+function validatePayload(payload: CpPayload): void {
+  if (!payload.event?.name) {
+    throw new Error("Invalid payload: missing event.name");
+  }
+  if (!payload.settings?.tournamentName) {
+    throw new Error("Invalid payload: missing settings.tournamentName");
+  }
+  if (!Array.isArray(payload.subEvents)) {
+    throw new Error("Invalid payload: subEvents must be an array");
+  }
+  if (!Array.isArray(payload.clubs)) {
+    throw new Error("Invalid payload: clubs must be an array");
+  }
+  if (!Array.isArray(payload.teams)) {
+    throw new Error("Invalid payload: teams must be an array");
+  }
+  if (!Array.isArray(payload.players)) {
+    throw new Error("Invalid payload: players must be an array");
+  }
+  if (!Array.isArray(payload.entries)) {
+    throw new Error("Invalid payload: entries must be an array");
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const payloadPath = args[0];
+
+  if (!payloadPath) {
+    console.error("Usage: cp-file-writer.js <payload.json> [--template <path>] [--output <path>]");
+    process.exit(1);
+  }
+
+  const templateIdx = args.indexOf("--template");
+  const outputIdx = args.indexOf("--output");
+
+  const templatePath =
+    templateIdx >= 0
+      ? args[templateIdx + 1]
+      : join(process.cwd(), "libs/backend/generator/assets/empty.cp");
+
+  // Parse and validate payload
+  let payload: CpPayload;
+  try {
+    const payloadRaw = await readFile(payloadPath, "utf-8");
+    payload = JSON.parse(payloadRaw);
+  } catch (e) {
+    console.error(`Failed to read/parse payload file: ${payloadPath}`, e);
+    process.exit(1);
+  }
+
+  validatePayload(payload!);
+
+  const outputPath =
+    outputIdx >= 0 ? args[outputIdx + 1] : join(process.cwd(), `${payload.event.name}.cp`);
+
+  const password = process.env["CP_PASS"];
+  if (!password) {
+    console.error("CP_PASS environment variable is required");
+    process.exit(1);
+  }
+
+  if (!existsSync(templatePath)) {
+    console.error(`Template file not found: ${templatePath}`);
+    process.exit(1);
+  }
+
+  console.log(`Copying template: ${templatePath} → ${outputPath}`);
+  await copyFile(templatePath, outputPath);
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  let ADODB;
+  try {
+    ADODB = require("node-adodb");
+  } catch (e) {
+    console.error(
+      "node-adodb is not available. This script must run on Windows with Jet OLEDB 4.0.",
+      e
+    );
+    process.exit(1);
+  }
+
+  const connection: AdodbConnection = ADODB.open(
+    `Provider=Microsoft.Jet.OLEDB.4.0;Data Source=${resolve(outputPath)};Jet OLEDB:Database Password=${password}`
+  );
+
+  console.log("Preparing CP file...");
+  await prepCpFile(connection, payload);
+
+  console.log(`Adding ${payload.subEvents.length} events...`);
+  const eventIdMap = await addEvents(connection, payload.subEvents);
+
+  console.log(`Adding ${payload.clubs.length} clubs...`);
+  const clubIdMap = await addClubs(connection, payload.clubs);
+
+  console.log(`Adding ${payload.locations.length} locations...`);
+  const locationIdMap = await addLocations(connection, payload.locations, clubIdMap);
+
+  console.log(`Adding ${payload.teams.length} teams...`);
+  const teamIdMap = await addTeams(connection, payload.teams, clubIdMap, locationIdMap);
+
+  console.log(`Adding ${payload.entries.length} entries...`);
+  await addEntries(connection, payload.entries, eventIdMap, teamIdMap);
+
+  console.log(`Adding ${payload.players.length} players...`);
+  await addPlayers(connection, payload.players, payload.teamPlayers, clubIdMap, teamIdMap);
+
+  console.log(`Adding ${payload.memos.length} memos...`);
+  await addMemos(connection, payload.memos, teamIdMap);
+
+  console.log(`CP file generated: ${resolve(outputPath)}`);
+}
+
+// Export for testing
+export { jetEscape, jetString, validatePayload };
+
+async function prepCpFile(connection: AdodbConnection, payload: CpPayload): Promise<void> {
+  const queries = [
+    "DELETE FROM TournamentDay;",
+    "DELETE FROM stageentry;",
+    "DELETE FROM League;",
+    "DELETE FROM Entry;",
+    "DELETE FROM TeamPlayer;",
+    "DELETE FROM PlayerlevelEntry;",
+    "DELETE FROM Team;",
+    "DELETE FROM Court;",
+    "DELETE FROM Location;",
+    "DELETE FROM Player;",
+    "DELETE FROM Club;",
+    "DELETE FROM Event;",
+    "DELETE FROM stage;",
+    // Default leagues
+    'INSERT INTO League(id, name) VALUES(1, "Heren");',
+    'INSERT INTO League(id, name) VALUES(2, "Dames");',
+    'INSERT INTO League(id, name) VALUES(3, "Gemengd");',
+    'UPDATE SettingsMemo SET [value] = NULL where [name] = "TournamentLogo"',
+    // New file: set unicode and tournament name
+    `UPDATE settings SET [value] = "${new Date()
+      .toISOString()
+      .replace(/[-T:.Z]/g, "")
+      .substring(0, 18)}" where [name] = "unicode"`,
+    'UPDATE settings SET [value] = NULL where [name] = "director" or [name] = "DirectorEmail" or [name] = "DirectorPhone" or [name] = "LocationAddress1" or [name] = "LocationPostalCode" or [name] = "LocationCity" or [name] = "LocationState" or [name] = "Location"',
+    `UPDATE settings SET [value] = ${jetString(payload.settings.tournamentName)} where [name] = "tournament"`,
+  ];
+
+  await connection.transaction(queries);
+}
+
+async function addEvents(
+  connection: AdodbConnection,
+  subEvents: CpSubEvent[]
+): Promise<Map<string, { cpId: number; stages: Record<StageNames, number> }>> {
+  const map = new Map<string, { cpId: number; stages: Record<StageNames, number> }>();
+
+  for (const subEvent of subEvents) {
+    const query = `INSERT INTO Event(name, gender, eventtype, league, sortorder) VALUES(${jetString(subEvent.name)}, ${subEvent.gender}, 2, ${subEvent.gender}, ${subEvent.sortOrder});`;
+    const res = await connection.execute<Identity>(query, "SELECT @@Identity AS id");
+    const cpId = res[0].id;
+
+    const stages: Record<StageNames, number> = {
+      "Main Draw": -1,
+      Reserves: -1,
+      Uitloten: -1,
+    };
+
+    for (const stage of STAGES) {
+      const stageQuery = `INSERT INTO stage(name, event, displayorder, stagetype) VALUES("${stage.name}", "${cpId}", "${stage.displayOrder}", "${stage.stagetype}");`;
+      const stageRes = await connection.execute<Identity>(stageQuery, "SELECT @@Identity AS id");
+      stages[stage.name] = stageRes[0].id;
+    }
+
+    map.set(subEvent.refId, { cpId, stages });
+  }
+
+  return map;
+}
+
+async function addClubs(
+  connection: AdodbConnection,
+  clubs: CpClub[]
+): Promise<Map<string, number>> {
+  const map = new Map<string, number>();
+
+  for (const club of clubs) {
+    const query = `INSERT INTO Club(name, clubId, country, abbreviation) VALUES(${jetString(club.name)}, "${jetEscape(String(club.clubId))}", ${club.country}, "${jetEscape(club.abbreviation)}")`;
+    const res = await connection.execute<Identity>(query, "SELECT @@Identity AS id");
+    map.set(club.refId, res[0].id);
+  }
+
+  return map;
+}
+
+async function addLocations(
+  connection: AdodbConnection,
+  locations: CpLocation[],
+  clubIdMap: Map<string, number>
+): Promise<Map<string, number>> {
+  const map = new Map<string, number>();
+
+  for (const loc of locations) {
+    const clubCpId = clubIdMap.get(loc.clubRefId);
+    if (clubCpId == null) continue;
+
+    const query = `INSERT INTO Location(name, address, postalcode, city, phone, clubid) VALUES(${jetString(loc.name)}, ${jetString(loc.address)}, "${jetEscape(loc.postalcode)}", "${jetEscape(loc.city)}", "${jetEscape(loc.phone)}", ${clubCpId})`;
+    const res = await connection.execute<Identity>(query, "SELECT @@Identity AS id");
+    map.set(loc.refId, res[0].id);
+  }
+
+  return map;
+}
+
+async function addTeams(
+  connection: AdodbConnection,
+  teams: CpTeam[],
+  clubIdMap: Map<string, number>,
+  locationIdMap: Map<string, number>
+): Promise<Map<string, number>> {
+  const map = new Map<string, number>();
+
+  for (const team of teams) {
+    const clubCpId = clubIdMap.get(team.clubRefId);
+    if (clubCpId == null) continue;
+
+    const prefLoc =
+      team.preferredLocationRefId != null
+        ? (locationIdMap.get(team.preferredLocationRefId) ?? "NULL")
+        : "NULL";
+    const plantime = team.planTime ? `#${team.planTime}#` : "NULL";
+    const dayofweek = team.dayOfWeek ?? "NULL";
+
+    const query = `INSERT INTO Team(name, club, country, entrydate, contact, phone, email, dayofweek, plantime, preferredlocation1) VALUES(${jetString(team.name)}, ${clubCpId}, ${team.country}, #${team.entryDate}#, "${jetEscape(team.contact)}", "${jetEscape(team.phone)}", "${jetEscape(team.email)}", ${dayofweek}, ${plantime}, ${prefLoc})`;
+
+    try {
+      const res = await connection.execute<Identity>(query, "SELECT @@Identity AS id");
+      map.set(team.refId, res[0].id);
+    } catch (e) {
+      console.error(`Error inserting team ${team.name}:`, e);
+    }
+  }
+
+  return map;
+}
+
+async function addEntries(
+  connection: AdodbConnection,
+  entries: CpEntry[],
+  eventIdMap: Map<string, { cpId: number; stages: Record<StageNames, number> }>,
+  teamIdMap: Map<string, number>
+): Promise<void> {
+  for (const entry of entries) {
+    const teamCpId = teamIdMap.get(entry.teamRefId);
+    const eventData = eventIdMap.get(entry.subEventRefId);
+    if (teamCpId == null || eventData == null) continue;
+
+    const entryQuery = `INSERT INTO Entry(event, team) VALUES("${eventData.cpId}", "${teamCpId}")`;
+    const res = await connection.execute<Identity>(entryQuery, "SELECT @@Identity AS id");
+
+    const stageQuery = `INSERT INTO stageentry(entry, stage) VALUES(${res[0].id}, ${eventData.stages["Main Draw"]})`;
+    await connection.execute(stageQuery);
+  }
+}
+
+async function addPlayers(
+  connection: AdodbConnection,
+  players: CpPlayer[],
+  teamPlayers: CpTeamPlayer[],
+  clubIdMap: Map<string, number>,
+  teamIdMap: Map<string, number>
+): Promise<void> {
+  const playerIdMap = new Map<string, number>();
+  const batchQueries: string[] = [];
+
+  for (const player of players) {
+    const clubCpId = clubIdMap.get(player.clubRefId);
+    if (clubCpId == null) continue;
+
+    const query = `INSERT INTO Player(name, firstname, gender, memberid, club, foreignid, dob) VALUES(${jetString(player.lastName)}, ${jetString(player.firstName)}, ${player.gender}, ${jetString(player.memberId)}, ${clubCpId}, NULL, NULL)`;
+    const res = await connection.execute<Identity>(query, "SELECT @@Identity AS id");
+    const cpId = res[0].id;
+    playerIdMap.set(player.refId, cpId);
+
+    batchQueries.push(
+      `INSERT INTO PlayerlevelEntry(leveltype, playerid, level1, level2, level3) VALUES(1, ${cpId}, ${player.levels.single}, ${player.levels.double}, ${player.levels.mix})`
+    );
+  }
+
+  // Add team-player associations
+  for (const tp of teamPlayers) {
+    const teamCpId = teamIdMap.get(tp.teamRefId);
+    const playerCpId = playerIdMap.get(tp.playerRefId);
+    if (teamCpId == null || playerCpId == null) continue;
+
+    batchQueries.push(
+      `INSERT INTO TeamPlayer(team, player, status) VALUES(${teamCpId}, ${playerCpId}, ${tp.status})`
+    );
+  }
+
+  if (batchQueries.length > 0) {
+    await connection.transaction(batchQueries);
+  }
+}
+
+async function addMemos(
+  connection: AdodbConnection,
+  memos: CpMemo[],
+  teamIdMap: Map<string, number>
+): Promise<void> {
+  const queries: string[] = [];
+
+  for (const memo of memos) {
+    const teamCpId = teamIdMap.get(memo.teamRefId);
+    if (teamCpId == null) continue;
+
+    queries.push(`UPDATE Team SET [memo] = ${jetString(memo.memo)} WHERE id = ${teamCpId}`);
+  }
+
+  if (queries.length > 0) {
+    await connection.transaction(queries);
+  }
+}
+
+// Only run when executed directly (not when imported by tests)
+if (require.main === module) {
+  main().catch((e) => {
+    console.error("CP file generation failed:", e);
+    process.exit(1);
+  });
+}

--- a/libs/backend/generator/src/services/cp-data-collector.spec.ts
+++ b/libs/backend/generator/src/services/cp-data-collector.spec.ts
@@ -1,0 +1,806 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException } from "@nestjs/common";
+import { I18nService } from "nestjs-i18n";
+import { CpDataCollector } from "./cp-data-collector";
+import { EventCompetition, Player, Club } from "@badman/backend-database";
+import { EnrollmentValidationService } from "@badman/backend-enrollment";
+import { TeamMembershipType } from "@badman/utils";
+
+// Helper to create mock objects with association getters
+function mockEvent(overrides: Partial<EventCompetition> = {}) {
+  return {
+    id: "event-1",
+    name: "Test Competition 2025",
+    season: 2025,
+    getSubEventCompetitions: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  } as unknown as EventCompetition;
+}
+
+function mockSubEvent(overrides = {}) {
+  return {
+    id: "sub-1",
+    name: "Heren A",
+    eventType: "M",
+    getEventEntries: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+function mockClub(overrides = {}) {
+  return {
+    id: "club-1",
+    name: "BC Test",
+    clubId: "12345",
+    abbreviation: "BCT",
+    getLocations: jest.fn().mockResolvedValue([]),
+    getComments: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+function mockTeam(overrides = {}) {
+  return {
+    id: "team-1",
+    name: "BC Test",
+    clubId: "club-1",
+    type: "M",
+    link: null,
+    teamNumber: 1,
+    preferredDay: "wednesday",
+    preferredTime: "20:00",
+    phone: "0123456789",
+    email: "team@test.be",
+    players: [],
+    getClub: jest.fn().mockResolvedValue(mockClub()),
+    getCaptain: jest.fn().mockResolvedValue({
+      fullName: "Jan Janssens",
+    }),
+    getPrefferedLocation: jest.fn().mockResolvedValue(null),
+    ...overrides,
+  };
+}
+
+function mockEntry(overrides = {}) {
+  return {
+    id: "entry-1",
+    subEventId: "sub-1",
+    createdAt: new Date("2025-01-15T10:00:00Z"),
+    meta: {
+      competition: {
+        teamIndex: 1,
+        players: [
+          { id: "player-1", single: 5, double: 4, mix: 3 },
+          { id: "player-2", single: 8, double: 7, mix: -1 },
+        ],
+      },
+    },
+    getTeam: jest.fn().mockResolvedValue(mockTeam()),
+    ...overrides,
+  };
+}
+
+function mockLocation(overrides = {}) {
+  return {
+    id: "loc-1",
+    name: "Sporthal Test",
+    street: "Teststraat",
+    streetNumber: "42",
+    postalcode: "1000",
+    city: "Brussel",
+    phone: "02 123 45 67",
+    ...overrides,
+  };
+}
+
+describe("CpDataCollector", () => {
+  let collector: CpDataCollector;
+  let mockValidation: jest.Mocked<EnrollmentValidationService>;
+  let mockI18n: jest.Mocked<I18nService>;
+
+  beforeEach(async () => {
+    mockValidation = {
+      fetchAndValidate: jest.fn().mockResolvedValue({ teams: [] }),
+    } as any;
+
+    mockI18n = {
+      translate: jest.fn().mockImplementation((key: string) => key),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CpDataCollector,
+        { provide: EnrollmentValidationService, useValue: mockValidation },
+        { provide: I18nService, useValue: mockI18n },
+      ],
+    }).compile();
+
+    collector = module.get<CpDataCollector>(CpDataCollector);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("collect", () => {
+    it("should throw NotFoundException when event does not exist", async () => {
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(null);
+
+      await expect(collector.collect("nonexistent")).rejects.toThrow(NotFoundException);
+    });
+
+    it("should return a correct CpPayload structure for a basic competition", async () => {
+      const club = mockClub({
+        getLocations: jest.fn().mockResolvedValue([mockLocation()]),
+        getComments: jest.fn().mockResolvedValue([]),
+      });
+
+      const team = mockTeam({
+        getClub: jest.fn().mockResolvedValue(club),
+        getPrefferedLocation: jest.fn().mockResolvedValue(mockLocation()),
+      });
+
+      const entry = mockEntry({
+        getTeam: jest.fn().mockResolvedValue(team),
+      });
+
+      const subEvent = mockSubEvent({
+        getEventEntries: jest.fn().mockResolvedValue([entry]),
+      });
+
+      const event = mockEvent({
+        getSubEventCompetitions: jest.fn().mockResolvedValue([subEvent]),
+      });
+
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(event);
+      jest.spyOn(Player, "findAll").mockResolvedValue([
+        {
+          id: "player-1",
+          lastName: "Janssens",
+          firstName: "Jan",
+          gender: "M",
+          memberId: "50001",
+        } as any,
+        {
+          id: "player-2",
+          lastName: "Peeters",
+          firstName: "Piet",
+          gender: "M",
+          memberId: "50002",
+        } as any,
+      ]);
+
+      mockValidation.fetchAndValidate.mockResolvedValue({
+        teams: [],
+      } as any);
+
+      const payload = await collector.collect("event-1");
+
+      // Verify structure
+      expect(payload.event).toEqual({
+        name: "Test Competition 2025",
+        season: 2025,
+      });
+      expect(payload.subEvents).toHaveLength(1);
+      expect(payload.subEvents[0]).toMatchObject({
+        refId: "sub-1",
+        name: "Heren A",
+        gender: 1,
+        sortOrder: 0,
+      });
+      expect(payload.clubs).toHaveLength(1);
+      expect(payload.clubs[0]).toMatchObject({
+        refId: "club-1",
+        name: "BC Test",
+        clubId: "12345",
+        country: 19,
+      });
+      expect(payload.locations).toHaveLength(1);
+      expect(payload.locations[0]).toMatchObject({
+        refId: "loc-1",
+        clubRefId: "club-1",
+        name: "Sporthal Test",
+        address: "Teststraat 42",
+      });
+      expect(payload.teams).toHaveLength(1);
+      expect(payload.teams[0]).toMatchObject({
+        refId: "team-1",
+        clubRefId: "club-1",
+        name: "BC Test (1)",
+        country: 19,
+        dayOfWeek: 3,
+      });
+      expect(payload.players).toHaveLength(2);
+      expect(payload.teamPlayers).toHaveLength(2);
+      expect(payload.entries).toHaveLength(1);
+      expect(payload.settings.tournamentName).toBe("Test Competition 2025");
+    });
+
+    it("should deduplicate clubs across multiple sub-events", async () => {
+      const club = mockClub({
+        getLocations: jest.fn().mockResolvedValue([]),
+        getComments: jest.fn().mockResolvedValue([]),
+      });
+
+      const team1 = mockTeam({
+        id: "team-1",
+        getClub: jest.fn().mockResolvedValue(club),
+      });
+      const team2 = mockTeam({
+        id: "team-2",
+        getClub: jest.fn().mockResolvedValue(club),
+      });
+
+      const entry1 = mockEntry({
+        id: "entry-1",
+        getTeam: jest.fn().mockResolvedValue(team1),
+      });
+      const entry2 = mockEntry({
+        id: "entry-2",
+        subEventId: "sub-2",
+        getTeam: jest.fn().mockResolvedValue(team2),
+      });
+
+      const subEvent1 = mockSubEvent({
+        id: "sub-1",
+        getEventEntries: jest.fn().mockResolvedValue([entry1]),
+      });
+      const subEvent2 = mockSubEvent({
+        id: "sub-2",
+        name: "Dames A",
+        eventType: "F",
+        getEventEntries: jest.fn().mockResolvedValue([entry2]),
+      });
+
+      const event = mockEvent({
+        getSubEventCompetitions: jest.fn().mockResolvedValue([subEvent1, subEvent2]),
+      });
+
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(event);
+      jest.spyOn(Player, "findAll").mockResolvedValue([]);
+      mockValidation.fetchAndValidate.mockResolvedValue({
+        teams: [],
+      } as any);
+
+      const payload = await collector.collect("event-1");
+
+      // Same club appears in both sub-events, should only appear once
+      expect(payload.clubs).toHaveLength(1);
+      expect(payload.subEvents).toHaveLength(2);
+      expect(payload.teams).toHaveLength(2);
+    });
+
+    it("should deduplicate players across multiple teams of the same club", async () => {
+      const club = mockClub({
+        getLocations: jest.fn().mockResolvedValue([]),
+        getComments: jest.fn().mockResolvedValue([]),
+      });
+
+      // Shared player across two teams
+      const sharedPlayerMeta = {
+        id: "player-1",
+        single: 5,
+        double: 4,
+        mix: 3,
+      };
+
+      const team1 = mockTeam({
+        id: "team-1",
+        getClub: jest.fn().mockResolvedValue(club),
+      });
+      const team2 = mockTeam({
+        id: "team-2",
+        getClub: jest.fn().mockResolvedValue(club),
+      });
+
+      const entry1 = mockEntry({
+        id: "entry-1",
+        meta: { competition: { teamIndex: 1, players: [sharedPlayerMeta] } },
+        getTeam: jest.fn().mockResolvedValue(team1),
+      });
+      const entry2 = mockEntry({
+        id: "entry-2",
+        meta: {
+          competition: {
+            teamIndex: 2,
+            players: [sharedPlayerMeta, { id: "player-2", single: 8, double: 7, mix: -1 }],
+          },
+        },
+        getTeam: jest.fn().mockResolvedValue(team2),
+      });
+
+      const subEvent = mockSubEvent({
+        getEventEntries: jest.fn().mockResolvedValue([entry1, entry2]),
+      });
+
+      const event = mockEvent({
+        getSubEventCompetitions: jest.fn().mockResolvedValue([subEvent]),
+      });
+
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(event);
+      jest.spyOn(Player, "findAll").mockResolvedValue([
+        {
+          id: "player-1",
+          lastName: "Janssens",
+          firstName: "Jan",
+          gender: "M",
+          memberId: "50001",
+        } as any,
+        {
+          id: "player-2",
+          lastName: "Peeters",
+          firstName: "Piet",
+          gender: "M",
+          memberId: "50002",
+        } as any,
+      ]);
+      mockValidation.fetchAndValidate.mockResolvedValue({
+        teams: [],
+      } as any);
+
+      const payload = await collector.collect("event-1");
+
+      // Player-1 appears in both teams but should only be in players array once
+      expect(payload.players).toHaveLength(2);
+      // But teamPlayers should have 3 entries (player-1 in team-1, player-1 + player-2 in team-2)
+      expect(payload.teamPlayers).toHaveLength(3);
+    });
+
+    it("should skip teams without a club", async () => {
+      const teamNoClub = mockTeam({
+        getClub: jest.fn().mockResolvedValue(null),
+      });
+      const entry = mockEntry({
+        getTeam: jest.fn().mockResolvedValue(teamNoClub),
+      });
+      const subEvent = mockSubEvent({
+        getEventEntries: jest.fn().mockResolvedValue([entry]),
+      });
+      const event = mockEvent({
+        getSubEventCompetitions: jest.fn().mockResolvedValue([subEvent]),
+      });
+
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(event);
+      jest.spyOn(Player, "findAll").mockResolvedValue([]);
+      mockValidation.fetchAndValidate.mockResolvedValue({
+        teams: [],
+      } as any);
+
+      const payload = await collector.collect("event-1");
+
+      expect(payload.teams).toHaveLength(0);
+      expect(payload.clubs).toHaveLength(0);
+    });
+
+    it("should map gender correctly", async () => {
+      const subEvents = [
+        mockSubEvent({ id: "s1", name: "Heren", eventType: "M" }),
+        mockSubEvent({ id: "s2", name: "Dames", eventType: "F" }),
+        mockSubEvent({ id: "s3", name: "Gemengd", eventType: "MX" }),
+      ];
+
+      // All sub-events have no entries for simplicity
+      const event = mockEvent({
+        getSubEventCompetitions: jest.fn().mockResolvedValue(subEvents),
+      });
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(event);
+      mockValidation.fetchAndValidate.mockResolvedValue({
+        teams: [],
+      } as any);
+
+      const payload = await collector.collect("event-1");
+
+      expect(payload.subEvents[0].gender).toBe(1); // M
+      expect(payload.subEvents[1].gender).toBe(2); // F
+      expect(payload.subEvents[2].gender).toBe(3); // MX
+    });
+
+    it("should map day-of-week correctly", async () => {
+      const days = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"];
+      const expected = [1, 2, 3, 4, 5, 6, 7];
+
+      const club = mockClub({
+        getLocations: jest.fn().mockResolvedValue([]),
+        getComments: jest.fn().mockResolvedValue([]),
+      });
+
+      const teams = days.map((day, i) =>
+        mockTeam({
+          id: `team-${i}`,
+          preferredDay: day,
+          getClub: jest.fn().mockResolvedValue(club),
+        })
+      );
+
+      const entries = teams.map((team, i) =>
+        mockEntry({
+          id: `entry-${i}`,
+          meta: { competition: { teamIndex: i + 1, players: [] } },
+          getTeam: jest.fn().mockResolvedValue(team),
+        })
+      );
+
+      const subEvent = mockSubEvent({
+        getEventEntries: jest.fn().mockResolvedValue(entries),
+      });
+
+      const event = mockEvent({
+        getSubEventCompetitions: jest.fn().mockResolvedValue([subEvent]),
+      });
+
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(event);
+      jest.spyOn(Player, "findAll").mockResolvedValue([]);
+      mockValidation.fetchAndValidate.mockResolvedValue({
+        teams: [],
+      } as any);
+
+      const payload = await collector.collect("event-1");
+
+      payload.teams.forEach((team, i) => {
+        expect(team.dayOfWeek).toBe(expected[i]);
+      });
+    });
+
+    it("should handle team without captain or preferred location", async () => {
+      const club = mockClub({
+        getLocations: jest.fn().mockResolvedValue([]),
+        getComments: jest.fn().mockResolvedValue([]),
+      });
+
+      const team = mockTeam({
+        preferredDay: null,
+        preferredTime: null,
+        phone: null,
+        email: null,
+        getClub: jest.fn().mockResolvedValue(club),
+        getCaptain: jest.fn().mockResolvedValue(null),
+        getPrefferedLocation: jest.fn().mockResolvedValue(null),
+      });
+
+      const entry = mockEntry({
+        meta: { competition: { teamIndex: 1, players: [] } },
+        getTeam: jest.fn().mockResolvedValue(team),
+      });
+
+      const subEvent = mockSubEvent({
+        getEventEntries: jest.fn().mockResolvedValue([entry]),
+      });
+
+      const event = mockEvent({
+        getSubEventCompetitions: jest.fn().mockResolvedValue([subEvent]),
+      });
+
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(event);
+      jest.spyOn(Player, "findAll").mockResolvedValue([]);
+      mockValidation.fetchAndValidate.mockResolvedValue({
+        teams: [],
+      } as any);
+
+      const payload = await collector.collect("event-1");
+
+      expect(payload.teams[0].contact).toBeNull();
+      expect(payload.teams[0].dayOfWeek).toBeNull();
+      expect(payload.teams[0].planTime).toBeNull();
+      expect(payload.teams[0].preferredLocationRefId).toBeNull();
+    });
+
+    it("should include memos with validation errors and comments", async () => {
+      const club = mockClub({
+        getLocations: jest.fn().mockResolvedValue([]),
+        getComments: jest.fn().mockResolvedValue([{ message: "Club comment here" }]),
+      });
+
+      const team = mockTeam({
+        getClub: jest.fn().mockResolvedValue(club),
+        players: [
+          {
+            id: "player-1",
+            TeamPlayerMembership: {
+              membershipType: TeamMembershipType.REGULAR,
+            },
+          },
+        ],
+      });
+
+      const entry = mockEntry({
+        meta: { competition: { teamIndex: 1, players: [{ id: "player-1" }] } },
+        getTeam: jest.fn().mockResolvedValue(team),
+      });
+
+      const subEvent = mockSubEvent({
+        getEventEntries: jest.fn().mockResolvedValue([entry]),
+      });
+
+      const event = mockEvent({
+        getSubEventCompetitions: jest.fn().mockResolvedValue([subEvent]),
+      });
+
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(event);
+      jest.spyOn(Player, "findAll").mockResolvedValue([]);
+
+      mockValidation.fetchAndValidate.mockResolvedValue({
+        teams: [
+          {
+            id: "team-1",
+            errors: [
+              {
+                message: "all.v1.enrollment.error.test",
+                params: {},
+              },
+            ],
+          },
+        ],
+      } as any);
+
+      mockI18n.translate.mockReturnValue("Translated error message");
+
+      const payload = await collector.collect("event-1");
+
+      expect(payload.memos).toHaveLength(1);
+      expect(payload.memos[0].teamRefId).toBe("team-1");
+      expect(payload.memos[0].memo).toContain("--==[Fouten]==--");
+      expect(payload.memos[0].memo).toContain("Translated error message");
+      expect(payload.memos[0].memo).toContain("--==[Club comments]==--");
+      expect(payload.memos[0].memo).toContain("Club comment here");
+    });
+
+    it("should strip HTML tags from validation error messages", async () => {
+      const club = mockClub({
+        getLocations: jest.fn().mockResolvedValue([]),
+        getComments: jest.fn().mockResolvedValue([]),
+      });
+
+      const team = mockTeam({
+        getClub: jest.fn().mockResolvedValue(club),
+        players: [],
+      });
+
+      const entry = mockEntry({
+        meta: { competition: { teamIndex: 1, players: [] } },
+        getTeam: jest.fn().mockResolvedValue(team),
+      });
+
+      const subEvent = mockSubEvent({
+        getEventEntries: jest.fn().mockResolvedValue([entry]),
+      });
+
+      const event = mockEvent({
+        getSubEventCompetitions: jest.fn().mockResolvedValue([subEvent]),
+      });
+
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(event);
+      jest.spyOn(Player, "findAll").mockResolvedValue([]);
+
+      mockValidation.fetchAndValidate.mockResolvedValue({
+        teams: [
+          {
+            id: "team-1",
+            errors: [
+              {
+                message: "error.key",
+                params: {},
+              },
+            ],
+          },
+        ],
+      } as any);
+
+      mockI18n.translate.mockReturnValue("Error with <strong>HTML</strong> tags");
+
+      const payload = await collector.collect("event-1");
+
+      expect(payload.memos[0].memo).toContain("Error with HTML tags");
+      expect(payload.memos[0].memo).not.toContain("<strong>");
+    });
+
+    it("should preserve special characters in data (no SQL escaping at this layer)", async () => {
+      const club = mockClub({
+        name: "BC O'Brien & Müller",
+        getLocations: jest
+          .fn()
+          .mockResolvedValue([mockLocation({ name: 'Sporthal "De Grote" Hal' })]),
+        getComments: jest.fn().mockResolvedValue([]),
+      });
+
+      const team = mockTeam({
+        name: "O'Brien Team",
+        getClub: jest.fn().mockResolvedValue(club),
+      });
+
+      const entry = mockEntry({
+        meta: { competition: { teamIndex: 1, players: [] } },
+        getTeam: jest.fn().mockResolvedValue(team),
+      });
+
+      const subEvent = mockSubEvent({
+        getEventEntries: jest.fn().mockResolvedValue([entry]),
+      });
+
+      const event = mockEvent({
+        getSubEventCompetitions: jest.fn().mockResolvedValue([subEvent]),
+      });
+
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(event);
+      jest.spyOn(Player, "findAll").mockResolvedValue([]);
+      mockValidation.fetchAndValidate.mockResolvedValue({
+        teams: [],
+      } as any);
+
+      const payload = await collector.collect("event-1");
+
+      expect(payload.clubs[0].name).toBe("BC O'Brien & Müller");
+      expect(payload.locations[0].name).toBe('Sporthal "De Grote" Hal');
+      expect(payload.teams[0].name).toBe("O'Brien Team (1)");
+    });
+
+    it("should produce JSON-serializable output (no Date objects, circular refs)", async () => {
+      const club = mockClub({
+        getLocations: jest.fn().mockResolvedValue([mockLocation()]),
+        getComments: jest.fn().mockResolvedValue([]),
+      });
+
+      const team = mockTeam({
+        getClub: jest.fn().mockResolvedValue(club),
+      });
+
+      const entry = mockEntry({
+        getTeam: jest.fn().mockResolvedValue(team),
+      });
+
+      const subEvent = mockSubEvent({
+        getEventEntries: jest.fn().mockResolvedValue([entry]),
+      });
+
+      const event = mockEvent({
+        getSubEventCompetitions: jest.fn().mockResolvedValue([subEvent]),
+      });
+
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(event);
+      jest.spyOn(Player, "findAll").mockResolvedValue([
+        {
+          id: "player-1",
+          lastName: "Test",
+          firstName: "Player",
+          gender: "M",
+          memberId: "99999",
+        } as any,
+      ]);
+      mockValidation.fetchAndValidate.mockResolvedValue({
+        teams: [],
+      } as any);
+
+      const payload = await collector.collect("event-1");
+
+      // Round-trip through JSON should produce identical result
+      const serialized = JSON.stringify(payload);
+      const deserialized = JSON.parse(serialized);
+      expect(deserialized).toEqual(payload);
+    });
+
+    it("should format team name with teamIndex from entry meta", async () => {
+      const club = mockClub({
+        getLocations: jest.fn().mockResolvedValue([]),
+        getComments: jest.fn().mockResolvedValue([]),
+      });
+
+      const team = mockTeam({
+        name: "BC Test",
+        getClub: jest.fn().mockResolvedValue(club),
+      });
+
+      const entry = mockEntry({
+        meta: { competition: { teamIndex: 3, players: [] } },
+        getTeam: jest.fn().mockResolvedValue(team),
+      });
+
+      const subEvent = mockSubEvent({
+        getEventEntries: jest.fn().mockResolvedValue([entry]),
+      });
+
+      const event = mockEvent({
+        getSubEventCompetitions: jest.fn().mockResolvedValue([subEvent]),
+      });
+
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(event);
+      jest.spyOn(Player, "findAll").mockResolvedValue([]);
+      mockValidation.fetchAndValidate.mockResolvedValue({
+        teams: [],
+      } as any);
+
+      const payload = await collector.collect("event-1");
+
+      expect(payload.teams[0].name).toBe("BC Test (3)");
+    });
+
+    it("should format entryDate as MM/DD/YYYY HH:MM:ss", async () => {
+      const club = mockClub({
+        getLocations: jest.fn().mockResolvedValue([]),
+        getComments: jest.fn().mockResolvedValue([]),
+      });
+
+      const team = mockTeam({
+        getClub: jest.fn().mockResolvedValue(club),
+      });
+
+      const entry = mockEntry({
+        createdAt: new Date("2025-03-15T14:30:45Z"),
+        meta: { competition: { teamIndex: 1, players: [] } },
+        getTeam: jest.fn().mockResolvedValue(team),
+      });
+
+      const subEvent = mockSubEvent({
+        getEventEntries: jest.fn().mockResolvedValue([entry]),
+      });
+
+      const event = mockEvent({
+        getSubEventCompetitions: jest.fn().mockResolvedValue([subEvent]),
+      });
+
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(event);
+      jest.spyOn(Player, "findAll").mockResolvedValue([]);
+      mockValidation.fetchAndValidate.mockResolvedValue({
+        teams: [],
+      } as any);
+
+      const payload = await collector.collect("event-1");
+
+      // Must match MM/DD/YYYY HH:MM:ss format for Access date literals
+      expect(payload.teams[0].entryDate).toMatch(/^\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2}$/);
+      // Verify the actual date components
+      expect(payload.teams[0].entryDate).toContain("03/15/2025");
+    });
+
+    it("should set player levels with defaults of -1", async () => {
+      const club = mockClub({
+        getLocations: jest.fn().mockResolvedValue([]),
+        getComments: jest.fn().mockResolvedValue([]),
+      });
+
+      const team = mockTeam({
+        getClub: jest.fn().mockResolvedValue(club),
+      });
+
+      const entry = mockEntry({
+        meta: {
+          competition: {
+            teamIndex: 1,
+            players: [
+              { id: "player-1" }, // No levels specified
+            ],
+          },
+        },
+        getTeam: jest.fn().mockResolvedValue(team),
+      });
+
+      const subEvent = mockSubEvent({
+        getEventEntries: jest.fn().mockResolvedValue([entry]),
+      });
+
+      const event = mockEvent({
+        getSubEventCompetitions: jest.fn().mockResolvedValue([subEvent]),
+      });
+
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(event);
+      jest.spyOn(Player, "findAll").mockResolvedValue([
+        {
+          id: "player-1",
+          lastName: "NoLevels",
+          firstName: "Player",
+          gender: "M",
+          memberId: "11111",
+        } as any,
+      ]);
+      mockValidation.fetchAndValidate.mockResolvedValue({
+        teams: [],
+      } as any);
+
+      const payload = await collector.collect("event-1");
+
+      expect(payload.players[0].levels).toEqual({
+        single: -1,
+        double: -1,
+        mix: -1,
+      });
+    });
+  });
+});

--- a/libs/backend/generator/src/services/cp-data-collector.ts
+++ b/libs/backend/generator/src/services/cp-data-collector.ts
@@ -1,0 +1,418 @@
+import {
+  Club,
+  EventCompetition,
+  EventEntry,
+  Player,
+  SubEventCompetition,
+  Team,
+} from "@badman/backend-database";
+import { EnrollmentValidationService } from "@badman/backend-enrollment";
+import { I18nTranslations, SubEventTypeEnum, TeamMembershipType } from "@badman/utils";
+import { Injectable, Logger, NotFoundException } from "@nestjs/common";
+import { format } from "date-fns";
+import { I18nService } from "nestjs-i18n";
+import {
+  CpClub,
+  CpEntry,
+  CpLocation,
+  CpMemo,
+  CpPayload,
+  CpPlayer,
+  CpSubEvent,
+  CpTeam,
+  CpTeamPlayer,
+} from "../interfaces/cp-payload.interface";
+
+interface TeamData {
+  dbTeam: Team;
+  dbEntry: EventEntry;
+  dbSubEvent: SubEventCompetition;
+}
+
+@Injectable()
+export class CpDataCollector {
+  private readonly logger = new Logger(CpDataCollector.name);
+
+  constructor(
+    private _validation: EnrollmentValidationService,
+    private readonly i18nService: I18nService<I18nTranslations>
+  ) {}
+
+  async collect(eventId: string): Promise<CpPayload> {
+    this.logger.log(`Collecting CP data for event ${eventId}`);
+
+    const dbEvent = await EventCompetition.findByPk(eventId);
+    if (!dbEvent) {
+      throw new NotFoundException(`Event ${eventId} not found`);
+    }
+
+    const dbSubEvents = await dbEvent.getSubEventCompetitions();
+
+    // Collect clubs, locations, teams, players, entries
+    const clubMap = new Map<string, { dbClub: Club }>();
+    const teamDataList: TeamData[] = [];
+
+    // Traverse: dbSubEvents → entries → teams → clubs
+    for (const dbSubEvent of dbSubEvents) {
+      const dbEntries = await dbSubEvent.getEventEntries();
+      for (const dbEntry of dbEntries) {
+        const [dbTeam] = await Promise.all([
+          dbEntry.getTeam({
+            include: [{ model: Player, as: "players" }],
+          }),
+        ]);
+        const dbClub = await dbTeam.getClub();
+
+        if (!dbClub) {
+          this.logger.warn(`Team ${dbTeam.name} has no club, skipping`);
+          continue;
+        }
+
+        if (!clubMap.has(dbClub.id)) {
+          clubMap.set(dbClub.id, { dbClub });
+        }
+
+        teamDataList.push({ dbTeam, dbEntry, dbSubEvent });
+      }
+    }
+
+    // Build sub-events payload
+    const cpSubEvents = this._collectSubEvents(dbSubEvents);
+
+    // Build clubs payload
+    const cpClubs = this._collectClubs(clubMap);
+
+    // Build locations payload
+    const cpLocations = await this._collectLocations(clubMap);
+
+    // Build teams payload
+    const { cpTeams, cpEntries } = await this._collectTeams(teamDataList, clubMap);
+
+    // Build players + teamPlayers payload
+    const { cpPlayers, cpTeamPlayers } = await this._collectPlayers(teamDataList, clubMap);
+
+    // Build memos payload
+    const cpMemos = await this._collectMemos(dbEvent, clubMap, teamDataList);
+
+    return {
+      event: {
+        name: dbEvent.name!,
+        season: dbEvent.season,
+      },
+      subEvents: cpSubEvents,
+      clubs: cpClubs,
+      locations: cpLocations,
+      teams: cpTeams,
+      players: cpPlayers,
+      teamPlayers: cpTeamPlayers,
+      entries: cpEntries,
+      memos: cpMemos,
+      settings: {
+        tournamentName: dbEvent.name!,
+      },
+    };
+  }
+
+  private _collectSubEvents(dbSubEvents: SubEventCompetition[]): CpSubEvent[] {
+    return dbSubEvents.map((dbSubEvent, i) => ({
+      refId: dbSubEvent.id,
+      name: dbSubEvent.name!,
+      gender: this._getGender(dbSubEvent.eventType),
+      sortOrder: i,
+    }));
+  }
+
+  private _collectClubs(clubMap: Map<string, { dbClub: Club }>): CpClub[] {
+    return [...clubMap.values()].map(({ dbClub }) => ({
+      refId: dbClub.id,
+      name: dbClub.name || "",
+      clubId: dbClub.clubId!,
+      // 19 = Belgium (Competition Planner country code for Belgian federations)
+      country: 19,
+      abbreviation: dbClub.abbreviation || "",
+    }));
+  }
+
+  private async _collectLocations(clubMap: Map<string, { dbClub: Club }>): Promise<CpLocation[]> {
+    const cpLocations: CpLocation[] = [];
+
+    for (const [, { dbClub }] of clubMap) {
+      const dbLocations = await dbClub.getLocations();
+      for (const dbLocation of dbLocations) {
+        cpLocations.push({
+          refId: dbLocation.id,
+          clubRefId: dbClub.id,
+          name: dbLocation.name || "",
+          address: `${dbLocation.street || ""} ${dbLocation.streetNumber || ""}`.trim(),
+          postalcode: dbLocation.postalcode || "",
+          city: dbLocation.city || "",
+          phone: dbLocation.phone || null,
+        });
+      }
+    }
+
+    return cpLocations;
+  }
+
+  private async _collectTeams(
+    teamDataList: TeamData[],
+    clubMap: Map<string, { dbClub: Club }>
+  ): Promise<{ cpTeams: CpTeam[]; cpEntries: CpEntry[] }> {
+    const cpTeams: CpTeam[] = [];
+    const cpEntries: CpEntry[] = [];
+
+    for (const { dbTeam, dbEntry, dbSubEvent } of teamDataList) {
+      const club = clubMap.get(dbTeam.clubId!);
+      if (!club) continue;
+
+      const index = dbEntry.meta?.competition?.teamIndex;
+
+      const [dbCaptain, dbPreferredLocation] = await Promise.all([
+        dbTeam.getCaptain(),
+        dbTeam.getPrefferedLocation(),
+      ]);
+
+      cpTeams.push({
+        refId: dbTeam.id,
+        clubRefId: club.dbClub.id,
+        subEventRefId: dbSubEvent.id,
+        name: `${dbTeam.name} (${index})`,
+        // 19 = Belgium (Competition Planner country code)
+        country: 19,
+        entryDate: this._formatEntryDate(dbEntry.createdAt ?? new Date()),
+        contact: dbCaptain?.fullName || null,
+        phone: dbTeam.phone || null,
+        email: dbTeam.email || null,
+        dayOfWeek: this._getDayOfWeek(dbTeam.preferredDay),
+        planTime: dbTeam.preferredTime ? `${dbTeam.preferredTime}` : null,
+        preferredLocationRefId: dbPreferredLocation?.id || null,
+      });
+
+      cpEntries.push({
+        teamRefId: dbTeam.id,
+        subEventRefId: dbSubEvent.id,
+      });
+    }
+
+    return { cpTeams, cpEntries };
+  }
+
+  private async _collectPlayers(
+    teamDataList: TeamData[],
+    clubMap: Map<string, { dbClub: Club }>
+  ): Promise<{ cpPlayers: CpPlayer[]; cpTeamPlayers: CpTeamPlayer[] }> {
+    // Deduplicate players per club
+    const playersPerClub = new Map<
+      string,
+      { id: string; single?: number; double?: number; mix?: number }[]
+    >();
+
+    for (const { dbTeam, dbEntry } of teamDataList) {
+      const players = [...(dbEntry?.meta?.competition?.players ?? [])];
+      const clubId = dbTeam.clubId!;
+
+      const existing = playersPerClub.get(clubId) ?? [];
+      for (const player of players) {
+        if (!existing.find((p) => p.id === player.id)) {
+          existing.push({
+            id: player.id!,
+            single: player.single,
+            double: player.double,
+            mix: player.mix,
+          });
+        }
+      }
+      playersPerClub.set(clubId, existing);
+    }
+
+    // Fetch full player data and build payload
+    const cpPlayers: CpPlayer[] = [];
+    const playerRefSet = new Set<string>();
+
+    for (const [clubId, entryPlayers] of playersPerClub) {
+      const club = clubMap.get(clubId);
+      if (!club) continue;
+
+      const playerIds = entryPlayers.map((p) => p.id).filter(Boolean) as string[];
+      const dbPlayers = await Player.findAll({
+        where: { id: playerIds },
+      });
+
+      for (const dbPlayer of dbPlayers) {
+        if (playerRefSet.has(dbPlayer.id)) continue;
+        playerRefSet.add(dbPlayer.id);
+
+        const entryPlayer = entryPlayers.find((p) => p.id === dbPlayer.id);
+
+        cpPlayers.push({
+          refId: dbPlayer.id,
+          clubRefId: clubId,
+          lastName: dbPlayer.lastName || "",
+          firstName: dbPlayer.firstName || "",
+          gender: this._getGender(dbPlayer.gender),
+          memberId: dbPlayer.memberId || null,
+          levels: {
+            single: entryPlayer?.single ?? -1,
+            double: entryPlayer?.double ?? -1,
+            mix: entryPlayer?.mix ?? -1,
+          },
+        });
+      }
+    }
+
+    // Build teamPlayers from entry meta
+    const cpTeamPlayers: CpTeamPlayer[] = [];
+    for (const { dbTeam, dbEntry } of teamDataList) {
+      const players = [...(dbEntry?.meta?.competition?.players ?? [])];
+      for (const player of players) {
+        if (player.id) {
+          cpTeamPlayers.push({
+            teamRefId: dbTeam.id,
+            playerRefId: player.id,
+            status: 1,
+          });
+        }
+      }
+    }
+
+    return { cpPlayers, cpTeamPlayers };
+  }
+
+  private async _collectMemos(
+    dbEvent: EventCompetition,
+    clubMap: Map<string, { dbClub: Club }>,
+    teamDataList: TeamData[]
+  ): Promise<CpMemo[]> {
+    const cpMemos: CpMemo[] = [];
+
+    for (const [, { dbClub }] of clubMap) {
+      const teamsOfClub = teamDataList.filter((t) => t.dbTeam.clubId === dbClub.id);
+
+      const validation = await this._validation.fetchAndValidate(
+        {
+          clubId: dbClub.id,
+          teams: teamsOfClub.map((t) => ({
+            id: t.dbTeam.id,
+            name: t.dbTeam.name,
+            type: t.dbTeam.type,
+            link: t.dbTeam.link,
+            teamNumber: t.dbTeam.teamNumber,
+            basePlayers: [...(t.dbEntry?.meta?.competition?.players ?? [])],
+            players: (t.dbTeam.players ?? [])
+              .filter((p) => p.TeamPlayerMembership.membershipType === TeamMembershipType.REGULAR)
+              .map((p) => p.id),
+            backupPlayers: (t.dbTeam.players ?? [])
+              .filter((p) => p.TeamPlayerMembership.membershipType === TeamMembershipType.BACKUP)
+              .map((p) => p.id),
+            subEventId: t.dbEntry?.subEventId,
+          })),
+          season: dbEvent.season,
+        },
+        EnrollmentValidationService.defaultValidators()
+      );
+
+      const dbComments = await dbClub.getComments({
+        where: {
+          linkType: "competition",
+          linkId: dbEvent.id,
+        },
+      });
+
+      for (const team of validation.teams ?? []) {
+        if (!team) continue;
+
+        const teamData = teamDataList.find((t) => t.dbTeam.id === team.id);
+        if (!teamData) {
+          this.logger.warn(
+            `Team ${team.id} not in team list for club ${dbClub.name}(${dbClub.id})`
+          );
+          continue;
+        }
+
+        const errors = (
+          team.errors?.map((e) => {
+            if (!e.message) return "";
+            const message: string = this.i18nService.translate(e.message, {
+              args: e.params as never,
+              lang: "nl_BE",
+            });
+            return message.replace(/<[^>]*>?/gm, "");
+          }) ?? []
+        ).filter(Boolean);
+
+        const commentTexts = dbComments?.map((c) => `${c.message}`) ?? [];
+
+        // Build memo text
+        let memo = "";
+
+        if (errors.length > 0) {
+          memo += `--==[Fouten]==--\n`;
+          memo += errors.join("\n");
+          memo += "\n\n";
+        }
+
+        if (commentTexts.length > 0) {
+          memo += `--==[Club comments]==--\n`;
+          memo += commentTexts.join("\n");
+          memo += "\n\n";
+        }
+
+        if (memo.length > 0) {
+          cpMemos.push({
+            teamRefId: teamData.dbTeam.id,
+            memo,
+          });
+        }
+      }
+    }
+
+    return cpMemos;
+  }
+
+  /**
+   * Format a date for Access date literals: MM/DD/YYYY HH:mm:ss
+   */
+  private _formatEntryDate(date: Date | string): string {
+    const d = typeof date === "string" ? new Date(date) : date;
+    return format(d, "MM/dd/yyyy HH:mm:ss");
+  }
+
+  /**
+   * Map day name to Competition Planner day number (1=monday through 7=sunday).
+   * The input values come from the Team model's preferredDay ENUM.
+   */
+  private _getDayOfWeek(day?: string): number | null {
+    if (!day) return null;
+
+    const dayMap: Record<string, number> = {
+      monday: 1,
+      tuesday: 2,
+      wednesday: 3,
+      thursday: 4,
+      friday: 5,
+      saturday: 6,
+      sunday: 7,
+    };
+
+    return dayMap[day] ?? null;
+  }
+
+  private _getGender(gender?: string): number | null {
+    if (!gender) return null;
+
+    switch (gender) {
+      case "M":
+      case SubEventTypeEnum.M:
+        return 1;
+      case "F":
+      case "V":
+      case SubEventTypeEnum.F:
+        return 2;
+      case "MX":
+      case SubEventTypeEnum.MX:
+        return 3;
+      default:
+        return null;
+    }
+  }
+}

--- a/libs/backend/generator/src/services/index.ts
+++ b/libs/backend/generator/src/services/index.ts
@@ -1,3 +1,4 @@
 // start:ng42.barrel
+export * from "./cp-data-collector";
 export * from "./planner";
 // end:ng42.barrel

--- a/libs/backend/mailing/src/compile/templates/cpExportFailed/html.pug
+++ b/libs/backend/mailing/src/compile/templates/cpExportFailed/html.pug
@@ -1,0 +1,18 @@
+extends ../../layouts/layout.pug
+
+block title
+  h1.text-center
+    | CP bestand mislukt
+
+block content
+  p.text-center
+    p
+      | Beste #{ user },
+      br
+      br
+      | Het genereren van je CP bestand is helaas mislukt. Probeer het opnieuw of neem contact op met de beheerder.
+    br
+    br
+    | Met sportieve groeten,
+    br
+    | Badman

--- a/libs/backend/mailing/src/compile/templates/cpExportReady/html.pug
+++ b/libs/backend/mailing/src/compile/templates/cpExportReady/html.pug
@@ -1,0 +1,21 @@
+extends ../../layouts/layout.pug
+
+block title
+  h1.text-center
+    | CP bestand klaar
+
+block content
+  p.text-center
+    p
+      | Beste #{ user },
+      br
+      br
+      | Je CP bestand is succesvol gegenereerd en klaar om te downloaden.
+    p
+      a(href=downloadUrl)
+        | Download CP bestand
+    br
+    br
+    | Met sportieve groeten,
+    br
+    | Badman

--- a/libs/backend/mailing/src/services/mailing/mailing.service.ts
+++ b/libs/backend/mailing/src/services/mailing/mailing.service.ts
@@ -596,6 +596,55 @@ export class MailingService {
     await this._sendMail(options);
   }
 
+  async sendCpExportReadyMail(
+    to: {
+      fullName: string;
+      email: string;
+      slug: string;
+    },
+    downloadUrl: string
+  ) {
+    const options = {
+      from: "info@badman.app",
+      to: to.email,
+      subject: "CP bestand klaar",
+      template: "cpExportReady",
+      context: {
+        user: to.fullName,
+        downloadUrl,
+        settingsSlug: to.slug,
+      },
+    } as MailOptions<{
+      user: string;
+      downloadUrl: string;
+      settingsSlug: string;
+    }>;
+
+    await this._sendMail(options);
+  }
+
+  async sendCpExportFailedMail(to: {
+    fullName: string;
+    email: string;
+    slug: string;
+  }) {
+    const options = {
+      from: "info@badman.app",
+      to: to.email,
+      subject: "CP bestand mislukt",
+      template: "cpExportFailed",
+      context: {
+        user: to.fullName,
+        settingsSlug: to.slug,
+      },
+    } as MailOptions<{
+      user: string;
+      settingsSlug: string;
+    }>;
+
+    await this._sendMail(options);
+  }
+
   private async _setupMailing() {
     if (this.initialized) return;
     if ((this.configService.get<boolean>("MAIL_ENABLED") ?? false) == false) {

--- a/libs/utils/src/config/configuration.ts
+++ b/libs/utils/src/config/configuration.ts
@@ -168,8 +168,11 @@ export const configSchema = Joi.object({
   }),
 
   CP_PASS: Joi.string().optional(),
+  GITHUB_TOKEN_CP: Joi.string().optional(),
   GITHUB_REPO_OWNER: Joi.string().optional(),
   GITHUB_REPO_NAME: Joi.string().optional(),
+  CP_CALLBACK_URL: Joi.string().optional(),
+  CP_WEBHOOK_SECRET: Joi.string().optional(),
 
   APOLLO_GRAPH_REF: Joi.when("NODE_ENV", {
     is: Joi.valid("production", "staging", "beta"),
@@ -260,8 +263,11 @@ export type ConfigType = {
   TWIZZIT_API_USER: string;
   TWIZZIT_API_PASS: string;
   CP_PASS?: string;
+  GITHUB_TOKEN_CP?: string;
   GITHUB_REPO_OWNER?: string;
   GITHUB_REPO_NAME?: string;
+  CP_CALLBACK_URL?: string;
+  CP_WEBHOOK_SECRET?: string;
   APOLLO_GRAPH_REF?: string;
   GRAPH_ID: string;
   RENDER_API_KEY: string;


### PR DESCRIPTION
## Summary

- Partial revert of 595473afe restoring the CP export feature on main (controller + tests, generator scripts/services/interfaces, mailing templates + service methods, config schema, workflow, docs).
- Test/lint/package.json repairs from 595473afe stay on main (not undone).
- Merge when CP export is ready to ship to prod.

## Restored

- `apps/api/src/app/controllers/cp.controller.{ts,spec.ts}` + wiring in `app.module.ts`
- `libs/backend/generator/src/{scripts/cp-file-writer, services/cp-data-collector, interfaces/cp-payload}` + barrel re-exports + `GeneratorModule` providers
- `libs/backend/mailing` pug templates + `sendCpExportReadyMail` / `sendCpExportFailedMail` on `MailingService`
- `libs/utils/src/config/configuration.ts`: `GITHUB_TOKEN_CP`, `CP_CALLBACK_URL`, `CP_WEBHOOK_SECRET` (schema + type)
- `.github/workflows/generate-cp.yml`
- `docs/estimates/export-reports-migration/*` and `docs/guides/cp-export-*.md`

## Test plan

- [ ] CI green on PR validation (`nx affected -t lint test`)
- [ ] Confirm prod build works locally: `NX_BASE=v6.185.0 nx affected -t lint test build -c ci --exclude="$(node scripts/ci/legacy-projects.js)"`
- [ ] Verify `CpController` reachable and the three CP env vars validate
- [ ] Confirm mailing templates compile (`sendCpExportReadyMail`, `sendCpExportFailedMail`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)