### PR TITLE
hotfix(release): drop version.git block so createRelease can push

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -6,12 +6,7 @@
   "release": {
     "version": {
       "specifierSource": "conventional-commits",
-      "currentVersionResolver": "git-tag",
-      "git": {
-        "commit": false,
-        "tag": false,
-        "push": false
-      }
+      "currentVersionResolver": "git-tag"
     },
     "changelog": {
       "workspaceChangelog": {


### PR DESCRIPTION
## Summary
- Removes the redundant `release.version.git = { commit:false, tag:false, push:false }` block from `nx.json` that was triggering nx21 validation `GIT_PUSH_FALSE_WITH_CREATE_RELEASE` on every prod deploy after PR #907 merged.
- nx defaults for the version subcommand are already `commit/tag/push: false`, so the override was redundant; removing it keeps current behaviour while satisfying the validator so `release.changelog.workspaceChangelog.createRelease: github` can run.

## Why this is a hotfix
The prod deploy on `main` failed with:

```
NX   The createRelease option for changelogs cannot be enabled when git push is explicitly disabled because the commit needs to be pushed to the remote in order to tie the release to it
```

PR #907 (Release: backend games generation & exports) merged into `main` but the changelog step never ran, so no GitHub release was created and the deploy pipeline halted. Hotfix branched off `main` per AGENTS.md branching rules.

## Test plan
- [x] `npx nx release version --dry-run` succeeds with no validation error and no version-step git ops
- [ ] `deploy-production.yml` reaches `Create release` step and emits a `v*` tag + GitHub release once merged