### PR TITLE
fix(ci): use run-many --all for deploy jobs

### DIFF
--- a/.github/actions/setup-monorepo/action.yml
+++ b/.github/actions/setup-monorepo/action.yml
@@ -1,5 +1,5 @@
 name: Setup Monorepo
-description: nx-set-shas, Node from .nvmrc, cached node_modules + Nx local cache. Caller MUST run actions/checkout@v4 with fetch-depth 0 first.
+description: nx-set-shas, Node from .nvmrc, cached node_modules + Nx local cache. Caller MUST run actions/checkout@v5 with fetch-depth 0 first.
 
 inputs:
   cache-nx:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -122,9 +122,11 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-monorepo
+        with:
+          cache-nx: "false"
 
       - name: Deploy
-        run: npx --yes nx affected -t deploy --no-agents
+        run: npx --yes nx run-many -t deploy --all --no-agents
         env:
           API_HOOK: ${{ secrets.PROD_API_HOOK }}
           WORKER_SYNC_HOOK: ${{ secrets.PROD_WORKER_SYNC_HOOK }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -50,9 +50,11 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-monorepo
+        with:
+          cache-nx: "false"
 
       - name: Deploy
-        run: npx --yes nx affected -t deploy --no-agents
+        run: npx --yes nx run-many -t deploy --all --no-agents
         env:
           API_HOOK: ${{ secrets.STAGING_API_HOOK }}
           WORKER_SYNC_HOOK: ${{ secrets.STAGING_WORKER_SYNC_HOOK }}


### PR DESCRIPTION
## Problem

`nx affected -t deploy` in the deploy job re-runs `nrwl/nx-set-shas` which recalculates `NX_BASE` **after** the build job already succeeded. This pushes the base past our changes → "No tasks were run" → nothing deployed.

Additionally, the restored NX cache from the build job contains artifacts the deploy job can't recognize → "Unrecognized Cache Artifacts" warning.

## Fix

- Switch deploy jobs to `nx run-many -t deploy --all --no-agents` — deploy always deploys all projects with a `deploy` target, not just "affected" ones
- Set `cache-nx: false` in deploy jobs to skip the stale NX cache restore

Affects `deploy-staging.yml` and `deploy-production.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)