### PR TITLE
chore(ci): bump actions/checkout to v5, opt into Node.js 24

### DIFF
--- a/.github/workflows/_shared-migrate.yml
+++ b/.github/workflows/_shared-migrate.yml
@@ -37,6 +37,7 @@ jobs:
       group: migrate-${{ inputs.target-environment }}
       cancel-in-progress: false
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       NODE_ENV: ${{ inputs.target-environment }}
       DB_IP: ${{ secrets.DB_IP }}
       DB_PORT: ${{ secrets.DB_PORT }}
@@ -46,7 +47,7 @@ jobs:
       DB_DIALECT: ${{ secrets.DB_DIALECT }}
       DB_SSL: ${{ secrets.DB_SSL }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -21,13 +21,16 @@ concurrency:
 
 run-name: Prod release ${{ github.run_number }}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
       NEW_VERSION: ${{ steps.create_release.outputs.new_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -114,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -138,7 +141,7 @@ jobs:
       SENTRY_PROJECT: backend
       VERSION: ${{ needs.build.outputs.NEW_VERSION }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -13,11 +13,14 @@ concurrency:
   group: deploy-staging-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -42,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/generate-cp.yml
+++ b/.github/workflows/generate-cp.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,11 +12,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout@v4` → `@v5` across all workflows (Node 20 deprecated Jun 2026, removed Sep 2026)
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at workflow level for `deploy-staging`, `deploy-production`, `pull-request`, and `_shared-migrate` (covers `setup-node@v4` and `upload-artifact@v4` which have no v5 yet)
- `generate-cp.yml` already had the flag set at job level

## Test plan

- [ ] PR validation workflow passes on this branch
- [ ] No regression on affected workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)