### PR TITLE
feat(cp): route payload through GitHub Gist to bypass 65KB dispatch limit

### DIFF
--- a/.github/workflows/generate-cp.yml
+++ b/.github/workflows/generate-cp.yml
@@ -35,7 +35,7 @@ jobs:
             import fs from 'node:fs';
             const res = await fetch('https://api.github.com/gists/${{ inputs.gist_id }}', {
               headers: {
-                Authorization: 'Bearer ${{ secrets.GITHUB_TOKEN_CP }}',
+                Authorization: 'Bearer ${{ secrets.GH_TOKEN_CP }}',
                 Accept: 'application/vnd.github.v3+json',
               },
             });

--- a/.github/workflows/generate-cp.yml
+++ b/.github/workflows/generate-cp.yml
@@ -3,8 +3,8 @@ name: Generate CP File
 on:
   workflow_dispatch:
     inputs:
-      payload:
-        description: "CpPayload JSON (base64-encoded)"
+      gist_id:
+        description: "GitHub Gist ID containing CpPayload JSON"
         required: true
       callback_url:
         description: "Backend webhook URL for completion notification"
@@ -28,17 +28,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Decode payload
+      - name: Fetch payload from Gist
         shell: bash
         run: |
           node --input-type=module -e "
             import fs from 'node:fs';
-            const decoded = Buffer.from(process.env.PAYLOAD_B64, 'base64').toString('utf-8');
-            fs.writeFileSync('payload.json', decoded);
-            console.log('Payload decoded, size:', decoded.length, 'bytes');
+            const res = await fetch('https://api.github.com/gists/${{ inputs.gist_id }}', {
+              headers: {
+                Authorization: 'Bearer ${{ secrets.GITHUB_TOKEN_CP }}',
+                Accept: 'application/vnd.github.v3+json',
+              },
+            });
+            if (!res.ok) throw new Error('Gist fetch failed: ' + res.status);
+            const gist = await res.json();
+            const content = gist.files['payload.json'].content;
+            fs.writeFileSync('payload.json', content);
+            console.log('Payload fetched, size:', content.length, 'bytes');
           "
-        env:
-          PAYLOAD_B64: ${{ inputs.payload }}
 
       - name: Build file writer
         run: npx nx build backend-generator

