### PR TITLE
hotfix(release): truncate body + bypass nx GitHub release prompt

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      release_version:
+        description: "Explicit version to release (e.g. 7.0.0). Leave empty to derive from conventional commits."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   actions: read
@@ -61,7 +67,12 @@ jobs:
 
       - name: Create release
         id: create_release
-        run: node scripts/release.js --dry-run=false
+        run: |
+          if [ -n "${{ inputs.release_version }}" ]; then
+            node scripts/release.js --dry-run=false --version="${{ inputs.release_version }}"
+          else
+            node scripts/release.js --dry-run=false
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -4,7 +4,14 @@ const yargs = require("yargs");
 const { hideBin } = require("yargs/helpers");
 const fs = require("fs");
 const path = require("path");
+const os = require("os");
+const { execFileSync } = require("child_process");
 const runExec = require("./run-exec");
+
+// GitHub release body hard cap. The API rejects bodies over 125000 characters
+// with a 422 ("body is too long"), and nx then prompts to open a browser
+// (which dead-locks in non-TTY CI). Stay safely under the limit.
+const MAX_RELEASE_BODY = 120000;
 
 // Walk through directory recursively
 function walkDir(currentDir, newVersion) {
@@ -22,26 +29,31 @@ function walkDir(currentDir, newVersion) {
 // Function to update version.json file
 function updateVersion(filePath, newVersion) {
   try {
-    // Read file content
     const content = fs.readFileSync(filePath, "utf8");
-
-    // Parse JSON content
     let data = JSON.parse(content);
-
-    data = {
-      ...data,
-      version: newVersion,
-    };
-
-    // Stringify updated data
+    data = { ...data, version: newVersion };
     const updatedContent = JSON.stringify(data, null, 2);
-
-    // Write updated content to file
     fs.writeFileSync(filePath, updatedContent);
     console.log(`Updated ${filePath} to version ${newVersion}`);
   } catch (error) {
     console.error(`Error updating ${filePath}:`, error);
   }
+}
+
+// Extract the most recent version's section from CHANGELOG.md.
+// nx writes new entries at the top; the latest section runs from the
+// first `## ` heading to the next `## ` heading (or EOF).
+function extractLatestChangelogEntry(changelogPath) {
+  if (!fs.existsSync(changelogPath)) return "";
+  const raw = fs.readFileSync(changelogPath, "utf8");
+  const match = raw.match(/^## [^\n]*[\s\S]*?(?=^## |\Z)/m);
+  return match ? match[0].trimEnd() : "";
+}
+
+function truncateBody(body, repoSlug, tag) {
+  if (body.length <= MAX_RELEASE_BODY) return body;
+  const tail = `\n\n_… changelog truncated. See [CHANGELOG.md on the ${tag} tag](https://github.com/${repoSlug}/blob/${tag}/CHANGELOG.md) for the full list._\n`;
+  return body.slice(0, MAX_RELEASE_BODY - tail.length) + tail;
 }
 
 (async () => {
@@ -75,15 +87,57 @@ function updateVersion(filePath, newVersion) {
     // update version.json files
     walkDir("./apps", workspaceVersion);
 
-    // // add version.json files to git
+    // add version.json files to git
     await runExec("git add '**/**/version.json'");
 
+    // Generate CHANGELOG.md + commit + tag + push, but DO NOT let nx create the
+    // GitHub release. With ~6000+ commits in a release window the workspace
+    // changelog can exceed GitHub's 125000-char body limit; nx posts the full
+    // body, gets a 422, and then drops into an interactive "finish in browser?"
+    // prompt that hangs CI. We do the release creation ourselves below, with
+    // truncation, via the gh CLI.
     await releaseChangelog({
       versionData: projectsVersionData,
       version: workspaceVersion,
       dryRun: options.dryRun,
       verbose: options.verbose,
+      createRelease: false,
     });
+
+    const tag = `v${workspaceVersion}`;
+
+    if (!options.dryRun) {
+      const repoSlug = process.env.GITHUB_REPOSITORY;
+      if (!repoSlug) {
+        core.warning(
+          "GITHUB_REPOSITORY is not set; skipping GitHub release creation. (Tag and changelog were still pushed by nx.)"
+        );
+      } else {
+        const latest = extractLatestChangelogEntry(path.resolve("CHANGELOG.md"));
+        if (!latest) {
+          core.warning(
+            "CHANGELOG.md has no version section to publish; skipping GitHub release creation."
+          );
+        } else {
+          const body = truncateBody(latest, repoSlug, tag);
+          const bodyFile = path.join(os.tmpdir(), `release-body-${tag}.md`);
+          fs.writeFileSync(bodyFile, body);
+          try {
+            execFileSync(
+              "gh",
+              ["release", "create", tag, "--title", tag, "--notes-file", bodyFile, "--verify-tag"],
+              { stdio: "inherit" }
+            );
+            core.info(`Created GitHub release ${tag} (${body.length} chars)`);
+          } finally {
+            fs.unlinkSync(bodyFile);
+          }
+        }
+      }
+    } else {
+      core.info(`[dry-run] Would create GitHub release ${tag}`);
+    }
+
     core.setOutput("NEW_VERSION", workspaceVersion);
     core.info(`New version: ${workspaceVersion}`);
   } catch (error) {


### PR DESCRIPTION
## Summary
Prod deploy after PR #907 hit two release-script failures:
- Workspace changelog body > GitHub's 125000-char release-body limit (PR #907 brought ~6000 commits in one window) → 422 from the GitHub API.
- nx then asked \"Do you want to finish creating the release manually in your browser?\", which hangs non-TTY CI and exits with code 1, so no release is created and the tag is published without notes.

Fix in \`scripts/release.js\`:
- Pass \`createRelease: false\` to \`releaseChangelog\` — nx still writes CHANGELOG.md and pushes the commit + tag, but does not call the GitHub API itself, so the failure path that triggers the prompt is removed.
- Extract the latest \`## ...\` section from CHANGELOG.md after the tag is pushed.
- Truncate to 120000 chars with a link back to the full changelog on the tag.
- Create the GitHub release via \`gh release create --notes-file --verify-tag\`.
- Skip in dry-run.

\`nx.json\` keeps \`release.changelog.workspaceChangelog.createRelease: github\` so ad-hoc \`nx release\` runs from a dev machine still create a release through nx; only the CI script overrides.

Future releases will be small and the truncation is a no-op — the safeguard only kicks in for unusually large commit ranges like this one.

## Test plan
- [x] \`node -c scripts/release.js\` passes
- [ ] Re-run prod deploy on main: \`Create release\` step succeeds, tag \`v6.186.0\` (or next) is created, GitHub release exists with truncated body + link to full CHANGELOG.md