### PR TITLE
hotfix(release): fix \Z regex + add lefthook pre-commit/pre-push

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,31 @@
+# Lefthook config — local Git hooks
+# Installed by `npm install` (postinstall hook) or `npx lefthook install`.
+# Skip with `git commit --no-verify` / `git push --no-verify` when needed.
+
+pre-commit:
+  parallel: true
+  jobs:
+    - name: eslint
+      glob: "*.{js,jsx,ts,tsx}"
+      # Stage any auto-fixes lefthook applies; ESLint exits non-zero on
+      # remaining errors so the commit is blocked.
+      run: npx eslint --fix {staged_files} && git add {staged_files}
+
+    - name: prettier
+      glob: "*.{js,jsx,ts,tsx,json,md,yml,yaml,scss,css,html,pug}"
+      exclude:
+        - "libs/utils/src/lib/i18n.generated.ts"
+        - "**/CHANGELOG.md"
+        - "**/all.json"
+      run: npx prettier --write {staged_files} && git add {staged_files}
+
+pre-push:
+  jobs:
+    - name: affected-lint
+      # Mirror the CI lint gate so issues like the `\Z` regex escape don't
+      # only surface after a 10-minute pipeline. Legacy projects stay
+      # excluded (Constitution V).
+      run: |
+        BASE_REF=$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD origin/develop 2>/dev/null || git rev-parse HEAD~1)
+        NX_BASE="$BASE_REF" NX_HEAD=HEAD \
+          npx nx affected -t lint --exclude="$(node scripts/ci/legacy-projects.js)"

--- a/package-lock.json
+++ b/package-lock.json
@@ -207,6 +207,7 @@
         "jest-preset-angular": "14.6.0",
         "jest-util": "30.0.5",
         "jsonc-eslint-parser": "^2.4.0",
+        "lefthook": "^2.1.8",
         "ng-packagr": "20.1.0",
         "nx": "21.3.7",
         "prettier": "3.4.2",
