### PR TITLE
hotfix(release): exit cleanly when no version bump

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -87,6 +87,19 @@ function truncateBody(body, repoSlug, tag) {
 
     console.log(`Workspace version: ${workspaceVersion}`);
 
+    // nx returns null/undefined when conventional commits since the last tag
+    // contain no `feat:` / `fix:` (or BREAKING CHANGE) entries — i.e. nothing
+    // to bump. Don't fall through and create a `vnull` tag, write null into
+    // version.json files, or call gh with no version. Exit cleanly so the
+    // workflow can still deploy the existing build.
+    if (workspaceVersion == null) {
+      core.info(
+        "No version bump detected from conventional commits since the last release tag — skipping changelog and GitHub release. Deploy will continue with the existing version."
+      );
+      core.setOutput("NEW_VERSION", "");
+      return;
+    }
+
     // update version.json files
     walkDir("./apps", workspaceVersion);
 


### PR DESCRIPTION
## Summary
The last prod deploy on `main` failed at the `Create release` step with:

```
tag vnull doesn't exist in the repo Badminton-Apps/badman, aborting due to --verify-tag flag
Error: Command failed: gh release create vnull --title vnull --notes-file /tmp/release-body-vnull.md --verify-tag
```

Root cause: `releaseVersion()` returns `workspaceVersion: null` when none of the commits since the last release tag map to a conventional-commits bump (only `chore:`, `ci:`, `docs:`, `hotfix:` etc. — which is exactly what's on `main` since `v6.186.0`). My earlier rewrite of `scripts/release.js` did not handle that case: it wrote `"version": null` into every `apps/**/version.json`, called `releaseChangelog` (no-op), and then ran `gh release create vnull --verify-tag`, which failed.

## Fix
- If `workspaceVersion` is null/undefined, log a message, set `NEW_VERSION=""` (the gated `sentry-release` job already skips when this is empty), and `return` cleanly with exit 0.
- Don't touch `version.json` files.
- Don't call `gh`.

## Verification
- `node scripts/release.js --dry-run` against current `main`: workspace version comes back `null`, the new branch triggers, no `version.json` file is touched, no `gh` call.
- Output: \`No version bump detected from conventional commits since the last release tag — skipping changelog and GitHub release. Deploy will continue with the existing version.\`

## Test plan
- [x] Local dry-run confirms early-exit path
- [x] Pre-commit + pre-push lint hooks ran clean
- [ ] After merge: prod deploy succeeds through to \`deploy-prod\` even though no new version is released