### PR TITLE
fix(enrollment): enforce window gate in submitEnrollment [BAD-237]

### DIFF
--- a/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.resolver.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { Player } from "@badman/backend-database";
+import { AdminSetting, Player } from "@badman/backend-database";
 import { NotificationService } from "@badman/backend-notifications";
 import { GraphQLError } from "graphql";
 import { Sequelize } from "sequelize-typescript";
@@ -81,6 +81,9 @@ describe("SubmitEnrollmentResolver.submitEnrollment", () => {
     resolver = module.get<SubmitEnrollmentResolver>(SubmitEnrollmentResolver);
     submitService = module.get(SubmitEnrollmentService);
     notificationService = module.get(NotificationService);
+
+    // Default: no AdminSetting row → gate skipped
+    jest.spyOn(AdminSetting, "findOne").mockResolvedValue(null);
 
     // Default: service succeeds
     submitService.run.mockResolvedValue(defaultServiceResult);
@@ -240,6 +243,71 @@ describe("SubmitEnrollmentResolver.submitEnrollment", () => {
 
     expect(result.teams).toHaveLength(1);
     expect(result.teams[0].entryId).toBe("entry-uuid");
+  });
+
+  // Enrollment window gate
+  it("throws ENROLLMENT_CLOSED when toggle is off", async () => {
+    const user = makeUser(["edit-any:club"]);
+    jest.spyOn(AdminSetting, "findOne").mockResolvedValue({
+      enabled: false,
+      startDate: null,
+      endDate: null,
+    } as AdminSetting);
+
+    await expect(resolver.submitEnrollment(user, makeInput())).rejects.toMatchObject({
+      extensions: { code: ErrorCode.ENROLLMENT_CLOSED },
+    });
+    expect(submitService.run).not.toHaveBeenCalled();
+  });
+
+  it("throws ENROLLMENT_CLOSED when endDate has passed", async () => {
+    const user = makeUser(["edit-any:club"]);
+    const yesterday = new Date(Date.now() - 86_400_000);
+    jest.spyOn(AdminSetting, "findOne").mockResolvedValue({
+      enabled: true,
+      startDate: null,
+      endDate: yesterday,
+    } as AdminSetting);
+
+    await expect(resolver.submitEnrollment(user, makeInput())).rejects.toMatchObject({
+      extensions: { code: ErrorCode.ENROLLMENT_CLOSED },
+    });
+  });
+
+  it("throws ENROLLMENT_CLOSED when startDate is in the future", async () => {
+    const user = makeUser(["edit-any:club"]);
+    const tomorrow = new Date(Date.now() + 86_400_000);
+    jest.spyOn(AdminSetting, "findOne").mockResolvedValue({
+      enabled: true,
+      startDate: tomorrow,
+      endDate: null,
+    } as AdminSetting);
+
+    await expect(resolver.submitEnrollment(user, makeInput())).rejects.toMatchObject({
+      extensions: { code: ErrorCode.ENROLLMENT_CLOSED },
+    });
+  });
+
+  it("allows submission when toggle is on and dates are in range", async () => {
+    const user = makeUser(["edit-any:club"]);
+    const yesterday = new Date(Date.now() - 86_400_000);
+    const tomorrow = new Date(Date.now() + 86_400_000);
+    jest.spyOn(AdminSetting, "findOne").mockResolvedValue({
+      enabled: true,
+      startDate: yesterday,
+      endDate: tomorrow,
+    } as AdminSetting);
+
+    await resolver.submitEnrollment(user, makeInput());
+    expect(submitService.run).toHaveBeenCalled();
+  });
+
+  it("allows submission when no enrollment setting row exists", async () => {
+    const user = makeUser(["edit-any:club"]);
+    jest.spyOn(AdminSetting, "findOne").mockResolvedValue(null);
+
+    await resolver.submitEnrollment(user, makeInput());
+    expect(submitService.run).toHaveBeenCalled();
   });
 
   // GraphQLErrors from service are rethrown without wrapping

--- a/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.resolver.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.resolver.ts
@@ -1,5 +1,5 @@
 import { User } from "@badman/backend-authorization";
-import { Player } from "@badman/backend-database";
+import { AdminSetting, Player } from "@badman/backend-database";
 import { NotificationService } from "@badman/backend-notifications";
 import { Logger } from "@nestjs/common";
 import { Args, Mutation, Resolver } from "@nestjs/graphql";
@@ -31,6 +31,19 @@ export class SubmitEnrollmentResolver {
       throw new GraphQLError("Permission denied", {
         extensions: { code: ErrorCode.PERMISSION_DENIED, clubId },
       });
+    }
+
+    const enrollmentSetting = await AdminSetting.findOne({ where: { key: "enrollment" } });
+    if (enrollmentSetting) {
+      const now = new Date();
+      const afterStart = !enrollmentSetting.startDate || now >= enrollmentSetting.startDate;
+      const beforeEnd = !enrollmentSetting.endDate || now <= enrollmentSetting.endDate;
+      const isOpen = enrollmentSetting.enabled && afterStart && beforeEnd;
+      if (!isOpen) {
+        throw new GraphQLError("Enrollment is currently closed", {
+          extensions: { code: ErrorCode.ENROLLMENT_CLOSED },
+        });
+      }
     }
 
     const confirmed = await user.hasAnyPermission(["change:transfer"]);

--- a/libs/backend/graphql/src/utils/error-codes.ts
+++ b/libs/backend/graphql/src/utils/error-codes.ts
@@ -38,6 +38,7 @@ export const ErrorCode = {
   NO_TEAMS_TO_FINALISE: "NO_TEAMS_TO_FINALISE",
 
   // Atomic enrollment submission (libs/backend/graphql/src/resolvers/event/competition/submit-enrollment.resolver.ts)
+  ENROLLMENT_CLOSED: "ENROLLMENT_CLOSED",
   VALIDATION_FAILED: "VALIDATION_FAILED",
 } as const;
 


### PR DESCRIPTION
## Summary

- `submitEnrollment` mutation had no backend check against `AdminSetting` — the toggle/date gate existed **only on the frontend**, allowing direct API calls to bypass enrollment windows
- Add an early guard: if an `enrollment` setting row exists, the mutation throws `ENROLLMENT_CLOSED` when `enabled = false` OR current date is outside `[startDate, endDate]`
- Add new `ENROLLMENT_CLOSED` error code to the stable registry in `error-codes.ts`
- 5 new test cases covering: toggle off, endDate passed, startDate in future, valid window, no setting row

## Test plan

- [ ] `npx jest --config libs/backend/graphql/jest.config.ts --testPathPattern submit-enrollment.resolver.spec` → 19/19 pass
- [ ] Manually verify: toggle off → mutation returns `ENROLLMENT_CLOSED`
- [ ] Manually verify: date after endDate → mutation returns `ENROLLMENT_CLOSED`
- [ ] Manually verify: valid window → mutation proceeds normally
- [ ] Frontend should handle `ENROLLMENT_CLOSED` code (coordinate with frontend repo)

Closes [BAD-237](https://linear.app/dashdot/issue/BAD-237)

🤖 Generated with [Claude Code](https://claude.com/claude-code)