--- a/apps/api/src/app/controllers/cp.controller.spec.ts
+++ b/apps/api/src/app/controllers/cp.controller.spec.ts
@@ -54,7 +54,7 @@ describe("CpController", () => {
     } as any;
 
     mockConfigService = {
-      GITHUB_TOKEN_CP: "ghp_test_token",
+      GH_TOKEN_CP: "ghp_test_token",
       GITHUB_REPO_OWNER: "Badminton-Apps",
       GITHUB_REPO_NAME: "badman",
       CP_CALLBACK_URL: "https://api.test.com/cp/webhook",
@@ -166,8 +166,8 @@ describe("CpController", () => {
       ).rejects.toThrow(BadGatewayException);
     });
 
-    it("should return 503 if GITHUB_TOKEN_CP is not configured", async () => {
-      mockConfigService.GITHUB_TOKEN_CP = undefined;
+    it("should return 503 if GH_TOKEN_CP is not configured", async () => {
+      mockConfigService.GH_TOKEN_CP = undefined;
       const user = mockUser();
 
       await expect(

--- a/apps/api/src/app/controllers/cp.controller.spec.ts
+++ b/apps/api/src/app/controllers/cp.controller.spec.ts
@@ -111,7 +111,12 @@ describe("CpController", () => {
 
     it("should call CpDataCollector and trigger workflow_dispatch", async () => {
       const user = mockUser();
-      mockFetch.mockResolvedValue({ status: 204 });
+      mockFetch
+        .mockResolvedValueOnce({
+          status: 201,
+          json: jest.fn().mockResolvedValue({ id: "gist-abc" }),
+        }) // _createGist
+        .mockResolvedValueOnce({ status: 204 }); // workflow dispatch
 
       const result = await controller.generate(user, {
         eventId: "a0000000-0000-4000-8000-000000000001",
@@ -139,26 +144,47 @@ describe("CpController", () => {
       await expect(controller.generate(user, { eventId: "" })).rejects.toThrow();
     });
 
-    it("should base64-encode the payload in the workflow dispatch", async () => {
+    it("should pass gist_id in the workflow dispatch inputs", async () => {
       const user = mockUser();
-      mockFetch.mockResolvedValue({ status: 204 });
+      mockFetch
+        .mockResolvedValueOnce({
+          status: 201,
+          json: jest.fn().mockResolvedValue({ id: "gist-xyz" }),
+        }) // _createGist
+        .mockResolvedValueOnce({ status: 204 }); // workflow dispatch
 
       await controller.generate(user, { eventId: "a0000000-0000-4000-8000-000000000001" });
 
-      const fetchCall = mockFetch.mock.calls[0];
-      const body = JSON.parse(fetchCall[1].body);
+      const dispatchCall = mockFetch.mock.calls[1]; // second fetch = dispatch
+      const body = JSON.parse(dispatchCall[1].body);
 
-      // Verify payload input is base64
-      const decoded = Buffer.from(body.inputs.payload, "base64").toString("utf-8");
-      const payload = JSON.parse(decoded);
-      expect(payload.event.name).toBe("Test");
+      expect(body.inputs.gist_id).toBe("gist-xyz");
+      expect(body.inputs.payload).toBeUndefined();
     });
 
-    it("should return 502 if GitHub API fails", async () => {
+    it("should return 502 if GitHub API dispatch fails", async () => {
       const user = mockUser();
-      mockFetch.mockResolvedValue({
-        status: 422,
-        text: jest.fn().mockResolvedValue("Validation failed"),
+      mockFetch
+        .mockResolvedValueOnce({
+          status: 201,
+          json: jest.fn().mockResolvedValue({ id: "gist-abc" }),
+        }) // _createGist
+        .mockResolvedValueOnce({
+          status: 422,
+          text: jest.fn().mockResolvedValue("Validation failed"),
+        }) // dispatch fails
+        .mockResolvedValueOnce({ status: 204 }); // _deleteGist cleanup
+
+      await expect(
+        controller.generate(user, { eventId: "a0000000-0000-4000-8000-000000000001" })
+      ).rejects.toThrow(BadGatewayException);
+    });
+
+    it("should return 502 if Gist creation fails", async () => {
+      const user = mockUser();
+      mockFetch.mockResolvedValueOnce({
+        status: 500,
+        text: jest.fn().mockResolvedValue("Server Error"),
       });
 
       await expect(
@@ -177,12 +203,17 @@ describe("CpController", () => {
 
     it("should return 409 if generation is already in progress for same event", async () => {
       const user = mockUser();
-      mockFetch.mockResolvedValue({ status: 204 });
+      mockFetch
+        .mockResolvedValueOnce({
+          status: 201,
+          json: jest.fn().mockResolvedValue({ id: "gist-abc" }),
+        })
+        .mockResolvedValueOnce({ status: 204 });
 
       // First call succeeds
       await controller.generate(user, { eventId: "a0000000-0000-4000-8000-000000000001" });
 
-      // Second call should be rejected
+      // Second call should be rejected (no fetch needed — blocked before Gist creation)
       await expect(
         controller.generate(user, { eventId: "a0000000-0000-4000-8000-000000000001" })
       ).rejects.toThrow(ConflictException);
@@ -213,7 +244,13 @@ describe("CpController", () => {
     it("should accept valid webhook and update generation record", async () => {
       // First, trigger a generation to create a pending record
       const user = mockUser();
-      mockFetch.mockResolvedValue({ status: 204 });
+      mockFetch
+        .mockResolvedValueOnce({
+          status: 201,
+          json: jest.fn().mockResolvedValue({ id: "gist-abc" }),
+        })
+        .mockResolvedValueOnce({ status: 204 }) // dispatch
+        .mockResolvedValueOnce({ status: 204 }); // _deleteGist on webhook
       await controller.generate(user, { eventId: "a0000000-0000-4000-8000-000000000001" });
 
       jest.spyOn(Player, "findByPk").mockResolvedValue({
@@ -232,7 +269,13 @@ describe("CpController", () => {
 
     it("should handle failed status", async () => {
       const user = mockUser();
-      mockFetch.mockResolvedValue({ status: 204 });
+      mockFetch
+        .mockResolvedValueOnce({
+          status: 201,
+          json: jest.fn().mockResolvedValue({ id: "gist-abc" }),
+        })
+        .mockResolvedValueOnce({ status: 204 }) // dispatch
+        .mockResolvedValueOnce({ status: 204 }); // _deleteGist on webhook
       await controller.generate(user, { eventId: "a0000000-0000-4000-8000-000000000001" });
 
       jest.spyOn(Player, "findByPk").mockResolvedValue({
@@ -283,7 +326,13 @@ describe("CpController", () => {
     it("should return 410 for failed generation", async () => {
       // Set up a completed webhook first
       const user = mockUser();
-      mockFetch.mockResolvedValue({ status: 204 });
+      mockFetch
+        .mockResolvedValueOnce({
+          status: 201,
+          json: jest.fn().mockResolvedValue({ id: "gist-abc" }),
+        })
+        .mockResolvedValueOnce({ status: 204 }) // dispatch
+        .mockResolvedValueOnce({ status: 204 }); // _deleteGist on webhook
       await controller.generate(user, { eventId: "a0000000-0000-4000-8000-000000000001" });
 
       jest.spyOn(Player, "findByPk").mockResolvedValue({
@@ -306,7 +355,12 @@ describe("CpController", () => {
       // Set up a completed generation
       const user = mockUser();
       mockFetch
+        .mockResolvedValueOnce({
+          status: 201,
+          json: jest.fn().mockResolvedValue({ id: "gist-abc" }),
+        }) // _createGist
         .mockResolvedValueOnce({ status: 204 }) // workflow dispatch
+        .mockResolvedValueOnce({ status: 204 }) // _deleteGist on webhook
         .mockResolvedValueOnce({
           // artifacts list
           ok: true,

--- a/apps/api/src/app/controllers/cp.controller.ts
+++ b/apps/api/src/app/controllers/cp.controller.ts
@@ -93,15 +93,13 @@ export class CpController {
     const payload = await this.dataCollector.collect(eventId);
 
     // Trigger GitHub Actions workflow
-    const githubToken = this.configService.get("GITHUB_TOKEN_CP");
+    const githubToken = this.configService.get("GH_TOKEN_CP");
     const repoOwner = this.configService.get("GITHUB_REPO_OWNER") || "Badminton-Apps";
     const repoName = this.configService.get("GITHUB_REPO_NAME") || "badman";
     const callbackUrl = this.configService.get("CP_CALLBACK_URL");
 
     if (!githubToken) {
-      throw new ServiceUnavailableException(
-        "CP export is not configured (missing GITHUB_TOKEN_CP)"
-      );
+      throw new ServiceUnavailableException("CP export is not configured (missing GH_TOKEN_CP)");
     }
     if (!callbackUrl) {
       throw new ServiceUnavailableException(
@@ -192,7 +190,7 @@ export class CpController {
 
         // Best-effort Gist cleanup
         if (record.gistId) {
-          const githubToken = this.configService.get("GITHUB_TOKEN_CP");
+          const githubToken = this.configService.get("GH_TOKEN_CP");
           if (githubToken) {
             await this._deleteGist(record.gistId, githubToken);
           }
@@ -261,7 +259,7 @@ export class CpController {
     }
 
     // Fetch artifact from GitHub
-    const githubToken = this.configService.get("GITHUB_TOKEN_CP");
+    const githubToken = this.configService.get("GH_TOKEN_CP");
     const repoOwner = this.configService.get("GITHUB_REPO_OWNER") || "Badminton-Apps";
     const repoName = this.configService.get("GITHUB_REPO_NAME") || "badman";
 

--- a/apps/api/src/app/controllers/cp.controller.ts
+++ b/apps/api/src/app/controllers/cp.controller.ts
@@ -17,7 +17,6 @@ import {
   Logger,
   NotFoundException,
   Param,
-  PayloadTooLargeException,
   Post,
   Res,
   ServiceUnavailableException,
@@ -34,6 +33,7 @@ interface CpGenerationRecord {
   locale: string;
   status: "pending" | "completed" | "failed";
   createdAt: Date;
+  gistId?: string;
 }
 
 @Controller("cp")
@@ -92,17 +92,6 @@ export class CpController {
     this.logger.log(`Collecting CP data for event ${eventId}`);
     const payload = await this.dataCollector.collect(eventId);
 
-    // Base64 encode
-    const payloadJson = JSON.stringify(payload);
-    const payloadBase64 = Buffer.from(payloadJson).toString("base64");
-
-    // Validate size (GitHub workflow_dispatch input limit is 65535 chars)
-    if (payloadBase64.length > 65535) {
-      throw new PayloadTooLargeException(
-        `Competition data is too large for export (${payloadBase64.length} chars, max 65535). Contact support.`
-      );
-    }
-
     // Trigger GitHub Actions workflow
     const githubToken = this.configService.get("GITHUB_TOKEN_CP");
     const repoOwner = this.configService.get("GITHUB_REPO_OWNER") || "Badminton-Apps";
@@ -120,6 +109,13 @@ export class CpController {
       );
     }
 
+    let gistId: string;
+    try {
+      gistId = await this._createGist(JSON.stringify(payload), githubToken);
+    } catch {
+      throw new BadGatewayException("Failed to upload payload to GitHub Gist");
+    }
+
     const workflowUrl = `https://api.github.com/repos/${repoOwner}/${repoName}/actions/workflows/generate-cp.yml/dispatches`;
 
     const response = await fetch(workflowUrl, {
@@ -132,7 +128,7 @@ export class CpController {
       body: JSON.stringify({
         ref: "develop",
         inputs: {
-          payload: payloadBase64,
+          gist_id: gistId,
           callback_url: callbackUrl,
           requesting_user_id: user.id,
         },
@@ -142,6 +138,7 @@ export class CpController {
     if (response.status !== 204) {
       const errorBody = await response.text();
       this.logger.error(`GitHub API error: ${response.status} ${errorBody}`);
+      await this._deleteGist(gistId, githubToken);
       throw new BadGatewayException(
         `Failed to trigger CP generation: GitHub API returned ${response.status}`
       );
@@ -156,6 +153,7 @@ export class CpController {
       locale,
       status: "pending",
       createdAt: new Date(),
+      gistId,
     };
     this.generations.set(trackingId, record);
     this.pendingByEvent.set(eventId, trackingId);
@@ -191,6 +189,14 @@ export class CpController {
         record.runId = body.run_id;
         record.status = body.status === "completed" ? "completed" : "failed";
         matchedTrackingId = trackingId;
+
+        // Best-effort Gist cleanup
+        if (record.gistId) {
+          const githubToken = this.configService.get("GITHUB_TOKEN_CP");
+          if (githubToken) {
+            await this._deleteGist(record.gistId, githubToken);
+          }
+        }
 
         // Clean up pending-by-event
         this.pendingByEvent.delete(record.eventId);
@@ -342,6 +348,44 @@ export class CpController {
       email: player.email,
       slug: player.slug,
     });
+  }
+
+  private async _createGist(content: string, token: string): Promise<string> {
+    const res = await fetch("https://api.github.com/gists", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github.v3+json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        public: false,
+        files: { "payload.json": { content } },
+      }),
+    });
+
+    if (res.status !== 201) {
+      const body = await res.text();
+      this.logger.error(`Gist create failed: ${res.status} ${body}`);
+      throw new BadGatewayException(`GitHub Gist API returned ${res.status}`);
+    }
+
+    const data = (await res.json()) as { id: string };
+    return data.id;
+  }
+
+  private async _deleteGist(gistId: string, token: string): Promise<void> {
+    const res = await fetch(`https://api.github.com/gists/${gistId}`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github.v3+json",
+      },
+    });
+
+    if (res.status !== 204 && res.status !== 404) {
+      this.logger.warn(`Gist delete returned unexpected status ${res.status} for gist ${gistId}`);
+    }
   }
 
   /**

--- a/libs/utils/src/config/configuration.ts
+++ b/libs/utils/src/config/configuration.ts
@@ -168,7 +168,7 @@ export const configSchema = Joi.object({
   }),
 
   CP_PASS: Joi.string().optional(),
-  GITHUB_TOKEN_CP: Joi.string().optional(),
+  GH_TOKEN_CP: Joi.string().optional(),
   GITHUB_REPO_OWNER: Joi.string().optional(),
   GITHUB_REPO_NAME: Joi.string().optional(),
   CP_CALLBACK_URL: Joi.string().optional(),
@@ -263,7 +263,7 @@ export type ConfigType = {
   TWIZZIT_API_USER: string;
   TWIZZIT_API_PASS: string;
   CP_PASS?: string;
-  GITHUB_TOKEN_CP?: string;
+  GH_TOKEN_CP?: string;
   GITHUB_REPO_OWNER?: string;
   GITHUB_REPO_NAME?: string;
   CP_CALLBACK_URL?: string;


### PR DESCRIPTION
## Summary

- Replaces base64 `payload` workflow_dispatch input with a `gist_id` input — removes the 65 535-char size cap that caused `PayloadTooLargeException` for large competitions
- On `generate()`: uploads JSON to a private GitHub Gist, passes `gist_id` to the workflow; cleans up Gist on dispatch failure
- On `webhook()`: deletes the Gist (best-effort, never throws) after the workflow completes
- Workflow `generate-cp.yml`: swaps "Decode payload" (base64 env var) for "Fetch payload from Gist" (native fetch via Node.js module)

## ⚠️ Manual prerequisite before production deploy

`GH_TOKEN_CP` secret must be set in repo → Settings → Secrets and variables → Actions.

Use a **classic PAT** (fine-grained PATs do not support Gist scope) with only the **gist** scope checked.

> Note: GitHub rejects secrets starting with `GITHUB_` — the secret is named `GH_TOKEN_CP`.

## Test plan

- [ ] T009: Trigger CP export for small competition — export completes, Gist created and deleted, `.cp` artifact downloadable
- [ ] Large competition (payload > 49 KB): export completes without `PayloadTooLargeException`
- [ ] Orphaned Gist check: no Gists remain in account after successful callback

## Related

- Linear: [BAD-228](https://linear.app/dashdot/issue/BAD-228)
- Spec: `specs/023-cp-gist-payload/spec.md` (frontend repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)