### PR TITLE
fix(ci): fix sentry-release always skipped — output name case mismatch

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -28,7 +28,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
-      NEW_VERSION: ${{ steps.create_release.outputs.new_version }}
+      NEW_VERSION: ${{ steps.create_release.outputs.NEW_VERSION }}
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
## Problem

`scripts/release.js` sets `core.setOutput("NEW_VERSION", ...)` (uppercase) but the job `outputs` block mapped `steps.create_release.outputs.new_version` (lowercase). GitHub Actions output names are case-sensitive — the value was always empty → `needs.build.outputs.NEW_VERSION != ''` always false → `sentry-release` job always skipped.

## Fix

Change `outputs.new_version` → `outputs.NEW_VERSION` to match what the script actually sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)