### PR TITLE
feat(i18n): add error translation to team dialog messages

### DIFF
--- a/libs/backend/translate/assets/i18n/en/all.json
+++ b/libs/backend/translate/assets/i18n/en/all.json
@@ -2527,7 +2527,8 @@
           },
           "messages": {
             "successAdd": "Team is added",
-            "successEdit": "Team is updated"
+            "successEdit": "Team is updated",
+            "error": "Something went wrong. Please try again."
           },
           "buttons": {
             "cancel": "Cancel",

--- a/libs/backend/translate/assets/i18n/fr_BE/all.json
+++ b/libs/backend/translate/assets/i18n/fr_BE/all.json
@@ -2078,6 +2078,15 @@
     },
     "locations": {
       "exceptions": "Exceptions"
+    },
+    "clubPage": {
+      "teams": {
+        "addEditTeamDialog": {
+          "messages": {
+            "error": "Une erreur s'est produite. Veuillez réessayer."
+          }
+        }
+      }
     }
   }
 }

--- a/libs/backend/translate/assets/i18n/nl_BE/all.json
+++ b/libs/backend/translate/assets/i18n/nl_BE/all.json
@@ -2245,7 +2245,8 @@
           },
           "messages": {
             "successAdd": "Team is toegevoegd",
-            "successEdit": "Team is bijgewerkt"
+            "successEdit": "Team is bijgewerkt",
+            "error": "Er is iets misgegaan. Probeer het opnieuw."
           },
           "buttons": {
             "cancel": "Annuleren",

--- a/libs/utils/src/lib/i18n.generated.ts
+++ b/libs/utils/src/lib/i18n.generated.ts
@@ -1474,6 +1474,15 @@ export type I18nTranslations = {
                     "error": string;
                 };
             };
+            "avgLevelPage": {
+                "error": string;
+                "empty": string;
+                "eventType": {
+                    "M": string;
+                    "F": string;
+                    "MX": string;
+                };
+            };
             "adminCompetitionsPage": {
                 "title": string;
                 "seasonSelectLabel": string;
@@ -1700,6 +1709,14 @@ export type I18nTranslations = {
                     "retryNotification": string;
                     "error": {
                         "network": {
+                            "title": string;
+                            "body": string;
+                        };
+                        "server": {
+                            "title": string;
+                            "body": string;
+                        };
+                        "validation": {
                             "title": string;
                             "body": string;
                         };
@@ -2529,6 +2546,7 @@ export type I18nTranslations = {
                         "messages": {
                             "successAdd": string;
                             "successEdit": string;
+                            "error": string;
                         };
                         "buttons": {
                             "cancel": string;
@@ -3383,6 +3401,7 @@ export type I18nTranslations = {
                 "actions": {
                     "edit": string;
                     "delete": string;
+                    "export": string;
                     "setRisersFallers": string;
                     "openCloseDate": string;
                     "openCloseEncounterChangeDate": string;
@@ -3392,7 +3411,14 @@ export type I18nTranslations = {
                     "messages": {
                         "syncSuccess": string;
                         "syncError": string;
+                        "cpGenerationStarted": string;
                     };
+                    "averageLevel": string;
+                    "downloadEnrollment": string;
+                    "downloadTeams": string;
+                    "downloadExceptions": string;
+                    "downloadLocations": string;
+                    "downloadCp": string;
                 };
                 "addCompetitionDialog": {
                     "title": string;


### PR DESCRIPTION
## Summary
- Add `clubPage.teams.addEditTeamDialog.messages.error` key to all 3 locales (en, nl_BE, fr_BE)
- Regenerated `i18n.generated.ts`

## Test plan
- [ ] API boots without type errors
- [ ] Team dialog shows error message on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)