@@ -31325,6 +31326,169 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/lefthook": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-2.1.8.tgz",
+      "integrity": "sha512-tJIoVpFF52PuU8YPJI9bRprGwzI6FR2GNeBbpMnXdRjjfJHyOR4VRLXilzoQ6lbhKVHfTohXhrQgLpU41bKITg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "2.1.8",
+        "lefthook-darwin-x64": "2.1.8",
+        "lefthook-freebsd-arm64": "2.1.8",
+        "lefthook-freebsd-x64": "2.1.8",
+        "lefthook-linux-arm64": "2.1.8",
+        "lefthook-linux-x64": "2.1.8",
+        "lefthook-openbsd-arm64": "2.1.8",
+        "lefthook-openbsd-x64": "2.1.8",
+        "lefthook-windows-arm64": "2.1.8",
+        "lefthook-windows-x64": "2.1.8"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-2.1.8.tgz",
+      "integrity": "sha512-6dZr2QUdJOOvy9FjQHZoFVfPjgxb9IH5f9DeU0OBYMQ0cUGvb5YjHnkUkRrWIlASmwFm1bk3OPwhqKU7pTsICw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-2.1.8.tgz",
+      "integrity": "sha512-DW1yc+W5RBHdwaPJ94/mwFNROmNHI8Osu0iziIeJFXJIdkQ2P+KHfoxBWejYd2QA2Eu5W9i+gBssTDkJ4kX2kA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-2.1.8.tgz",
+      "integrity": "sha512-rmWVdImTihY/V1bLSb3zeDxEHjRBQtudnkKKsoph934enIWPwzIap5zVHHAj8q9mzp0wpn5r1ybX55aO2wM61A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-2.1.8.tgz",
+      "integrity": "sha512-o1AG4CpmgESxLqZWzkXhne+PhLhLFV0GHVAIJCmieOwq4q2+rDYAudGhtot/NrgSpyMCo84qVSQmI8Dgnu1XJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-2.1.8.tgz",
+      "integrity": "sha512-er3zTjx2DMxojPJ1LZv0G3ug9Th+mAapqWrt5ZZhQNcXWW28pfvo2fCqBs6Fz14GMn4xassmwOpGovutSh1UtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-2.1.8.tgz",
+      "integrity": "sha512-3yGx0VFbPcaKiIir313ETNcyq34CfAwkIU+Ry3WMGDjrsRNuA/YlDxm0BHKLcum7u+rpVfT4Uz6r8gHdaHXolg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-openbsd-arm64": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-2.1.8.tgz",
+      "integrity": "sha512-Dq+GJdJdclOwxt4NneTFHjLSA4v8tI7XUZq40KUVtpUQDpZcYhXSdkTytB0uLmD52tbFKt9Kx0VbB6uvxPvLvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-openbsd-x64": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-2.1.8.tgz",
+      "integrity": "sha512-/Gv2EdlzyiDoK+9fDWIn+EeTgrNeVncQsSeAF47X2Abe5LGxuFjZbBXxEIkY1BU79OQNNLnkx0gFHbrr5mmd9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-2.1.8.tgz",
+      "integrity": "sha512-S+/pBBj/7hMQOl9pLBS4Ut8+U0feQbzmD7iN0ifNth4r/uqW8UFFAHwERbclfsVnni4ceHpt7lFr7sXsu0RU8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-2.1.8.tgz",
+      "integrity": "sha512-MpdgKMU/JLLCsEpTqJ9jWlxngSdDh3EknvUHveWePrIms7G11y6R3oZBNRSqZ+zx/PGNl/HKvqEtbwtw8Hz3gw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/less": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "6.130.0-beta.12",
   "license": "MIT",
   "scripts": {
+    "prepare": "lefthook install || true",
     "ng": "nx",
     "start": "nx serve",
     "start:prod": "node -r dotenv/config --max-old-space-size=1536 dist/apps/api/main.js",
@@ -235,6 +236,7 @@
     "jest-preset-angular": "14.6.0",
     "jest-util": "30.0.5",
     "jsonc-eslint-parser": "^2.4.0",
+    "lefthook": "^2.1.8",
     "ng-packagr": "20.1.0",
     "nx": "21.3.7",
     "prettier": "3.4.2",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -46,8 +46,11 @@ function updateVersion(filePath, newVersion) {
 function extractLatestChangelogEntry(changelogPath) {
   if (!fs.existsSync(changelogPath)) return "";
   const raw = fs.readFileSync(changelogPath, "utf8");
-  const match = raw.match(/^## [^\n]*[\s\S]*?(?=^## |\Z)/m);
-  return match ? match[0].trimEnd() : "";
+  // Split on `## ` headings; sections[0] is anything before the first heading
+  // (usually empty/preamble), sections[1] is the most recent entry.
+  const sections = raw.split(/^## /m);
+  if (sections.length < 2) return "";
+  return ("## " + sections[1]).trimEnd();
 }
 
 function truncateBody(body, repoSlug, tag) {


### PR DESCRIPTION
## Summary
Two follow-ups to #970:

1. **Fix lint error in `scripts/release.js`**. The `extractLatestChangelogEntry` regex used `\Z` (PCRE end-of-string anchor), which is a `no-useless-escape` ESLint error in JavaScript. CI failed `badman_scripts:lint` after #970 merged. Switched to a `split(/^## /m)` strategy that is portable and easier to reason about.

2. **Add lefthook** so the same kind of mistake gets caught before CI burns 10 minutes:
   - `pre-commit` (parallel): ESLint `--fix` + Prettier `--write` on staged JS/TS/markup files, with `libs/utils/src/lib/i18n.generated.ts`, `**/CHANGELOG.md`, and `**/all.json` excluded.
   - `pre-push`: `nx affected -t lint` against the merge-base with `origin/main` (falling back to `develop`), with the legacy-projects exclusion CI uses. Mirrors the CI lint gate locally — the `\Z` issue would have failed pre-push in ~20s instead of a 10-minute pipeline.
   - `npm install` runs `lefthook install` via a new `prepare` script so collaborators get the hooks automatically (`|| true` so environments without a git dir don't choke).

Skip with `git commit --no-verify` / `git push --no-verify` when needed.

## Test plan
- [x] `npx nx run badman_scripts:lint` passes (no `no-useless-escape`)
- [x] Pre-commit hook ran on this commit (eslint + prettier, ~2s)
- [x] Pre-push hook ran on this push (`affected-lint`, ~20s, 0 errors / 251 pre-existing warnings)
- [ ] After merge: prod deploy reaches `Create release` step and publishes `v6.187.0` with a truncated body + link to full CHANGELOG.md on the tag