### PR TITLE
test(032): add resolver spec coverage and audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ typesense-data/
 #Claude
 .claude/settings.local.json
 .claude/worktrees/
+.env.local

--- a/.maqa/state.json
+++ b/.maqa/state.json
@@ -36,7 +36,10 @@
       "mvp_scope": "T001-T025 (Phases 1-4: US1 + US2)",
       "tasks_completed": "T001-T025 (25/36)",
       "deferred": "T026-T036 (Phases 5-7: US4 hook refactor, US3 perf, polish)",
-      "implementation_commits": ["b7de5cf39", "ae63d6a61"],
+      "implementation_commits": [
+        "b7de5cf39",
+        "ae63d6a61"
+      ],
       "tests_passed": 126,
       "tests_skipped": 2,
       "qa_status": "approved",
@@ -62,8 +65,11 @@
       "branch": "007-finish-event-entry-hardening",
       "tasks_total": 24,
       "tasks_completed": "T001, T003-T020 (19/24)",
-      "deferred": "T002 (docker check), T021 (nx affected:test), T022 (manual quickstart walk), T023 (verify only), T024 (frontend PR — separate repo)",
-      "implementation_commits": ["e407d0553", "cf539101b"],
+      "deferred": "T002 (docker check), T021 (nx affected:test), T022 (manual quickstart walk), T023 (verify only), T024 (frontend PR \u2014 separate repo)",
+      "implementation_commits": [
+        "e407d0553",
+        "cf539101b"
+      ],
       "tests_passed": 12,
       "tests_total": 12,
       "qa_status": "approved",
@@ -91,9 +97,21 @@
       "spec_path": "specs/014-validate-clubid-uuid",
       "tasks_total": 23,
       "tasks_completed": "T001-T021, T023 (22/23)",
-      "deferred": "T022 (manual quickstart walk — needs running API + docker DB)",
-      "spec_kit_commits": ["fba14cd80", "0a1254a79", "a5a66aca7", "14c6286bf"],
-      "implementation_commits": ["16bc84aee", "1df5d7521", "188de9e84", "b321aa393", "6652660bb", "2afd4f47e"],
+      "deferred": "T022 (manual quickstart walk \u2014 needs running API + docker DB)",
+      "spec_kit_commits": [
+        "fba14cd80",
+        "0a1254a79",
+        "a5a66aca7",
+        "14c6286bf"
+      ],
+      "implementation_commits": [
+        "16bc84aee",
+        "1df5d7521",
+        "188de9e84",
+        "b321aa393",
+        "6652660bb",
+        "2afd4f47e"
+      ],
       "tests_passed": 252,
       "tests_skipped": 5,
       "lint_errors": 0,
@@ -111,7 +129,7 @@
         "principle_iv_resolver_tests": "PASS",
         "principle_v_legacy_frontend": "PASS (no diff)"
       },
-      "next_step": "open PR targeting develop; companion frontend PR resolves club slug → UUID before invoking Club-scoped mutations (see specs/008-reorder-teams-atomic/frontend-impact.md)"
+      "next_step": "open PR targeting develop; companion frontend PR resolves club slug \u2192 UUID before invoking Club-scoped mutations (see specs/008-reorder-teams-atomic/frontend-impact.md)"
     },
     "008-reorder-teams-atomic": {
       "status": "in_review",
@@ -126,22 +144,29 @@
         "plan": "plan.md",
         "research": "research.md",
         "data_model": "data-model.md",
-        "contracts": ["team-renumber-mutation.md", "team-renumbering-service.md"],
+        "contracts": [
+          "team-renumber-mutation.md",
+          "team-renumbering-service.md"
+        ],
         "frontend_impact": "frontend-impact.md",
         "quickstart": "quickstart.md",
         "tasks": "tasks.md"
       },
-      "spec_kit_commits": ["038b5ca10", "666d98c6d", "f67027148"],
+      "spec_kit_commits": [
+        "038b5ca10",
+        "666d98c6d",
+        "f67027148"
+      ],
       "tasks_total": 43,
       "tasks_completed": "T001-T021, T024, T029-T033, T034-T036, T038-T041 (37/43)",
       "deferred": [
-        "T022 (manual quickstart verification — needs live DB + seed data)",
-        "T023 (manual playground walk — needs live DB)",
-        "T025–T027 (integration test scenarios — need docker DB, marked as .todo)",
-        "T028 (run integration tests with RUN_INTEGRATION_TESTS=1 — needs docker DB)",
-        "T037 (integration assertion for rejected recalculate — marked .todo in integration spec)",
-        "T042 (manual end-to-end quickstart walk — needs running API)",
-        "T043 (AGENTS.md update — spec plan pointer OK, no change needed)"
+        "T022 (manual quickstart verification \u2014 needs live DB + seed data)",
+        "T023 (manual playground walk \u2014 needs live DB)",
+        "T025\u2013T027 (integration test scenarios \u2014 need docker DB, marked as .todo)",
+        "T028 (run integration tests with RUN_INTEGRATION_TESTS=1 \u2014 needs docker DB)",
+        "T037 (integration assertion for rejected recalculate \u2014 marked .todo in integration spec)",
+        "T042 (manual end-to-end quickstart walk \u2014 needs running API)",
+        "T043 (AGENTS.md update \u2014 spec plan pointer OK, no change needed)"
       ],
       "tests_passed": 160,
       "tests_skipped": 5,
@@ -202,8 +227,12 @@
       "worktree": "/Users/arno/Documents/Projects/Badman/feat-028-gate-enrollment-validation",
       "tasks_total": 33,
       "tasks_completed": "T001-T014, T017-T027, T029, T030, T032",
-      "tasks_deferred": "T015-T016 (operational manual verification), T028 (nx affected:test — empty test_command), T031 (operational Quickstart walk), T033 (no checked-in schema.gql)",
-      "implementation_commits": ["2de5cdc1f", "fcdedeaa7", "db6fcad0a"],
+      "tasks_deferred": "T015-T016 (operational manual verification), T028 (nx affected:test \u2014 empty test_command), T031 (operational Quickstart walk), T033 (no checked-in schema.gql)",
+      "implementation_commits": [
+        "2de5cdc1f",
+        "fcdedeaa7",
+        "db6fcad0a"
+      ],
       "feature_status": "done",
       "qa_status": "approved",
       "qa_checks": {
@@ -218,7 +247,10 @@
       "status": "in_review_qa_approved",
       "board": "local",
       "branch": "029-evententry-team-standing-loaders",
-      "implementation_commits": ["96d85a710", "3011f172b"],
+      "implementation_commits": [
+        "96d85a710",
+        "3011f172b"
+      ],
       "tests_passed": 29,
       "feature_status": "done",
       "qa_status": "approved",
@@ -236,6 +268,11 @@
       },
       "ci_gate": "none",
       "next_step": "open PR to develop"
+    },
+    "032-resolver-test-coverage": {
+      "status": "todo",
+      "board": "linear",
+      "branch": "032-resolver-test-coverage"
     }
   },
   "board": "linear",

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/030-ci-lean-migrations"
+  "feature_directory": "specs/032-resolver-test-coverage"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,21 @@ This file (`AGENTS.md`) is the single source of truth for AI-assisted developmen
 
 **`CLAUDE.md` is a symbolic link** to `AGENTS.md` in the repository root (`CLAUDE.md` → `AGENTS.md`). Tools that read either path see the same content. **Edit `AGENTS.md` only**—do not replace the symlink with a duplicate file, or Claude Code and Cursor will drift apart.
 
+## Environment Setup
+
+Required for dev and AI-assisted scripts:
+
+```bash
+# Copy .env.local if it doesn't exist (contains LINEAR_API_KEY for issue creation)
+cp .env.local.example .env.local  # or manually source .env before running scripts
+
+# Load environment in your shell (add to ~/.zshrc or ~/.bashrc for persistence):
+source /path/to/badman/.env.local
+```
+
+**Variables needed for scripts:**
+- `LINEAR_API_KEY` — for creating Linear issues from CLI
+
 ## Project Overview
 
 Competitive badminton management platform (Badman). Nx monorepo with NestJS (backend API + workers), Sequelize ORM (PostgreSQL), Apollo GraphQL (code-first), Bull queues (Redis).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,17 @@ prettier --check .
 
 # Seed test data
 npm run seed:test-data
+
+# Run full coverage report (all non-legacy libs/apps, no DB required)
+# Produces: text summary to console + lcov.info per lib under coverage/
+npm run test:coverage:all
+
+# Update coverage threshold after adding tests:
+# 1. Run: npm run test:coverage:all
+# 2. Find the "Lines %" for backend-graphql in the console output
+# 3. Round down to nearest 5%
+# 4. Edit libs/backend/graphql/jest.config.ts → coverageThreshold.global.*
+# 5. Commit the updated jest.config.ts
 ```
 
 ## Architecture
@@ -211,6 +222,6 @@ Long-form internal docs live under [`docs/`](docs/). Skim the relevant ones befo
 
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-[specs/030-ci-lean-migrations/plan.md](specs/030-ci-lean-migrations/plan.md)
+[specs/032-resolver-test-coverage/plan.md](specs/032-resolver-test-coverage/plan.md)
 
 <!-- SPECKIT END -->

--- a/libs/backend/graphql/jest.config.ts
+++ b/libs/backend/graphql/jest.config.ts
@@ -7,4 +7,14 @@ export default {
   },
   moduleFileExtensions: ["ts", "js", "html"],
   coverageDirectory: "../../../coverage/libs/backend/graphql",
+  coverageReporters: ["text", "lcov"],
+  testPathIgnorePatterns: ["/node_modules/", "\\.integration\\.spec\\.ts$"],
+  coverageThreshold: {
+    global: {
+      lines: 45,
+      branches: 30,
+      functions: 25,
+      statements: 50,
+    },
+  },
 };

--- a/libs/backend/graphql/src/resolvers/availability/availability.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/availability/availability.resolver.spec.ts
@@ -1,0 +1,136 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { Sequelize } from "sequelize-typescript";
+import { Availability, Location, Player } from "@badman/backend-database";
+import { AvailabilitysResolver } from "./availability.resolver";
+
+describe("AvailabilitysResolver", () => {
+  let resolver: AvailabilitysResolver;
+  let mockTransaction: { commit: jest.Mock; rollback: jest.Mock };
+
+  const buildUser = (allowed: boolean) =>
+    ({ id: "user-uuid", hasAnyPermission: jest.fn().mockResolvedValue(allowed) }) as unknown as Player;
+
+  beforeEach(async () => {
+    mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AvailabilitysResolver,
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<AvailabilitysResolver>(AvailabilitysResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("availability (query)", () => {
+    it("returns availability by id", async () => {
+      const a = { id: "a-uuid" } as unknown as Availability;
+      jest.spyOn(Availability, "findByPk").mockResolvedValue(a);
+      expect(await resolver.availability("a-uuid")).toBe(a);
+    });
+
+    it("returns null when availability not found", async () => {
+      jest.spyOn(Availability, "findByPk").mockResolvedValue(null);
+      expect(await resolver.availability("missing")).toBeNull();
+    });
+  });
+
+  describe("availabilities (query)", () => {
+    it("returns paged availability results", async () => {
+      const result = { count: 1, rows: [{ id: "a-uuid" }] } as any;
+      jest.spyOn(Availability, "findAndCountAll").mockResolvedValue(result);
+      expect(await resolver.availabilities({} as any)).toBe(result);
+    });
+  });
+
+  describe("createAvailability (mutation)", () => {
+    it("throws NotFoundException when location not found", async () => {
+      jest.spyOn(Location, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.createAvailability({ locationId: "loc-uuid" } as any, buildUser(true))
+      ).rejects.toThrow(NotFoundException);
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+
+    it("throws UnauthorizedException when user lacks location edit permission", async () => {
+      const fakeLocation = { clubId: "club-uuid" } as unknown as Location;
+      jest.spyOn(Location, "findByPk").mockResolvedValue(fakeLocation);
+      await expect(
+        resolver.createAvailability({ locationId: "loc-uuid" } as any, buildUser(false))
+      ).rejects.toThrow(UnauthorizedException);
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+
+    it("creates availability and commits on success", async () => {
+      const fakeLocation = { clubId: "club-uuid" } as unknown as Location;
+      const fakeAvail = { id: "a-new" } as unknown as Availability;
+      jest.spyOn(Location, "findByPk").mockResolvedValue(fakeLocation);
+      jest.spyOn(Availability, "create").mockResolvedValue(fakeAvail);
+      const result = await resolver.createAvailability(
+        { locationId: "loc-uuid" } as any,
+        buildUser(true)
+      );
+      expect(Availability.create).toHaveBeenCalled();
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(result).toBe(fakeAvail);
+    });
+  });
+
+  describe("updateAvailability (mutation)", () => {
+    it("throws NotFoundException when availability not found", async () => {
+      jest.spyOn(Availability, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.updateAvailability({ id: "missing" } as any, buildUser(true))
+      ).rejects.toThrow(NotFoundException);
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+
+    it("throws UnauthorizedException when user lacks location edit permission", async () => {
+      const fakeAvail = {
+        location: { clubId: "club-uuid" },
+        toJSON: jest.fn().mockReturnValue({}),
+        update: jest.fn(),
+      } as unknown as Availability;
+      jest.spyOn(Availability, "findByPk").mockResolvedValue(fakeAvail);
+      await expect(
+        resolver.updateAvailability({ id: "a-uuid" } as any, buildUser(false))
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("updates availability and commits on success", async () => {
+      const fakeAvail = {
+        location: { clubId: "club-uuid" },
+        toJSON: jest.fn().mockReturnValue({ id: "a-uuid" }),
+        update: jest.fn().mockResolvedValue(undefined),
+      } as unknown as Availability;
+      jest.spyOn(Availability, "findByPk").mockResolvedValue(fakeAvail);
+      const result = await resolver.updateAvailability(
+        { id: "a-uuid", exceptions: [] } as any,
+        buildUser(true)
+      );
+      expect(fakeAvail.update).toHaveBeenCalled();
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(result).toBe(fakeAvail);
+    });
+
+    it("rolls back on error", async () => {
+      const fakeAvail = {
+        location: { clubId: "club-uuid" },
+        toJSON: jest.fn().mockReturnValue({}),
+        update: jest.fn().mockRejectedValue(new Error("db fail")),
+      } as unknown as Availability;
+      jest.spyOn(Availability, "findByPk").mockResolvedValue(fakeAvail);
+      await expect(
+        resolver.updateAvailability({ id: "a-uuid", exceptions: [] } as any, buildUser(true))
+      ).rejects.toThrow("db fail");
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/club/club-membership.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/club/club-membership.resolver.spec.ts
@@ -1,0 +1,45 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { UnauthorizedException } from "@nestjs/common";
+import { ClubPlayerMembership, Player } from "@badman/backend-database";
+import { ClubPlayerMembershipsResolver } from "./club-membership.resolver";
+
+describe("ClubPlayerMembershipsResolver", () => {
+  let resolver: ClubPlayerMembershipsResolver;
+
+  const buildUser = (allowed: boolean) =>
+    ({ id: "user-uuid", hasAnyPermission: jest.fn().mockResolvedValue(allowed) }) as unknown as Player;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ClubPlayerMembershipsResolver],
+    }).compile();
+
+    resolver = module.get<ClubPlayerMembershipsResolver>(ClubPlayerMembershipsResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("clubPlayerMemberships (query)", () => {
+    it("throws UnauthorizedException when user lacks change:transfer permission", async () => {
+      await expect(resolver.clubPlayerMemberships(buildUser(false), {} as any)).rejects.toThrow(
+        UnauthorizedException
+      );
+    });
+
+    it("throws UnauthorizedException when user is null", async () => {
+      await expect(resolver.clubPlayerMemberships(null as any, {} as any)).rejects.toThrow(
+        UnauthorizedException
+      );
+    });
+
+    it("returns paged memberships when user has change:transfer permission", async () => {
+      const result = {
+        count: 2,
+        rows: [{ id: "m1" }, { id: "m2" }],
+      } as unknown as { count: number; rows: ClubPlayerMembership[] };
+      jest.spyOn(ClubPlayerMembership, "findAndCountAll").mockResolvedValue(result as any);
+      const response = await resolver.clubPlayerMemberships(buildUser(true), {} as any);
+      expect(response).toBe(result);
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/cronJobs/cronJob.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/cronJobs/cronJob.resolver.spec.ts
@@ -1,0 +1,86 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { Sequelize } from "sequelize-typescript";
+import { CronJob, Player } from "@badman/backend-database";
+import { CronService } from "@badman/backend-orchestrator";
+import { CronJobResolver } from "./cronJob.resolver";
+
+describe("CronJobResolver", () => {
+  let resolver: CronJobResolver;
+  let mockTransaction: { commit: jest.Mock; rollback: jest.Mock };
+  let mockCronService: { onModuleInit: jest.Mock };
+
+  const buildUser = (allowed: boolean) =>
+    ({ id: "user-uuid", hasAnyPermission: jest.fn().mockResolvedValue(allowed) }) as unknown as Player;
+
+  beforeEach(async () => {
+    mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
+    mockCronService = { onModuleInit: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CronJobResolver,
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+        },
+        {
+          provide: CronService,
+          useValue: mockCronService,
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<CronJobResolver>(CronJobResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("cronJobs (query)", () => {
+    it("returns list of cron jobs", async () => {
+      const list = [{ id: "j1" }] as unknown as CronJob[];
+      jest.spyOn(CronJob, "findAll").mockResolvedValue(list);
+      expect(await resolver.cronJobs({} as any)).toEqual(list);
+    });
+  });
+
+  describe("updateCronJob (mutation)", () => {
+    it("throws UnauthorizedException when user lacks change:job permission", async () => {
+      await expect(
+        resolver.updateCronJob(buildUser(false), { id: "j-uuid" } as any)
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("throws NotFoundException when cron job not found", async () => {
+      jest.spyOn(CronJob, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.updateCronJob(buildUser(true), { id: "missing" } as any)
+      ).rejects.toThrow(NotFoundException);
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+
+    it("updates cron job, reinitializes cron service, and commits on success", async () => {
+      const fakeCronJob = {
+        update: jest.fn().mockResolvedValue({ id: "j-uuid" }),
+      } as unknown as CronJob;
+      jest.spyOn(CronJob, "findByPk").mockResolvedValue(fakeCronJob);
+      const result = await resolver.updateCronJob(buildUser(true), { id: "j-uuid" } as any);
+      expect(fakeCronJob.update).toHaveBeenCalled();
+      expect(mockCronService.onModuleInit).toHaveBeenCalled();
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(result).toEqual({ id: "j-uuid" });
+    });
+
+    it("rolls back on error and does not commit", async () => {
+      const fakeCronJob = {
+        update: jest.fn().mockRejectedValue(new Error("db fail")),
+      } as unknown as CronJob;
+      jest.spyOn(CronJob, "findByPk").mockResolvedValue(fakeCronJob);
+      await expect(
+        resolver.updateCronJob(buildUser(true), { id: "j-uuid" } as any)
+      ).rejects.toThrow("db fail");
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+      expect(mockTransaction.commit).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/event/competition/assembly.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/assembly.resolver.spec.ts
@@ -1,0 +1,126 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException } from "@nestjs/common";
+import { Assembly, Player } from "@badman/backend-database";
+import { AssemblyValidationService } from "@badman/backend-assembly";
+import { RankingSystemService } from "@badman/backend-ranking";
+import { AssemblyResolver } from "./assembly.resolver";
+
+describe("AssemblyResolver", () => {
+  let resolver: AssemblyResolver;
+  let mockAssemblyService: { validate: jest.Mock };
+  let mockRankingSystemService: { getPrimary: jest.Mock; getById: jest.Mock };
+
+  const buildUser = (id = "user-uuid") => ({ id, fullName: "Test User" }) as unknown as Player;
+
+  beforeEach(async () => {
+    mockAssemblyService = { validate: jest.fn() };
+    mockRankingSystemService = { getPrimary: jest.fn(), getById: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AssemblyResolver,
+        { provide: AssemblyValidationService, useValue: mockAssemblyService },
+        { provide: RankingSystemService, useValue: mockRankingSystemService },
+      ],
+    }).compile();
+
+    resolver = module.get<AssemblyResolver>(AssemblyResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("validateAssembly (query)", () => {
+    it("delegates validation to AssemblyValidationService", async () => {
+      const fakeOutput = { valid: true, errors: [] };
+      mockAssemblyService.validate.mockResolvedValue(fakeOutput);
+      const result = await resolver.validateAssembly(buildUser(), {
+        teamId: "t-uuid",
+        encounterId: "enc-uuid",
+      } as any);
+      expect(mockAssemblyService.validate).toHaveBeenCalled();
+      expect(result).toBe(fakeOutput);
+    });
+  });
+
+  describe("createAssembly (mutation)", () => {
+    it("throws Error when assembly input is null", async () => {
+      await expect(resolver.createAssembly(buildUser(), null as any)).rejects.toThrow(
+        "Assembly is required"
+      );
+    });
+
+    it("throws Error when encounterId is missing", async () => {
+      await expect(
+        resolver.createAssembly(buildUser(), { teamId: "t-uuid" } as any)
+      ).rejects.toThrow("Encounter is required");
+    });
+
+    it("throws Error when teamId is missing", async () => {
+      await expect(
+        resolver.createAssembly(buildUser(), { encounterId: "enc-uuid" } as any)
+      ).rejects.toThrow("Team is required");
+    });
+
+    it("throws Error when user has no id", async () => {
+      await expect(
+        resolver.createAssembly(
+          { fullName: "No Id" } as unknown as Player,
+          { encounterId: "enc-uuid", teamId: "t-uuid" } as any
+        )
+      ).rejects.toThrow("User is required");
+    });
+
+    it("creates and returns new assembly when not found", async () => {
+      const newAssembly = { id: "a-new", encounterId: "enc-uuid", teamId: "t-uuid" } as unknown as Assembly;
+      jest.spyOn(Assembly, "findOrCreate").mockResolvedValue([newAssembly, true]);
+      const result = await resolver.createAssembly(buildUser(), {
+        encounterId: "enc-uuid",
+        teamId: "t-uuid",
+      } as any);
+      expect(result).toBe(newAssembly);
+    });
+
+    it("updates and returns existing assembly when already exists", async () => {
+      const existingAssembly = {
+        id: "a-existing",
+        encounterId: "enc-uuid",
+        teamId: "t-uuid",
+        assembly: {},
+        update: jest.fn().mockResolvedValue({ id: "a-existing" }),
+      } as unknown as Assembly;
+      jest.spyOn(Assembly, "findOrCreate").mockResolvedValue([existingAssembly, false]);
+      const result = await resolver.createAssembly(buildUser(), {
+        encounterId: "enc-uuid",
+        teamId: "t-uuid",
+      } as any);
+      expect(existingAssembly.update).toHaveBeenCalled();
+    });
+
+    it("returns null on unexpected error (graceful degradation)", async () => {
+      jest.spyOn(Assembly, "findOrCreate").mockRejectedValue(new Error("db error"));
+      const result = await resolver.createAssembly(buildUser(), {
+        encounterId: "enc-uuid",
+        teamId: "t-uuid",
+      } as any);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("titularsPlayers (ResolveField)", () => {
+    it("returns empty array when titularsPlayerData is null", async () => {
+      const result = await resolver.titularsPlayers({ titularsPlayerData: null } as any);
+      expect(result).toEqual([]);
+    });
+
+    it("throws NotFoundException when ranking system not found", async () => {
+      jest.spyOn(Player, "findAll").mockResolvedValue([]);
+      mockRankingSystemService.getById.mockResolvedValue(null);
+      await expect(
+        resolver.titularsPlayers({
+          titularsPlayerData: [{ id: "p1" }],
+          systemId: "sys-uuid",
+        } as any)
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/event/competition/encounter-change.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/encounter-change.resolver.spec.ts
@@ -1,0 +1,150 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { Sequelize } from "sequelize-typescript";
+import { getQueueToken } from "@nestjs/bull";
+import { EncounterChange, EncounterCompetition, Player } from "@badman/backend-database";
+import { SyncQueue } from "@badman/backend-queue";
+import { EncounterValidationService } from "@badman/backend-change-encounter";
+import { NotificationService } from "@badman/backend-notifications";
+import { EncounterChangeCompetitionResolver } from "./encounter-change.resolver";
+
+describe("EncounterChangeCompetitionResolver", () => {
+  let resolver: EncounterChangeCompetitionResolver;
+  let mockTransaction: { commit: jest.Mock; rollback: jest.Mock };
+  let mockSyncQueue: { add: jest.Mock };
+  let mockNotificationService: {
+    notifyEncounterChange: jest.Mock;
+    notifyEncounterChangeFinished: jest.Mock;
+  };
+  let mockEncounterService: {};
+
+  const buildUser = (allowed: boolean) =>
+    ({ id: "user-uuid", hasAnyPermission: jest.fn().mockResolvedValue(allowed) }) as unknown as Player;
+
+  beforeEach(async () => {
+    mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
+    mockSyncQueue = { add: jest.fn().mockResolvedValue(undefined) };
+    mockNotificationService = {
+      notifyEncounterChange: jest.fn(),
+      notifyEncounterChangeFinished: jest.fn(),
+    };
+    mockEncounterService = {};
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EncounterChangeCompetitionResolver,
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+        },
+        { provide: getQueueToken(SyncQueue), useValue: mockSyncQueue },
+        { provide: NotificationService, useValue: mockNotificationService },
+        { provide: EncounterValidationService, useValue: mockEncounterService },
+      ],
+    }).compile();
+
+    resolver = module.get<EncounterChangeCompetitionResolver>(EncounterChangeCompetitionResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("encounterChange (query)", () => {
+    it("returns encounter change by id", async () => {
+      const fakeChange = { id: "ec-uuid" } as unknown as EncounterChange;
+      jest.spyOn(EncounterChange, "findByPk").mockResolvedValue(fakeChange);
+      expect(await resolver.encounterChange("ec-uuid")).toBe(fakeChange);
+    });
+
+    it("throws NotFoundException when encounter change not found", async () => {
+      jest.spyOn(EncounterChange, "findByPk").mockResolvedValue(null);
+      await expect(resolver.encounterChange("missing")).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("encounterChanges (query)", () => {
+    it("returns paged encounter changes", async () => {
+      const result = { count: 1, rows: [{ id: "ec1" }] } as any;
+      jest.spyOn(EncounterChange, "findAndCountAll").mockResolvedValue(result);
+      expect(await resolver.encounterChanges({} as any)).toBe(result);
+    });
+  });
+
+  describe("updateEncounterChange (mutation)", () => {
+    it("throws NotFoundException when encounter change not found", async () => {
+      jest.spyOn(EncounterChange, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.updateEncounterChange(buildUser(true), { id: "missing" } as any)
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("throws NotFoundException when encounter not found", async () => {
+      const fakeChange = { id: "ec-uuid", encounterId: "enc-uuid" } as unknown as EncounterChange;
+      jest.spyOn(EncounterChange, "findByPk").mockResolvedValue(fakeChange);
+      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.updateEncounterChange(buildUser(true), { id: "ec-uuid" } as any)
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("throws UnauthorizedException when user lacks change:encounter for both clubs", async () => {
+      const fakeChange = { id: "ec-uuid", encounterId: "enc-uuid" } as unknown as EncounterChange;
+      const fakeHome = { clubId: "home-club" };
+      const fakeAway = { clubId: "away-club" };
+      const fakeEncounter = {
+        getHome: jest.fn().mockResolvedValue(fakeHome),
+        getAway: jest.fn().mockResolvedValue(fakeAway),
+      } as unknown as EncounterCompetition;
+      jest.spyOn(EncounterChange, "findByPk").mockResolvedValue(fakeChange);
+      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(fakeEncounter);
+      await expect(
+        resolver.updateEncounterChange(buildUser(false), { id: "ec-uuid" } as any)
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("updates encounter change and returns result when user has permission", async () => {
+      const updated = { id: "ec-uuid", status: "accepted" };
+      const fakeChange = {
+        id: "ec-uuid",
+        encounterId: "enc-uuid",
+        update: jest.fn().mockResolvedValue(updated),
+      } as unknown as EncounterChange;
+      const fakeHome = { clubId: "home-club" };
+      const fakeAway = { clubId: "away-club" };
+      const fakeEncounter = {
+        getHome: jest.fn().mockResolvedValue(fakeHome),
+        getAway: jest.fn().mockResolvedValue(fakeAway),
+      } as unknown as EncounterCompetition;
+      jest.spyOn(EncounterChange, "findByPk").mockResolvedValue(fakeChange);
+      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(fakeEncounter);
+      const result = await resolver.updateEncounterChange(buildUser(true), { id: "ec-uuid" } as any);
+      expect(fakeChange.update).toHaveBeenCalled();
+      expect(result).toBe(updated);
+    });
+  });
+
+  describe("addChangeEncounter (mutation)", () => {
+    it("throws NotFoundException when encounter not found", async () => {
+      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.addChangeEncounter(buildUser(true), { encounterId: "missing", home: true } as any)
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("throws NotFoundException when team not found in encounter", async () => {
+      const fakeEncounter = { home: null, away: null } as unknown as EncounterCompetition;
+      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(fakeEncounter);
+      await expect(
+        resolver.addChangeEncounter(buildUser(true), { encounterId: "enc-uuid", home: true } as any)
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("throws UnauthorizedException when user lacks change:encounter permission", async () => {
+      const fakeTeam = { clubId: "club-uuid" };
+      const fakeEncounter = { home: fakeTeam, away: null } as unknown as EncounterCompetition;
+      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(fakeEncounter);
+      await expect(
+        resolver.addChangeEncounter(buildUser(false), { encounterId: "enc-uuid", home: true } as any)
+      ).rejects.toThrow(UnauthorizedException);
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/event/competition/event.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/event.resolver.spec.ts
@@ -1,0 +1,155 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { Sequelize } from "sequelize-typescript";
+import { getQueueToken } from "@nestjs/bull";
+import { EventCompetition, Player } from "@badman/backend-database";
+import { SyncQueue } from "@badman/backend-queue";
+import { PointsService, RankingSystemService } from "@badman/backend-ranking";
+import { EventCompetitionResolver } from "./event.resolver";
+
+describe("EventCompetitionResolver", () => {
+  let resolver: EventCompetitionResolver;
+  let mockTransaction: { commit: jest.Mock; rollback: jest.Mock };
+  let mockSyncQueue: { add: jest.Mock };
+  let mockRankingSystemService: { getPrimary: jest.Mock; getById: jest.Mock };
+  let mockPointsService: { createRankingPointforGame: jest.Mock };
+
+  const buildUser = (allowed: boolean) =>
+    ({ id: "user-uuid", hasAnyPermission: jest.fn().mockResolvedValue(allowed) }) as unknown as Player;
+
+  beforeEach(async () => {
+    mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
+    mockSyncQueue = { add: jest.fn() };
+    mockRankingSystemService = { getPrimary: jest.fn(), getById: jest.fn() };
+    mockPointsService = { createRankingPointforGame: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EventCompetitionResolver,
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+        },
+        { provide: PointsService, useValue: mockPointsService },
+        { provide: getQueueToken(SyncQueue), useValue: mockSyncQueue },
+        { provide: RankingSystemService, useValue: mockRankingSystemService },
+      ],
+    }).compile();
+
+    resolver = module.get<EventCompetitionResolver>(EventCompetitionResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("eventCompetition (query — UUID)", () => {
+    it("finds by PK when id is a valid UUID", async () => {
+      const uuid = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+      const fakeEvent = { id: uuid } as unknown as EventCompetition;
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(fakeEvent);
+      expect(await resolver.eventCompetition(uuid)).toBe(fakeEvent);
+    });
+
+    it("finds by slug when id is not a UUID", async () => {
+      const fakeEvent = { id: "some-id", slug: "spring-2024" } as unknown as EventCompetition;
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(null);
+      jest.spyOn(EventCompetition, "findOne").mockResolvedValue(fakeEvent);
+      expect(await resolver.eventCompetition("spring-2024")).toBe(fakeEvent);
+    });
+
+    it("throws NotFoundException when not found by slug", async () => {
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(null);
+      jest.spyOn(EventCompetition, "findOne").mockResolvedValue(null);
+      await expect(resolver.eventCompetition("slug")).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("eventCompetitions (query)", () => {
+    it("returns paged results", async () => {
+      const result = { count: 1, rows: [{ id: "e1" }] } as any;
+      jest.spyOn(EventCompetition, "findAndCountAll").mockResolvedValue(result);
+      expect(await resolver.eventCompetitions({} as any)).toBe(result);
+    });
+  });
+
+  describe("updateEventCompetition (mutation)", () => {
+    it("throws UnauthorizedException when user lacks edit:competition permission", async () => {
+      await expect(
+        resolver.updateEventCompetition(buildUser(false), { id: "e-uuid" } as any)
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("throws NotFoundException when event not found", async () => {
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.updateEventCompetition(buildUser(true), { id: "missing" } as any)
+      ).rejects.toThrow(NotFoundException);
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+
+    it("updates event and commits on success", async () => {
+      const fakeEvent = {
+        id: "e-uuid",
+        official: false,
+        update: jest.fn().mockResolvedValue({ id: "e-uuid" }),
+        getSubEventCompetitions: jest.fn().mockResolvedValue([]),
+      } as unknown as EventCompetition;
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(fakeEvent);
+      const result = await resolver.updateEventCompetition(buildUser(true), { id: "e-uuid" } as any);
+      expect(fakeEvent.update).toHaveBeenCalled();
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(result).toEqual({ id: "e-uuid" });
+    });
+
+    it("rolls back on error", async () => {
+      const fakeEvent = {
+        id: "e-uuid",
+        official: false,
+        update: jest.fn().mockRejectedValue(new Error("db fail")),
+        getSubEventCompetitions: jest.fn().mockResolvedValue([]),
+      } as unknown as EventCompetition;
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(fakeEvent);
+      await expect(
+        resolver.updateEventCompetition(buildUser(true), { id: "e-uuid" } as any)
+      ).rejects.toThrow("db fail");
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+  });
+
+  describe("removeEventCompetition (mutation)", () => {
+    it("throws UnauthorizedException when user lacks delete:competition permission", async () => {
+      await expect(resolver.removeEventCompetition(buildUser(false), "e-uuid")).rejects.toThrow(
+        UnauthorizedException
+      );
+    });
+
+    it("throws NotFoundException when event not found", async () => {
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(null);
+      await expect(resolver.removeEventCompetition(buildUser(true), "missing")).rejects.toThrow(
+        NotFoundException
+      );
+    });
+  });
+
+  describe("recalculateStandingEvent (mutation)", () => {
+    it("throws UnauthorizedException when user lacks re-sync:points permission", async () => {
+      await expect(
+        resolver.recalculateStandingEvent(buildUser(false), "e-uuid")
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("throws NotFoundException when event not found", async () => {
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.recalculateStandingEvent(buildUser(true), "missing")
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("adds sync job and returns true", async () => {
+      const fakeEvent = { id: "e-uuid" } as unknown as EventCompetition;
+      jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(fakeEvent);
+      const result = await resolver.recalculateStandingEvent(buildUser(true), "e-uuid");
+      expect(mockSyncQueue.add).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/event/tournament/draw.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/tournament/draw.resolver.spec.ts
@@ -1,0 +1,139 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { Sequelize } from "sequelize-typescript";
+import { getQueueToken } from "@nestjs/bull";
+import { DrawTournament, Player, RankingSystem } from "@badman/backend-database";
+import { SyncQueue } from "@badman/backend-queue";
+import { PointsService, RankingSystemService } from "@badman/backend-ranking";
+import { DrawTournamentResolver } from "./draw.resolver";
+
+describe("DrawTournamentResolver", () => {
+  let resolver: DrawTournamentResolver;
+  let mockTransaction: { commit: jest.Mock; rollback: jest.Mock };
+  let mockSyncQueue: { add: jest.Mock };
+  let mockRankingSystemService: { getPrimary: jest.Mock; getById: jest.Mock };
+  let mockPointsService: { createRankingPointforGame: jest.Mock };
+
+  const buildUser = (allowed: boolean) =>
+    ({ id: "user-uuid", hasAnyPermission: jest.fn().mockResolvedValue(allowed) }) as unknown as Player;
+
+  beforeEach(async () => {
+    mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
+    mockSyncQueue = { add: jest.fn() };
+    mockRankingSystemService = { getPrimary: jest.fn(), getById: jest.fn() };
+    mockPointsService = { createRankingPointforGame: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DrawTournamentResolver,
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+        },
+        { provide: PointsService, useValue: mockPointsService },
+        { provide: getQueueToken(SyncQueue), useValue: mockSyncQueue },
+        { provide: RankingSystemService, useValue: mockRankingSystemService },
+      ],
+    }).compile();
+
+    resolver = module.get<DrawTournamentResolver>(DrawTournamentResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("drawTournament (query)", () => {
+    it("returns draw by id", async () => {
+      const fakeDraw = { id: "d-uuid" } as unknown as DrawTournament;
+      jest.spyOn(DrawTournament, "findByPk").mockResolvedValue(fakeDraw);
+      expect(await resolver.drawTournament("d-uuid")).toBe(fakeDraw);
+    });
+
+    it("throws NotFoundException when draw not found", async () => {
+      jest.spyOn(DrawTournament, "findByPk").mockResolvedValue(null);
+      await expect(resolver.drawTournament("missing")).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("drawTournaments (query)", () => {
+    it("returns list of draws", async () => {
+      const list = [{ id: "d1" }] as unknown as DrawTournament[];
+      jest.spyOn(DrawTournament, "findAll").mockResolvedValue(list);
+      expect(await resolver.drawTournaments({} as any)).toEqual(list);
+    });
+  });
+
+  describe("recalculateDrawTournamentRankingPoints (mutation)", () => {
+    it("throws UnauthorizedException when user lacks re-sync:points permission", async () => {
+      await expect(
+        resolver.recalculateDrawTournamentRankingPoints(buildUser(false), "d-uuid", "sys-uuid")
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("throws NotFoundException when ranking system not found", async () => {
+      mockRankingSystemService.getById.mockResolvedValue(null);
+      await expect(
+        resolver.recalculateDrawTournamentRankingPoints(buildUser(true), "d-uuid", "sys-uuid")
+      ).rejects.toThrow(NotFoundException);
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+
+    it("throws NotFoundException when draw not found", async () => {
+      const fakeSystem = { id: "sys-uuid" } as unknown as RankingSystem;
+      mockRankingSystemService.getById.mockResolvedValue(fakeSystem);
+      jest.spyOn(DrawTournament, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.recalculateDrawTournamentRankingPoints(buildUser(true), "d-uuid", "sys-uuid")
+      ).rejects.toThrow(NotFoundException);
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+
+    it("recalculates points and commits on success", async () => {
+      const fakeSystem = { id: "sys-uuid" } as unknown as RankingSystem;
+      mockRankingSystemService.getById.mockResolvedValue(fakeSystem);
+      const fakeGame = { id: "g1" };
+      const fakeDraw = { getGames: jest.fn().mockResolvedValue([fakeGame]) } as unknown as DrawTournament;
+      jest.spyOn(DrawTournament, "findByPk").mockResolvedValue(fakeDraw);
+      mockPointsService.createRankingPointforGame.mockResolvedValue(undefined);
+      const result = await resolver.recalculateDrawTournamentRankingPoints(
+        buildUser(true),
+        "d-uuid",
+        "sys-uuid"
+      );
+      expect(mockPointsService.createRankingPointforGame).toHaveBeenCalledWith(
+        fakeSystem,
+        fakeGame,
+        { transaction: mockTransaction }
+      );
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("syncDraw (mutation)", () => {
+    it("throws UnauthorizedException when user lacks sync:tournament permission", async () => {
+      await expect(
+        resolver.syncDraw(buildUser(false), "d-uuid", null as any, null as any, null as any, null as any, null as any)
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("throws Error when no valid argument combination provided", async () => {
+      await expect(
+        resolver.syncDraw(buildUser(true), null as any, null as any, null as any, null as any, null as any, null as any)
+      ).rejects.toThrow("Invalid arguments");
+    });
+
+    it("adds sync job and returns true when drawId provided", async () => {
+      const result = await resolver.syncDraw(
+        buildUser(true),
+        "d-uuid",
+        null as any,
+        null as any,
+        null as any,
+        null as any,
+        null as any
+      );
+      expect(mockSyncQueue.add).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/event/tournament/event.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/tournament/event.resolver.spec.ts
@@ -1,0 +1,149 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { Sequelize } from "sequelize-typescript";
+import { getQueueToken } from "@nestjs/bull";
+import { EventTournament, Player } from "@badman/backend-database";
+import { SyncQueue } from "@badman/backend-queue";
+import { PointsService, RankingSystemService } from "@badman/backend-ranking";
+import { EventTournamentResolver } from "./event.resolver";
+
+describe("EventTournamentResolver", () => {
+  let resolver: EventTournamentResolver;
+  let mockTransaction: { commit: jest.Mock; rollback: jest.Mock };
+  let mockSyncQueue: { add: jest.Mock };
+  let mockRankingSystemService: { getPrimary: jest.Mock; getById: jest.Mock };
+  let mockPointsService: { createRankingPointforGame: jest.Mock };
+
+  const buildUser = (allowed: boolean) =>
+    ({ id: "user-uuid", hasAnyPermission: jest.fn().mockResolvedValue(allowed) }) as unknown as Player;
+
+  beforeEach(async () => {
+    mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
+    mockSyncQueue = { add: jest.fn() };
+    mockRankingSystemService = { getPrimary: jest.fn(), getById: jest.fn() };
+    mockPointsService = { createRankingPointforGame: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EventTournamentResolver,
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+        },
+        { provide: PointsService, useValue: mockPointsService },
+        { provide: getQueueToken(SyncQueue), useValue: mockSyncQueue },
+        { provide: RankingSystemService, useValue: mockRankingSystemService },
+      ],
+    }).compile();
+
+    resolver = module.get<EventTournamentResolver>(EventTournamentResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("eventTournament (query — UUID)", () => {
+    it("finds by PK when id is a valid UUID", async () => {
+      const uuid = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+      const fakeEvent = { id: uuid } as unknown as EventTournament;
+      jest.spyOn(EventTournament, "findByPk").mockResolvedValue(fakeEvent);
+      expect(await resolver.eventTournament(uuid)).toBe(fakeEvent);
+    });
+
+    it("finds by slug when id is not a UUID", async () => {
+      const fakeEvent = { id: "some-id", slug: "autumn-cup-24" } as unknown as EventTournament;
+      jest.spyOn(EventTournament, "findByPk").mockResolvedValue(null);
+      jest.spyOn(EventTournament, "findOne").mockResolvedValue(fakeEvent);
+      expect(await resolver.eventTournament("autumn-cup-24")).toBe(fakeEvent);
+    });
+
+    it("throws NotFoundException when not found by slug", async () => {
+      jest.spyOn(EventTournament, "findByPk").mockResolvedValue(null);
+      jest.spyOn(EventTournament, "findOne").mockResolvedValue(null);
+      await expect(resolver.eventTournament("slug")).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("eventTournaments (query)", () => {
+    it("returns paged results", async () => {
+      const result = { count: 1, rows: [{ id: "t1" }] } as any;
+      jest.spyOn(EventTournament, "findAndCountAll").mockResolvedValue(result);
+      expect(await resolver.eventTournaments({} as any)).toBe(result);
+    });
+  });
+
+  describe("updateEventTournament (mutation)", () => {
+    it("throws UnauthorizedException when user lacks edit-any:tournament permission", async () => {
+      await expect(
+        resolver.updateEventTournament(buildUser(false), { id: "t-uuid" } as any)
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("throws NotFoundException when event not found", async () => {
+      jest.spyOn(EventTournament, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.updateEventTournament(buildUser(true), { id: "missing" } as any)
+      ).rejects.toThrow(NotFoundException);
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+
+    it("updates event and commits when official flag unchanged", async () => {
+      const fakeEvent = {
+        id: "t-uuid",
+        official: false,
+        update: jest.fn().mockResolvedValue({ id: "t-uuid" }),
+        getSubEventTournaments: jest.fn().mockResolvedValue([]),
+      } as unknown as EventTournament;
+      jest.spyOn(EventTournament, "findByPk").mockResolvedValue(fakeEvent);
+      const result = await resolver.updateEventTournament(buildUser(true), {
+        id: "t-uuid",
+        official: false,
+      } as any);
+      expect(fakeEvent.update).toHaveBeenCalled();
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(result).toEqual({ id: "t-uuid" });
+    });
+
+    it("rolls back on error", async () => {
+      const fakeEvent = {
+        id: "t-uuid",
+        official: false,
+        update: jest.fn().mockRejectedValue(new Error("db fail")),
+        getSubEventTournaments: jest.fn().mockResolvedValue([]),
+      } as unknown as EventTournament;
+      jest.spyOn(EventTournament, "findByPk").mockResolvedValue(fakeEvent);
+      await expect(
+        resolver.updateEventTournament(buildUser(true), { id: "t-uuid", official: false } as any)
+      ).rejects.toThrow("db fail");
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+  });
+
+  describe("removeEventTournament (mutation)", () => {
+    it("throws UnauthorizedException when user lacks delete-any:tournament permission", async () => {
+      await expect(resolver.removeEventTournament(buildUser(false), "t-uuid")).rejects.toThrow(
+        UnauthorizedException
+      );
+    });
+
+    it("throws NotFoundException when event not found", async () => {
+      jest.spyOn(EventTournament, "findByPk").mockResolvedValue(null);
+      await expect(resolver.removeEventTournament(buildUser(true), "missing")).rejects.toThrow(
+        NotFoundException
+      );
+    });
+  });
+
+  describe("syncEvent (mutation)", () => {
+    it("throws UnauthorizedException when user lacks sync:tournament permission", async () => {
+      await expect(
+        resolver.syncEvent(buildUser(false), "t-uuid", null as any, null as any)
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("adds job to sync queue and returns true", async () => {
+      const result = await resolver.syncEvent(buildUser(true), "t-uuid", null as any, null as any);
+      expect(mockSyncQueue.add).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/event/tournament/subevent.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/tournament/subevent.resolver.spec.ts
@@ -1,0 +1,148 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { Sequelize } from "sequelize-typescript";
+import { getQueueToken } from "@nestjs/bull";
+import { Player, RankingSystem, SubEventTournament, Game, DrawTournament } from "@badman/backend-database";
+import { SyncQueue } from "@badman/backend-queue";
+import { PointsService, RankingSystemService } from "@badman/backend-ranking";
+import { SubEventTournamentResolver } from "./subevent.resolver";
+
+describe("SubEventTournamentResolver", () => {
+  let resolver: SubEventTournamentResolver;
+  let mockTransaction: { commit: jest.Mock; rollback: jest.Mock };
+  let mockSyncQueue: { add: jest.Mock };
+  let mockRankingSystemService: { getPrimary: jest.Mock; getById: jest.Mock };
+  let mockPointsService: { createRankingPointforGame: jest.Mock };
+
+  const buildUser = (allowed: boolean) =>
+    ({ id: "user-uuid", hasAnyPermission: jest.fn().mockResolvedValue(allowed) }) as unknown as Player;
+
+  beforeEach(async () => {
+    mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
+    mockSyncQueue = { add: jest.fn() };
+    mockRankingSystemService = { getPrimary: jest.fn(), getById: jest.fn() };
+    mockPointsService = { createRankingPointforGame: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SubEventTournamentResolver,
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+        },
+        { provide: PointsService, useValue: mockPointsService },
+        { provide: getQueueToken(SyncQueue), useValue: mockSyncQueue },
+        { provide: RankingSystemService, useValue: mockRankingSystemService },
+      ],
+    }).compile();
+
+    resolver = module.get<SubEventTournamentResolver>(SubEventTournamentResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("subEventTournament (query)", () => {
+    it("returns subEvent by id", async () => {
+      const fakeSubEvent = { id: "se-uuid" } as unknown as SubEventTournament;
+      jest.spyOn(SubEventTournament, "findByPk").mockResolvedValue(fakeSubEvent);
+      expect(await resolver.subEventTournament("se-uuid")).toBe(fakeSubEvent);
+    });
+
+    it("throws NotFoundException when subEvent not found", async () => {
+      jest.spyOn(SubEventTournament, "findByPk").mockResolvedValue(null);
+      await expect(resolver.subEventTournament("missing")).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("subEventTournaments (query)", () => {
+    it("returns list of subEvents", async () => {
+      const list = [{ id: "se1" }] as unknown as SubEventTournament[];
+      jest.spyOn(SubEventTournament, "findAll").mockResolvedValue(list);
+      expect(await resolver.subEventTournaments({} as any)).toEqual(list);
+    });
+  });
+
+  describe("recalculateSubEventTournamentwRankingPoints (mutation)", () => {
+    it("throws UnauthorizedException when user lacks re-sync:points permission", async () => {
+      await expect(
+        resolver.recalculateSubEventTournamentwRankingPoints(buildUser(false), "se-uuid", "sys-uuid")
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("throws NotFoundException when ranking system not found", async () => {
+      mockRankingSystemService.getById.mockResolvedValue(null);
+      await expect(
+        resolver.recalculateSubEventTournamentwRankingPoints(buildUser(true), "se-uuid", "sys-uuid")
+      ).rejects.toThrow(NotFoundException);
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+
+    it("throws NotFoundException when subEvent not found", async () => {
+      const fakeSystem = { id: "sys-uuid" } as unknown as RankingSystem;
+      mockRankingSystemService.getById.mockResolvedValue(fakeSystem);
+      jest.spyOn(SubEventTournament, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.recalculateSubEventTournamentwRankingPoints(buildUser(true), "se-uuid", "sys-uuid")
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("recalculates points across all draws and commits on success", async () => {
+      const fakeSystem = { id: "sys-uuid" } as unknown as RankingSystem;
+      mockRankingSystemService.getById.mockResolvedValue(fakeSystem);
+      const fakeGame = { id: "g1" } as unknown as Game;
+      const fakeDraw = { games: [fakeGame] } as unknown as DrawTournament;
+      const fakeSubEvent = {
+        getDrawTournaments: jest.fn().mockResolvedValue([fakeDraw]),
+      } as unknown as SubEventTournament;
+      jest.spyOn(SubEventTournament, "findByPk").mockResolvedValue(fakeSubEvent);
+      mockPointsService.createRankingPointforGame.mockResolvedValue(undefined);
+      const result = await resolver.recalculateSubEventTournamentwRankingPoints(
+        buildUser(true),
+        "se-uuid",
+        "sys-uuid"
+      );
+      expect(mockPointsService.createRankingPointforGame).toHaveBeenCalledWith(
+        fakeSystem,
+        fakeGame,
+        { transaction: mockTransaction }
+      );
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("syncSubEvent (mutation)", () => {
+    it("throws UnauthorizedException when user lacks sync:tournament permission", async () => {
+      await expect(
+        resolver.syncSubEvent(
+          buildUser(false),
+          null as any, null as any,
+          "se-uuid", null as any,
+          null as any
+        )
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("throws Error when no valid argument combination provided", async () => {
+      await expect(
+        resolver.syncSubEvent(
+          buildUser(true),
+          null as any, null as any,
+          null as any, null as any,
+          null as any
+        )
+      ).rejects.toThrow("Invalid arguments");
+    });
+
+    it("adds sync job and returns true when subEventId provided", async () => {
+      const result = await resolver.syncSubEvent(
+        buildUser(true),
+        null as any, null as any,
+        "se-uuid", null as any,
+        null as any
+      );
+      expect(mockSyncQueue.add).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/faq/faq.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/faq/faq.resolver.spec.ts
@@ -1,0 +1,125 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { Sequelize } from "sequelize-typescript";
+import { Faq, Player } from "@badman/backend-database";
+import { FaqResolver } from "./faq.resolver";
+
+describe("FaqResolver", () => {
+  let resolver: FaqResolver;
+  let mockTransaction: { commit: jest.Mock; rollback: jest.Mock };
+
+  const buildUser = (allowed: boolean) =>
+    ({ id: "user-uuid", hasAnyPermission: jest.fn().mockResolvedValue(allowed) }) as unknown as Player;
+
+  beforeEach(async () => {
+    mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FaqResolver,
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<FaqResolver>(FaqResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("faq (query)", () => {
+    it("returns faq by id", async () => {
+      const fakeFaq = { id: "f-uuid" } as unknown as Faq;
+      jest.spyOn(Faq, "findByPk").mockResolvedValue(fakeFaq);
+      expect(await resolver.faq("f-uuid")).toBe(fakeFaq);
+    });
+
+    it("returns null when faq not found", async () => {
+      jest.spyOn(Faq, "findByPk").mockResolvedValue(null);
+      expect(await resolver.faq("missing")).toBeNull();
+    });
+  });
+
+  describe("faqs (query)", () => {
+    it("returns list of faqs", async () => {
+      const list = [{ id: "f1" }, { id: "f2" }] as unknown as Faq[];
+      jest.spyOn(Faq, "findAll").mockResolvedValue(list);
+      expect(await resolver.faqs({} as any)).toEqual(list);
+    });
+  });
+
+  describe("createFaq (mutation)", () => {
+    it("throws UnauthorizedException when user lacks add:faq permission", async () => {
+      await expect(resolver.createFaq(buildUser(false), {} as any)).rejects.toThrow(
+        UnauthorizedException
+      );
+    });
+
+    it("creates faq and commits on success", async () => {
+      const newFaq = { id: "f-new" } as unknown as Faq;
+      jest.spyOn(Faq, "create").mockResolvedValue(newFaq);
+      const result = await resolver.createFaq(buildUser(true), { question: "Q?" } as any);
+      expect(Faq.create).toHaveBeenCalledWith({ question: "Q?" }, { transaction: mockTransaction });
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(result).toBe(newFaq);
+    });
+
+    it("rolls back on error", async () => {
+      jest.spyOn(Faq, "create").mockRejectedValue(new Error("db fail"));
+      await expect(resolver.createFaq(buildUser(true), {} as any)).rejects.toThrow("db fail");
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+  });
+
+  describe("updateFaq (mutation)", () => {
+    it("throws UnauthorizedException when user lacks edit:faq permission", async () => {
+      await expect(resolver.updateFaq(buildUser(false), { id: "f-uuid" } as any)).rejects.toThrow(
+        UnauthorizedException
+      );
+    });
+
+    it("throws NotFoundException when faq not found", async () => {
+      jest.spyOn(Faq, "findByPk").mockResolvedValue(null);
+      await expect(resolver.updateFaq(buildUser(true), { id: "missing" } as any)).rejects.toThrow(
+        NotFoundException
+      );
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+
+    it("updates faq and commits on success", async () => {
+      const fakeFaq = {
+        update: jest.fn().mockResolvedValue({ id: "f-uuid", question: "New?" }),
+      } as unknown as Faq;
+      jest.spyOn(Faq, "findByPk").mockResolvedValue(fakeFaq);
+      const result = await resolver.updateFaq(buildUser(true), { id: "f-uuid", question: "New?" } as any);
+      expect(fakeFaq.update).toHaveBeenCalled();
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(result).toEqual({ id: "f-uuid", question: "New?" });
+    });
+  });
+
+  describe("deleteFaq (mutation)", () => {
+    it("throws UnauthorizedException when user lacks edit:faq permission", async () => {
+      await expect(resolver.deleteFaq(buildUser(false), "f-uuid")).rejects.toThrow(
+        UnauthorizedException
+      );
+    });
+
+    it("throws NotFoundException when faq not found", async () => {
+      jest.spyOn(Faq, "findByPk").mockResolvedValue(null);
+      await expect(resolver.deleteFaq(buildUser(true), "missing")).rejects.toThrow(NotFoundException);
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+
+    it("destroys faq and commits on success", async () => {
+      const fakeFaq = { destroy: jest.fn().mockResolvedValue(undefined) } as unknown as Faq;
+      jest.spyOn(Faq, "findByPk").mockResolvedValue(fakeFaq);
+      const result = await resolver.deleteFaq(buildUser(true), "f-uuid");
+      expect(fakeFaq.destroy).toHaveBeenCalled();
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/notification/notification.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/notification/notification.resolver.spec.ts
@@ -1,0 +1,106 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { Sequelize } from "sequelize-typescript";
+import { Notification, Player } from "@badman/backend-database";
+import { NotificationResolver } from "./notification.resolver";
+
+describe("NotificationResolver", () => {
+  let resolver: NotificationResolver;
+  let mockTransaction: { commit: jest.Mock; rollback: jest.Mock };
+
+  const buildUser = (id: string) => ({ id }) as unknown as Player;
+
+  beforeEach(async () => {
+    mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationResolver,
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<NotificationResolver>(NotificationResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("notification (query)", () => {
+    it("returns notification by id", async () => {
+      const n = { id: "n-uuid" } as unknown as Notification;
+      jest.spyOn(Notification, "findByPk").mockResolvedValue(n);
+      expect(await resolver.notification("n-uuid")).toBe(n);
+    });
+
+    it("returns null when notification not found", async () => {
+      jest.spyOn(Notification, "findByPk").mockResolvedValue(null);
+      expect(await resolver.notification("missing")).toBeNull();
+    });
+  });
+
+  describe("notifications (query)", () => {
+    it("returns list of notifications", async () => {
+      const list = [{ id: "n1" }] as unknown as Notification[];
+      jest.spyOn(Notification, "findAll").mockResolvedValue(list);
+      expect(await resolver.notifications({} as any)).toEqual(list);
+    });
+  });
+
+  describe("updateNotification (mutation)", () => {
+    it("throws NotFoundException when notification not found", async () => {
+      jest.spyOn(Notification, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.updateNotification({ id: "missing" } as any, buildUser("user-1"))
+      ).rejects.toThrow(NotFoundException);
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+
+    it("throws UnauthorizedException when sendToId does not match current user", async () => {
+      const fakeNotif = {
+        id: "n-uuid",
+        sendToId: "other-user",
+        toJSON: jest.fn().mockReturnValue({}),
+        update: jest.fn(),
+      } as unknown as Notification;
+      jest.spyOn(Notification, "findByPk").mockResolvedValue(fakeNotif);
+      await expect(
+        resolver.updateNotification({ id: "n-uuid" } as any, buildUser("user-1"))
+      ).rejects.toThrow(UnauthorizedException);
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+
+    it("updates notification and commits when user is the recipient", async () => {
+      const fakeNotif = {
+        id: "n-uuid",
+        sendToId: "user-1",
+        toJSON: jest.fn().mockReturnValue({ id: "n-uuid" }),
+        update: jest.fn().mockResolvedValue(undefined),
+      } as unknown as Notification;
+      jest.spyOn(Notification, "findByPk").mockResolvedValue(fakeNotif);
+      const result = await resolver.updateNotification(
+        { id: "n-uuid", read: true } as any,
+        buildUser("user-1")
+      );
+      expect(fakeNotif.update).toHaveBeenCalled();
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(result).toBe(fakeNotif);
+    });
+
+    it("rolls back on unexpected error", async () => {
+      const fakeNotif = {
+        id: "n-uuid",
+        sendToId: "user-1",
+        toJSON: jest.fn().mockReturnValue({}),
+        update: jest.fn().mockRejectedValue(new Error("db fail")),
+      } as unknown as Notification;
+      jest.spyOn(Notification, "findByPk").mockResolvedValue(fakeNotif);
+      await expect(
+        resolver.updateNotification({ id: "n-uuid" } as any, buildUser("user-1"))
+      ).rejects.toThrow("db fail");
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/ranking/rankingSystemGroup.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/ranking/rankingSystemGroup.resolver.spec.ts
@@ -1,0 +1,123 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { Sequelize } from "sequelize-typescript";
+import { Player, RankingGroup } from "@badman/backend-database";
+import { PointsService } from "@badman/backend-ranking";
+import { RankingGroupsResolver } from "./rankingSystemGroup.resolver";
+
+describe("RankingGroupsResolver", () => {
+  let resolver: RankingGroupsResolver;
+  let mockTransaction: { commit: jest.Mock; rollback: jest.Mock };
+  let mockPointsService: { createRankingPointforGame: jest.Mock };
+
+  const buildUser = (allowed: boolean) =>
+    ({ id: "user-uuid", hasAnyPermission: jest.fn().mockResolvedValue(allowed) }) as unknown as Player;
+
+  beforeEach(async () => {
+    mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
+    mockPointsService = { createRankingPointforGame: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RankingGroupsResolver,
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+        },
+        { provide: PointsService, useValue: mockPointsService },
+      ],
+    }).compile();
+
+    resolver = module.get<RankingGroupsResolver>(RankingGroupsResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("rankingGroup (query)", () => {
+    it("returns ranking group by id", async () => {
+      const fakeGroup = { id: "rg-uuid" } as unknown as RankingGroup;
+      jest.spyOn(RankingGroup, "findByPk").mockResolvedValue(fakeGroup);
+      expect(await resolver.rankingGroup("rg-uuid")).toBe(fakeGroup);
+    });
+
+    it("throws NotFoundException when group not found", async () => {
+      jest.spyOn(RankingGroup, "findByPk").mockResolvedValue(null);
+      await expect(resolver.rankingGroup("missing")).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("rankingGroups (query)", () => {
+    it("returns list of ranking groups", async () => {
+      const list = [{ id: "rg1" }] as unknown as RankingGroup[];
+      jest.spyOn(RankingGroup, "findAll").mockResolvedValue(list);
+      expect(await resolver.rankingGroups({} as any)).toEqual(list);
+    });
+  });
+
+  describe("addSubEventsToRankingGroup (mutation)", () => {
+    it("throws UnauthorizedException when user lacks add:event permission", async () => {
+      await expect(
+        resolver.addSubEventsToRankingGroup(buildUser(false), "rg-uuid", [], [])
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("throws NotFoundException when ranking group not found", async () => {
+      jest.spyOn(RankingGroup, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.addSubEventsToRankingGroup(buildUser(true), "missing", [], [])
+      ).rejects.toThrow(NotFoundException);
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+
+    it("adds sub-events and commits on success", async () => {
+      const fakeGroup = {
+        id: "rg-uuid",
+        addSubEventCompetitions: jest.fn().mockResolvedValue(undefined),
+        addSubEventTournaments: jest.fn().mockResolvedValue(undefined),
+        getRankingSystems: jest.fn().mockResolvedValue([]),
+      } as unknown as RankingGroup;
+      jest.spyOn(RankingGroup, "findByPk").mockResolvedValue(fakeGroup);
+
+      const db = require("@badman/backend-database");
+      jest.spyOn(db.Game, "findAll").mockResolvedValue([]);
+      jest.spyOn(db.SubEventCompetition, "findAll").mockResolvedValue([]);
+      jest.spyOn(db.SubEventTournament, "findAll").mockResolvedValue([]);
+
+      const result = await resolver.addSubEventsToRankingGroup(
+        buildUser(true),
+        "rg-uuid",
+        ["comp-1"],
+        ["tourn-1"]
+      );
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(result).toBe(fakeGroup);
+    });
+
+    it("rolls back on error", async () => {
+      const fakeGroup = {
+        id: "rg-uuid",
+        addSubEventCompetitions: jest.fn().mockRejectedValue(new Error("db fail")),
+      } as unknown as RankingGroup;
+      jest.spyOn(RankingGroup, "findByPk").mockResolvedValue(fakeGroup);
+      await expect(
+        resolver.addSubEventsToRankingGroup(buildUser(true), "rg-uuid", ["comp-1"], [])
+      ).rejects.toThrow("db fail");
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+  });
+
+  describe("removeSubEventsToRankingGroup (mutation)", () => {
+    it("throws UnauthorizedException when user lacks remove:event permission", async () => {
+      await expect(
+        resolver.removeSubEventsToRankingGroup(buildUser(false), "rg-uuid", [], [])
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("throws NotFoundException when ranking group not found", async () => {
+      jest.spyOn(RankingGroup, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.removeSubEventsToRankingGroup(buildUser(true), "missing", [], [])
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/security/claim.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/security/claim.resolver.spec.ts
@@ -1,0 +1,143 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { Sequelize } from "sequelize-typescript";
+import { Claim, Player } from "@badman/backend-database";
+import { ClaimResolver } from "./claim.resolver";
+
+describe("ClaimResolver", () => {
+  let resolver: ClaimResolver;
+  let mockTransaction: { commit: jest.Mock; rollback: jest.Mock };
+
+  const buildUser = (allowed: boolean) =>
+    ({ id: "user-uuid", hasAnyPermission: jest.fn().mockResolvedValue(allowed) }) as unknown as Player;
+
+  beforeEach(async () => {
+    mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ClaimResolver,
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<ClaimResolver>(ClaimResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("claim (query)", () => {
+    it("returns claim by id", async () => {
+      const fakeClaim = { id: "c-uuid" } as unknown as Claim;
+      jest.spyOn(Claim, "findByPk").mockResolvedValue(fakeClaim);
+      expect(await resolver.claim("c-uuid")).toBe(fakeClaim);
+    });
+
+    it("throws NotFoundException when claim not found", async () => {
+      jest.spyOn(Claim, "findByPk").mockResolvedValue(null);
+      await expect(resolver.claim("missing")).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("claims (query)", () => {
+    it("returns list of claims", async () => {
+      const list = [{ id: "c1" }, { id: "c2" }] as unknown as Claim[];
+      jest.spyOn(Claim, "findAll").mockResolvedValue(list);
+      expect(await resolver.claims({} as any)).toEqual(list);
+    });
+
+    it("returns empty array when no claims exist", async () => {
+      jest.spyOn(Claim, "findAll").mockResolvedValue([]);
+      expect(await resolver.claims({} as any)).toEqual([]);
+    });
+  });
+
+  describe("assignClaim (mutation)", () => {
+    it("throws UnauthorizedException when user lacks permission", async () => {
+      await expect(
+        resolver.assignClaim(buildUser(false), "c-uuid", "p-uuid", true)
+      ).rejects.toThrow(UnauthorizedException);
+      expect(mockTransaction.rollback).not.toHaveBeenCalled();
+    });
+
+    it("throws NotFoundException when player not found", async () => {
+      jest.spyOn(Player, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.assignClaim(buildUser(true), "c-uuid", "p-uuid", true)
+      ).rejects.toThrow(NotFoundException);
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+
+    it("adds claim and commits on success", async () => {
+      const fakePlayer = { addClaim: jest.fn().mockResolvedValue(undefined) } as unknown as Player;
+      jest.spyOn(Player, "findByPk").mockResolvedValue(fakePlayer);
+      const result = await resolver.assignClaim(buildUser(true), "c-uuid", "p-uuid", true);
+      expect(fakePlayer.addClaim).toHaveBeenCalledWith("c-uuid", { transaction: mockTransaction });
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it("removes claim when active=false", async () => {
+      const fakePlayer = { removeClaim: jest.fn().mockResolvedValue(undefined) } as unknown as Player;
+      jest.spyOn(Player, "findByPk").mockResolvedValue(fakePlayer);
+      await resolver.assignClaim(buildUser(true), "c-uuid", "p-uuid", false);
+      expect(fakePlayer.removeClaim).toHaveBeenCalledWith("c-uuid", { transaction: mockTransaction });
+    });
+
+    it("rolls back on error", async () => {
+      const fakePlayer = {
+        addClaim: jest.fn().mockRejectedValue(new Error("db fail")),
+      } as unknown as Player;
+      jest.spyOn(Player, "findByPk").mockResolvedValue(fakePlayer);
+      await expect(
+        resolver.assignClaim(buildUser(true), "c-uuid", "p-uuid", true)
+      ).rejects.toThrow("db fail");
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+      expect(mockTransaction.commit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("assignClaims (mutation)", () => {
+    it("throws UnauthorizedException when user lacks permission", async () => {
+      await expect(resolver.assignClaims(buildUser(false), [])).rejects.toThrow(
+        UnauthorizedException
+      );
+    });
+
+    it("throws NotFoundException when a player in the list is not found", async () => {
+      jest.spyOn(Player, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.assignClaims(buildUser(true), [{ playerId: "p-uuid", claimId: "c-uuid", active: true }])
+      ).rejects.toThrow(NotFoundException);
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+
+    it("processes all claims and commits on success", async () => {
+      const fakePlayer = {
+        addClaim: jest.fn().mockResolvedValue(undefined),
+        removeClaim: jest.fn().mockResolvedValue(undefined),
+      } as unknown as Player;
+      jest.spyOn(Player, "findByPk").mockResolvedValue(fakePlayer);
+      const result = await resolver.assignClaims(buildUser(true), [
+        { playerId: "p1", claimId: "c1", active: true },
+        { playerId: "p2", claimId: "c2", active: false },
+      ]);
+      expect(result).toBe(true);
+      expect(mockTransaction.commit).toHaveBeenCalled();
+    });
+
+    it("rolls back on error during processing", async () => {
+      const fakePlayer = {
+        addClaim: jest.fn().mockRejectedValue(new Error("bulk fail")),
+      } as unknown as Player;
+      jest.spyOn(Player, "findByPk").mockResolvedValue(fakePlayer);
+      await expect(
+        resolver.assignClaims(buildUser(true), [{ playerId: "p1", claimId: "c1", active: true }])
+      ).rejects.toThrow("bulk fail");
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/security/role.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/security/role.resolver.spec.ts
@@ -1,0 +1,208 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { Sequelize } from "sequelize-typescript";
+import { Player, Role } from "@badman/backend-database";
+import { RoleResolver } from "./role.resolver";
+
+describe("RoleResolver", () => {
+  let resolver: RoleResolver;
+  let mockTransaction: { commit: jest.Mock; rollback: jest.Mock };
+
+  const buildUser = (allowed: boolean) =>
+    ({ id: "user-uuid", hasAnyPermission: jest.fn().mockResolvedValue(allowed) }) as unknown as Player;
+
+  const fakeRole = {
+    id: "role-uuid",
+    linkId: "club-uuid",
+    linkType: "club",
+    update: jest.fn(),
+    setClaims: jest.fn(),
+    destroy: jest.fn(),
+    addPlayer: jest.fn(),
+    addPlayers: jest.fn(),
+    removePlayer: jest.fn(),
+    getClaims: jest.fn(),
+    getPlayers: jest.fn(),
+  } as unknown as Role;
+
+  beforeEach(async () => {
+    mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RoleResolver,
+        {
+          provide: Sequelize,
+          useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) },
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<RoleResolver>(RoleResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("role (query)", () => {
+    it("returns role by id", async () => {
+      jest.spyOn(Role, "findByPk").mockResolvedValue(fakeRole);
+      expect(await resolver.role("role-uuid")).toBe(fakeRole);
+    });
+
+    it("throws NotFoundException when role not found", async () => {
+      jest.spyOn(Role, "findByPk").mockResolvedValue(null);
+      await expect(resolver.role("missing")).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("roles (query)", () => {
+    it("returns list of roles", async () => {
+      const list = [fakeRole] as unknown as Role[];
+      jest.spyOn(Role, "findAll").mockResolvedValue(list);
+      expect(await resolver.roles({} as any)).toEqual(list);
+    });
+  });
+
+  describe("updateRole (mutation)", () => {
+    it("throws NotFoundException when role not found", async () => {
+      jest.spyOn(Role, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.updateRole(buildUser(true), { id: "missing" } as any)
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("throws UnauthorizedException when user lacks permission", async () => {
+      jest.spyOn(Role, "findByPk").mockResolvedValue(fakeRole);
+      await expect(
+        resolver.updateRole(buildUser(false), { id: "role-uuid", claims: [] } as any)
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("updates role and commits on success", async () => {
+      jest.spyOn(Role, "findByPk").mockResolvedValue(fakeRole);
+      (fakeRole.update as jest.Mock).mockResolvedValue(fakeRole);
+      (fakeRole.setClaims as jest.Mock).mockResolvedValue(undefined);
+      const result = await resolver.updateRole(buildUser(true), {
+        id: "role-uuid",
+        claims: [{ id: "c1" }],
+      } as any);
+      expect(fakeRole.update).toHaveBeenCalled();
+      expect(fakeRole.setClaims).toHaveBeenCalledWith(["c1"], { transaction: mockTransaction });
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(result).toBe(fakeRole);
+    });
+
+    it("rolls back on error", async () => {
+      jest.spyOn(Role, "findByPk").mockResolvedValue(fakeRole);
+      (fakeRole.update as jest.Mock).mockRejectedValue(new Error("db fail"));
+      await expect(
+        resolver.updateRole(buildUser(true), { id: "role-uuid", claims: [] } as any)
+      ).rejects.toThrow("db fail");
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+  });
+
+  describe("deleteRole (mutation)", () => {
+    it("throws NotFoundException when role not found", async () => {
+      jest.spyOn(Role, "findByPk").mockResolvedValue(null);
+      await expect(resolver.deleteRole(buildUser(true), "missing")).rejects.toThrow(NotFoundException);
+    });
+
+    it("throws UnauthorizedException when user lacks permission", async () => {
+      jest.spyOn(Role, "findByPk").mockResolvedValue(fakeRole);
+      await expect(resolver.deleteRole(buildUser(false), "role-uuid")).rejects.toThrow(
+        UnauthorizedException
+      );
+    });
+
+    it("destroys role and commits on success", async () => {
+      jest.spyOn(Role, "findByPk").mockResolvedValue(fakeRole);
+      (fakeRole.destroy as jest.Mock).mockResolvedValue(undefined);
+      const result = await resolver.deleteRole(buildUser(true), "role-uuid");
+      expect(fakeRole.destroy).toHaveBeenCalled();
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("createRole (mutation)", () => {
+    it("throws UnauthorizedException when user lacks permission", async () => {
+      await expect(
+        resolver.createRole(buildUser(false), {
+          linkId: "club-uuid",
+          linkType: "club",
+          claims: [],
+        } as any)
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("creates role and commits on success", async () => {
+      jest.spyOn(Role, "create").mockResolvedValue(fakeRole);
+      (fakeRole.setClaims as jest.Mock).mockResolvedValue(undefined);
+      const result = await resolver.createRole(buildUser(true), {
+        linkId: "club-uuid",
+        linkType: "club",
+        claims: [{ id: "c1" }],
+      } as any);
+      expect(Role.create).toHaveBeenCalled();
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(result).toBe(fakeRole);
+    });
+  });
+
+  describe("addPlayerToRole (mutation)", () => {
+    it("throws NotFoundException when role not found", async () => {
+      jest.spyOn(Role, "findByPk").mockResolvedValue(null);
+      await expect(resolver.addPlayerToRole(buildUser(true), "missing", "p1")).rejects.toThrow(
+        NotFoundException
+      );
+    });
+
+    it("throws UnauthorizedException when user lacks permission", async () => {
+      jest.spyOn(Role, "findByPk").mockResolvedValue(fakeRole);
+      await expect(
+        resolver.addPlayerToRole(buildUser(false), "role-uuid", "p1")
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("throws NotFoundException when player not found", async () => {
+      jest.spyOn(Role, "findByPk").mockResolvedValue(fakeRole);
+      jest.spyOn(Player, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.addPlayerToRole(buildUser(true), "role-uuid", "p1")
+      ).rejects.toThrow(NotFoundException);
+      expect(mockTransaction.rollback).toHaveBeenCalled();
+    });
+
+    it("adds player to role and commits on success", async () => {
+      jest.spyOn(Role, "findByPk").mockResolvedValue(fakeRole);
+      const fakePlayer = {} as unknown as Player;
+      jest.spyOn(Player, "findByPk").mockResolvedValue(fakePlayer);
+      (fakeRole.addPlayer as jest.Mock).mockResolvedValue(undefined);
+      const result = await resolver.addPlayerToRole(buildUser(true), "role-uuid", "p1");
+      expect(fakeRole.addPlayer).toHaveBeenCalledWith(fakePlayer, { transaction: mockTransaction });
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("removePlayerFromRole (mutation)", () => {
+    it("throws NotFoundException when role not found", async () => {
+      jest.spyOn(Role, "findByPk").mockResolvedValue(null);
+      await expect(
+        resolver.removePlayerFromRole(buildUser(true), "missing", "p1")
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("removes player and commits on success", async () => {
+      jest.spyOn(Role, "findByPk").mockResolvedValue(fakeRole);
+      const fakePlayer = {} as unknown as Player;
+      jest.spyOn(Player, "findByPk").mockResolvedValue(fakePlayer);
+      (fakeRole.removePlayer as jest.Mock).mockResolvedValue(undefined);
+      const result = await resolver.removePlayerFromRole(buildUser(true), "role-uuid", "p1");
+      expect(fakeRole.removePlayer).toHaveBeenCalledWith(fakePlayer, { transaction: mockTransaction });
+      expect(mockTransaction.commit).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/libs/backend/graphql/src/resolvers/services/service.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/services/service.resolver.spec.ts
@@ -1,0 +1,30 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { Service } from "@badman/backend-database";
+import { ServiceResolver } from "./service.resolver";
+
+describe("ServiceResolver", () => {
+  let resolver: ServiceResolver;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ServiceResolver],
+    }).compile();
+
+    resolver = module.get<ServiceResolver>(ServiceResolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe("services (query)", () => {
+    it("returns list of services", async () => {
+      const list = [{ id: "s1" }, { id: "s2" }] as unknown as Service[];
+      jest.spyOn(Service, "findAll").mockResolvedValue(list);
+      expect(await resolver.services({} as any)).toEqual(list);
+    });
+
+    it("returns empty array when no services exist", async () => {
+      jest.spyOn(Service, "findAll").mockResolvedValue([]);
+      expect(await resolver.services({} as any)).toEqual([]);
+    });
+  });
+});

--- a/libs/utils/src/lib/i18n.generated.ts
+++ b/libs/utils/src/lib/i18n.generated.ts
@@ -1474,6 +1474,15 @@ export type I18nTranslations = {
                     "error": string;
                 };
             };
+            "avgLevelPage": {
+                "error": string;
+                "empty": string;
+                "eventType": {
+                    "M": string;
+                    "F": string;
+                    "MX": string;
+                };
+            };
             "adminCompetitionsPage": {
                 "title": string;
                 "seasonSelectLabel": string;
@@ -1700,6 +1709,14 @@ export type I18nTranslations = {
                     "retryNotification": string;
                     "error": {
                         "network": {
+                            "title": string;
+                            "body": string;
+                        };
+                        "server": {
+                            "title": string;
+                            "body": string;
+                        };
+                        "validation": {
                             "title": string;
                             "body": string;
                         };
@@ -3383,6 +3400,7 @@ export type I18nTranslations = {
                 "actions": {
                     "edit": string;
                     "delete": string;
+                    "export": string;
                     "setRisersFallers": string;
                     "openCloseDate": string;
                     "openCloseEncounterChangeDate": string;
@@ -3392,7 +3410,14 @@ export type I18nTranslations = {
                     "messages": {
                         "syncSuccess": string;
                         "syncError": string;
+                        "cpGenerationStarted": string;
                     };
+                    "averageLevel": string;
+                    "downloadEnrollment": string;
+                    "downloadTeams": string;
+                    "downloadExceptions": string;
+                    "downloadLocations": string;
+                    "downloadCp": string;
                 };
                 "addCompetitionDialog": {
                     "title": string;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:coverage": "npx nx test worker-sync --coverage --skip-nx-cache",
     "test:affected": "nx affected:test",
     "test:affected:coverage": "nx affected:test --coverage",
+    "test:coverage:all": "nx run-many --target=test --all --coverage --skip-nx-cache --exclude=badman,frontend-models,frontend-components,frontend-html-injects,frontend-vitals,frontend-translation,frontend-auth,frontend-excel,frontend-pdf,frontend-utils,frontend-graphql,frontend-queue,frontend-cp,frontend-twizzit,frontend-seo,frontend-club,frontend-ranking,frontend-role,frontend-general,frontend-tournament,frontend-transfers,frontend-team,frontend-job,frontend-rule,frontend-team-assembly,frontend-change-encounter,frontend-team-enrollment,frontend-event,frontend-notifications,frontend-player",
     "lint": "nx lint",
     "e2e": "nx run-many --target=e2e",
     "e2e:ui": "nx run-many --target=e2e --ui",

--- a/specs/032-resolver-test-coverage/audit.md
+++ b/specs/032-resolver-test-coverage/audit.md
@@ -1,0 +1,368 @@
+# Resolver Audit — 033 resolvers (all backend-graphql)
+
+**Date**: 2026-06-08  
+**Coverage baseline** (post-spec addition): statements 50%, branches 31%, functions 26%, lines 48%
+
+Categories checked per resolver:
+1. **Missing auth** — mutations reachable without permission check
+2. **Duplication** — logic repeated across resolvers without extraction
+3. **N+1 performance** — ResolveFields issuing individual queries per parent row
+4. **Code quality** — structural issues, dead code, naming inconsistency
+5. **Bugs** — observable incorrect behavior
+6. **Missing idempotency** — create mutations lacking alreadyExisted semantics (Constitution Principle III)
+
+Legend: ✅ OK · ⚠️ Warn · 🚨 Issue
+
+---
+
+## 1. assembly.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 1 | Missing auth | ⚠️ | `createAssembly` — no `hasAnyPermission` call. Any authenticated user can write assembly for any encounter. Intentional (player self-submission), but should be documented. |
+| 2 | Missing idempotency | ✅ | Uses `findOrCreate`; updates existing record. Pattern is correct but doesn't return `alreadyExisted`. |
+| 3 | Code quality | ⚠️ | Error handler returns `null` instead of throwing — GraphQL client sees `null` with no error. Silences real failures. |
+| 4 | N+1 | ⚠️ | `titularsPlayers` and `baseTeamPlayers` ResolveFields call `player.getCurrentRanking(systemId)` per player in a loop — unbatched. |
+
+---
+
+## 2. availability.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 5 | Missing auth | ⚠️ | `createAvailability` — auth check is inside the transaction, after location lookup. If location not found, rollback happens before auth check fires. Auth should precede DB work. |
+| 6 | Missing idempotency | 🚨 | No uniqueness key check. Creating two availabilities for the same location+period creates duplicate rows. |
+| 7 | Naming | ⚠️ | Resolver class named `AvailabilitysResolver` (typo: double-s). |
+
+---
+
+## 3. calculate-index.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 8 | Auth | ✅ | No mutations. Read-only. |
+| 9 | N+1 | ✅ | Calculation performed in service layer. |
+
+---
+
+## 4. claim.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 10 | Auth | ✅ | `edit:claims` checked before transaction. |
+| 11 | Duplication | ⚠️ | `assignClaim` and `assignClaims` share identical addClaim/removeClaim logic. Extract to private method. |
+
+---
+
+## 5. club-membership.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 12 | Auth | ⚠️ | `clubPlayerMemberships` is a **query** requiring `change:transfer`. Unusual — auth on read-only operations prevents viewing historical transfer data by non-admin. Intentional, but worth reviewing with product. |
+| 13 | N+1 | 🚨 | `club()` and `player()` ResolveFields call `membership.getClub()` / `membership.getPlayer()` per row. With 100 memberships → 200 extra queries. Use DataLoader or eager-load with `include`. |
+
+---
+
+## 6. club.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 14 | Auth | ✅ | All mutations check permissions. |
+| 15 | Idempotency | ✅ | `addPlayerToClub` uses `upsertMembership` service. |
+| 16 | N+1 | ⚠️ | `players()` ResolveField calls `club.getPlayers()` per club row. Acceptable if clubs are typically queried individually. |
+
+---
+
+## 7. comment.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 17 | Idempotency | ✅ | `addComment` uses `findOrCreate`. |
+| 18 | Auth | ✅ | Permission checked via `linkId_change:comment`. |
+
+---
+
+## 8. cronJob.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 19 | Code quality | ⚠️ | `_cronsService.onModuleInit()` called before `transaction.commit()`. If commit fails, cron jobs are re-initialized against stale DB state. Move call after commit. |
+| 20 | Auth | ✅ | `change:job` checked. |
+
+---
+
+## 9. event/competition/draw.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 21 | Auth | ✅ | `edit:competition` checked for mutations. |
+| 22 | N+1 | ⚠️ | `encounterCompetitions()` ResolveField returns `draw.getEncounterCompetitions()` per draw row. |
+
+---
+
+## 10. event/competition/encounter-change.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 23 | Code quality | ⚠️ | `addChangeEncounter` is 200+ lines. Extract date-change logic and acceptance logic into dedicated private methods (partially done with `processAcceptedEncounterChange`). |
+| 24 | Auth | ✅ | Auth checked via home/away club permission before transaction. |
+| 25 | Code quality | ⚠️ | `syncQueue.add` failure after commit is silently swallowed (`catch` logs but doesn't rethrow). No retry or dead-letter mechanism. |
+
+---
+
+## 11. event/competition/encounter.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 26 | N+1 | 🚨 | `encounterChange()` ResolveField calls `encounter.getEncounterChange()` per encounter. `games()` ResolveField calls `encounter.getGames()` per encounter. Both should use DataLoader. |
+| 27 | Auth | ✅ | Mutations gate on club permissions. |
+
+---
+
+## 12. event/competition/enrollment.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 28 | Auth | ✅ | Uses `GraphQLError` with `ErrorCode.PERMISSION_DENIED` — compliant with Constitution Principle II. |
+| 29 | Idempotency | ✅ | Returns `EnrollmentResult` with `alreadyExisted` — compliant with Constitution Principle III. |
+
+---
+
+## 13. event/competition/event.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 30 | Auth | ✅ | All mutations check `edit:competition`, `delete:competition`, `re-sync:points`. |
+| 31 | Duplication | 🚨 | `addGamePointsForSubEvents` / `removeGamePointsForSubEvents` are duplicated almost verbatim in `event/tournament/event.resolver.ts` and `ranking/rankingSystemGroup.resolver.ts`. Extract to shared service in `backend-ranking`. |
+| 32 | N+1 | ⚠️ | `copyEventCompetition` iterates all sub-events/draws/encounters in nested loops without bulk operations. |
+
+---
+
+## 14. event/competition/submit-enrollment.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 33 | Auth | ✅ | Permission checked. |
+| 34 | Code quality | ✅ | Delegates to service layer. |
+
+---
+
+## 15. event/entry.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 35 | N+1 | ⚠️ | `players()` ResolveField calls `eventEntry.getPlayers()` per entry row. |
+| 36 | Auth | ✅ | Read-only queries are public. |
+
+---
+
+## 16. event/tournament/draw.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 37 | Auth | ✅ | `re-sync:points`, `sync:tournament` checked. |
+| 38 | Duplication | 🚨 | `recalculateDrawTournamentRankingPoints` logic duplicated in subevent and event tournament resolvers. Extract to `PointsService`. |
+| 39 | N+1 | ⚠️ | `games()` ResolveField calls `draw.getGames()` per draw. |
+
+---
+
+## 17. event/tournament/event.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 40 | Auth | ✅ | `edit-any:tournament`, `delete-any:tournament`, `re-sync:points`, `sync:tournament` checked. |
+| 41 | Duplication | 🚨 | `addGamePointsForSubEvents` / `removeGamePointsForSubEvents` duplicated — same as finding #31. |
+
+---
+
+## 18. event/tournament/subevent.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 42 | Auth | ✅ | Mutations guarded by `re-sync:points`, `sync:tournament`. |
+| 43 | Duplication | 🚨 | `recalculateSubEventTournamentwRankingPoints` repeats the same points-recalculation pattern from draw and event resolvers. |
+| 44 | Naming | ⚠️ | Method name `recalculateSubEventTournamentwRankingPoints` has double-letter typo (`...Tournamentw...`). |
+
+---
+
+## 19. faq.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 45 | Auth | ✅ | `add:faq` / `edit:faq` checked. |
+| 46 | Bug | ⚠️ | `faq(id)` query returns `null` instead of throwing `NotFoundException`. Inconsistent with most other `*Resolver.entity(id)` queries which throw. Client must handle both null and throw. |
+
+---
+
+## 20. game.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 47 | Auth | ✅ | Mutations check club/admin permissions. |
+| 48 | N+1 | ⚠️ | `players()` ResolveField calls game association per game row. |
+
+---
+
+## 21. lastRankingPlace.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 49 | Auth | ✅ | No active mutations (commented out). |
+| 50 | Code quality | ⚠️ | Two commented-out `@Mutation` blocks left in source — dead code. Remove or implement. |
+
+---
+
+## 22. location.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 51 | Auth | ✅ | `${clubId}_edit:location` checked. |
+| 52 | N+1 | ⚠️ | `club()` ResolveField calls `location.getClub()` per location. |
+
+---
+
+## 23. notification.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 53 | Auth | ⚠️ | `updateNotification` uses `sendToId !== user.id` instead of `hasAnyPermission`. No admin override path — admins cannot update any notification on behalf of users. |
+| 54 | Bug | ⚠️ | Transaction is started before the NotFoundException check on `findByPk`. If notification not found, `rollback()` is called from the catch, but the transaction was opened unnecessarily. Minor resource waste. |
+
+---
+
+## 24. player.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 55 | Auth | ✅ | `add:player`, `edit:player`, `${playerId}_edit:player` checked on mutations. |
+| 56 | N+1 | ⚠️ | `games()` ResolveField returns `player.getGames()` per player. Acceptable for single-player views, problematic for list queries. |
+
+---
+
+## 25. rankingPlace.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 57 | Auth | ✅ | Read-only resolver. |
+| 58 | N+1 | ✅ | Queries use ListArgs/findOptions with filters. |
+
+---
+
+## 26. rankingPoint.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 59 | Auth | ✅ | Read-only resolver. |
+
+---
+
+## 27. rankingSystem.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 60 | Auth | ✅ | `edit:ranking` checked. |
+| 61 | Duplication | ⚠️ | `getRankingGroups` ResolveField duplicates logic available via `rankingSystemGroup.resolver.ts`. |
+
+---
+
+## 28. rankingSystemGroup.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 62 | Auth | ✅ | `add:event` / `remove:event` checked. |
+| 63 | Duplication | 🚨 | `addGamePointsForSubEvents` / `removeGamePointsForSubEvents` third copy — see finding #31. |
+| 64 | Bug | ⚠️ | `removeSubEventsToRankingGroup` calls `addGamePointsForSubEvents` (not `removeGamePointsForSubEvents`) when removing subevents — copy-paste error. Points are added instead of removed. |
+
+---
+
+## 29. role.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 65 | Auth | ⚠️ | Auth checked AFTER `findByPk` in `updateRole` and `deleteRole`. If role doesn't exist, `NotFoundException` is thrown before the permission check — leaks information about role existence to unauthorized callers. |
+| 66 | Duplication | ⚠️ | `addPlayerToRole`, `removePlayerFromRole`, `updateRolePlayers` share similar auth check patterns. Extract `requireRoleEditPermission(user, dbRole)` helper. |
+
+---
+
+## 30. service.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 67 | Auth | ✅ | Read-only resolver. No mutations. |
+
+---
+
+## 31. setting.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 68 | Auth | ✅ | `change:settings` checked. |
+| 69 | Idempotency | ✅ | `updateEnrollmentSetting` — correct upsert pattern. |
+
+---
+
+## 32. team.resolver.ts
+
+| # | Category | Severity | Finding |
+|---|----------|----------|---------|
+| 70 | Auth | ✅ | `createTeam` uses `GraphQLError` + `ErrorCode.PERMISSION_DENIED`. |
+| 71 | Idempotency | ✅ | `createTeam` returns `TeamResult { alreadyExisted }` — compliant with Constitution Principle III. |
+| 72 | N+1 | ⚠️ | `players()` ResolveField branches on `teamAssociationService.getPlayers()` vs `team.getPlayers()`. Both are per-row. |
+
+---
+
+## 33. player/notification.resolver.ts → (see #23 above)
+
+*(File lives under `/notification/` not `/player/`; merged above.)*
+
+---
+
+## Priority Findings Summary
+
+### 🚨 Critical (fix before next production incident)
+
+| ID | Finding |
+|----|---------|
+| #64 | `removeSubEventsToRankingGroup` calls `addGamePoints` instead of `removeGamePoints` — ranking points not removed when subevents removed from group. |
+| #31/#41/#63 | `addGamePointsForSubEvents` duplicated 3× across resolvers — diverged already. Centralise in `PointsService`. |
+| #13 | `club-membership.resolver.ts` — N+1: `getClub()` + `getPlayer()` per membership row. |
+| #26 | `encounter.resolver.ts` — N+1: `getEncounterChange()` + `getGames()` per encounter row. |
+
+### ⚠️ High (address in next sprint)
+
+| ID | Finding |
+|----|---------|
+| #19 | `cronJob` — `onModuleInit()` called before `commit()`. Move post-commit. |
+| #3 | `assembly` — error swallowed as `null`; real DB errors are invisible to clients. |
+| #65 | `role` — auth after `findByPk` leaks existence info. |
+| #6 | `availability` — no uniqueness check on create; duplicate rows possible. |
+| #46 | `faq(id)` returns `null` instead of `NotFoundException` — inconsistent contract. |
+
+### ⚠️ Medium (backlog)
+
+| ID | Finding |
+|----|---------|
+| #11 | `claim` — `assignClaim`/`assignClaims` duplication. |
+| #20 | Dead code in `lastRankingPlace.resolver.ts`. |
+| #44 | Typo: `recalculateSubEventTournamentwRankingPoints`. |
+| #29/#66 | `role` resolver auth-after-lookup and duplicated permission helpers. |
+| #53 | `notification` auth — no admin override path. |
+
+---
+
+## Idempotency Compliance (Constitution Principle III)
+
+| Resolver | Create Mutation | Idempotent? | Notes |
+|----------|----------------|-------------|-------|
+| `team` | `createTeam` | ✅ | Returns `TeamResult { alreadyExisted }` |
+| `enrollment` | `createEnrollment` | ✅ | Returns `EnrollmentResult { alreadyExisted }` |
+| `assembly` | `createAssembly` | ⚠️ | Uses `findOrCreate` but returns entity, not `alreadyExisted` flag |
+| `comment` | `addComment` | ⚠️ | Uses `findOrCreate` but no `alreadyExisted` flag |
+| `club` | `createClub` | ❌ | No uniqueness check; duplicate slugs possible |
+| `faq` | `createFaq` | ❌ | No uniqueness key; duplicates possible |
+| `availability` | `createAvailability` | ❌ | No uniqueness key |
+| `location` | `createLocation` | ❌ | No uniqueness key |
+| `role` | `createRole` | ❌ | No uniqueness key |
+| `player` | `createPlayer` | ❌ | Check memberId uniqueness exists in DB but not returned |
+
+**Trivial fixes applied in this PR** (≤5 lines, no model/schema change): none — all idempotency gaps require schema changes or result type additions, violating the trivial-fix threshold.

--- a/specs/032-resolver-test-coverage/checklists/requirements.md
+++ b/specs/032-resolver-test-coverage/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Resolver Test Coverage
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec passes all items. Ready for `/speckit-plan`.

--- a/specs/032-resolver-test-coverage/data-model.md
+++ b/specs/032-resolver-test-coverage/data-model.md
@@ -1,0 +1,176 @@
+# Data Model: Resolver Test Coverage
+
+**Branch**: `032-resolver-test-coverage` | **Date**: 2026-06-08
+
+No new persistent entities. This document maps the test infrastructure "entities" — the stub shapes and module wiring for each resolver under test.
+
+---
+
+## Test infrastructure types
+
+### MockTransaction
+
+```typescript
+{ commit: jest.Mock; rollback: jest.Mock }
+// Created fresh in each beforeEach:
+mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
+```
+
+### buildUser helper
+
+```typescript
+const buildUser = (allowed: boolean) =>
+  ({ hasAnyPermission: jest.fn().mockResolvedValue(allowed) }) as unknown as Player;
+```
+
+### Sequelize stub (with transaction)
+
+```typescript
+{ provide: Sequelize, useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) } }
+```
+
+### Sequelize stub (no mutations needed)
+
+```typescript
+{ provide: Sequelize, useValue: { transaction: jest.fn() } }
+```
+
+### Bull Queue stub
+
+```typescript
+import { getQueueToken } from '@nestjs/bull';
+import { SyncQueue } from '@badman/backend-queue';
+
+{ provide: getQueueToken(SyncQueue), useValue: { add: jest.fn() } }
+```
+
+---
+
+## Per-resolver TestingModule provider map
+
+### Group A — Sequelize only
+
+Resolvers: `availability`, `faq`, `notification`, `claim`, `role`
+
+```typescript
+providers: [
+  <Name>Resolver,
+  { provide: Sequelize, useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) } },
+]
+```
+
+### Group B — No constructor (no DI)
+
+Resolvers: `club-membership` (ClubPlayerMembershipsResolver), `service` (ServiceResolver)
+
+```typescript
+providers: [
+  <Name>Resolver,
+  // No Sequelize needed — resolver uses model statics only, no injected deps
+]
+```
+
+### Group C — Sequelize + one service
+
+Resolvers: `cronJob` (+ CronService), `rankingSystemGroup` (+ PointsService)
+
+```typescript
+// cronJob:
+providers: [
+  CronJobResolver,
+  { provide: Sequelize, useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) } },
+  { provide: CronService, useValue: { listCrons: jest.fn(), updateCron: jest.fn() } },
+]
+
+// rankingSystemGroup:
+providers: [
+  RankingSystemGroupResolver,
+  { provide: Sequelize, useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) } },
+  { provide: PointsService, useValue: { addGamePointsForSubEvents: jest.fn(), removeGamePointsForSubEvents: jest.fn() } },
+]
+```
+
+### Group D — Sequelize + PointsService + SyncQueue + RankingSystemService
+
+Resolvers: `event/competition/event`, `event/tournament/draw`, `event/tournament/event`, `event/tournament/subevent`
+
+```typescript
+providers: [
+  <Name>Resolver,
+  { provide: Sequelize, useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) } },
+  { provide: PointsService, useValue: { addGamePointsForSubEvents: jest.fn(), removeGamePointsForSubEvents: jest.fn() } },
+  { provide: getQueueToken(SyncQueue), useValue: { add: jest.fn() } },
+  { provide: RankingSystemService, useValue: { getById: jest.fn(), invalidate: jest.fn() } },
+]
+```
+
+### Group E — Assembly resolver (no Sequelize)
+
+```typescript
+providers: [
+  AssemblyResolver,
+  { provide: AssemblyValidationService, useValue: { validate: jest.fn() } },
+  { provide: RankingSystemService, useValue: { getById: jest.fn() } },
+]
+```
+
+### Group F — EncounterChangeResolver (complex)
+
+```typescript
+providers: [
+  EncounterChangeResolver,
+  { provide: Sequelize, useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) } },
+  { provide: getQueueToken(SyncQueue), useValue: { add: jest.fn() } },
+  { provide: NotificationService, useValue: { notifyEncounterChange: jest.fn() } },
+  { provide: EncounterValidationService, useValue: { validate: jest.fn() } },
+]
+```
+
+---
+
+## Minimum required test cases per resolver
+
+| Resolver | Query tests | Mutation tests | ResolveField tests |
+|----------|-------------|----------------|-------------------|
+| availability | 2 (by id, list) | 2 (create, update) × 3 cases each | 2 (days, exceptions) |
+| club-membership | 1 (list) | — | 2 (club, player) |
+| cronJob | 1 (list) | 1 (update) × 3 cases | 1 (nextRun) |
+| assembly | 1 (validate) | 1 (create) × 3 cases | 2 (titularsPlayers, baseTeamPlayers) |
+| encounter-change | 2 (by id, list) | 2 (add, update) × 3 cases each | 1 (dates) |
+| event/comp/event | 3 (by id, list, seasons) | 2 (update, copy) × 3 cases each | 4 field resolvers |
+| tournament/draw | 2 (by id, list) | 2 (recalculate, sync) × 2 cases each | 3 field resolvers |
+| tournament/event | 2 (by id, list) | 3 (update, remove, recalculate) × 3 cases | 1 field resolver |
+| tournament/subevent | 2 (by id, list) | 2 (recalculate, sync) × 2 cases each | 3 field resolvers |
+| faq | 2 (by id, list) | 3 (create, update, delete) × 3 cases each | — |
+| notification | 2 (by id, list) | 1 (update) × 3 cases | 4 (encounter, competition, tournament, club) |
+| rankingSystemGroup | 2 (by id, list) | 2 (add, remove subEvents) × 3 cases each | 2 (subEventCompetitions, subEventTournaments) |
+| claim | 2 (by id, list) | 2 (assign, assignBulk) × 3 cases each | — |
+| role | 2 (by id, list) | 4 (create, update, delete, addPlayer, removePlayer, updatePlayers) × 3 cases | 2 (players, claims) |
+| service | 1 (list) | — | — |
+
+**Standard 3-case mutation coverage**: unauthorized → `UnauthorizedException`, not-found → `NotFoundException`, success → commit called.
+
+---
+
+## Audit document structure
+
+File: `specs/032-resolver-test-coverage/audit.md`
+
+```markdown
+# Resolver Audit
+
+## Summary
+| Category | Count |
+|----------|-------|
+| missing-auth | N |
+| duplication | N |
+| performance | N |
+| code-quality | N |
+| bug | N |
+
+## Findings
+
+| # | Category | File | Line | Issue | Suggested Remedy | Status |
+|---|----------|------|------|-------|-----------------|--------|
+| 1 | missing-auth | ... | ... | ... | ... | open/fixed/deferred |
+```

--- a/specs/032-resolver-test-coverage/plan.md
+++ b/specs/032-resolver-test-coverage/plan.md
@@ -1,0 +1,244 @@
+# Implementation Plan: Resolver Test Coverage
+
+**Branch**: `032-resolver-test-coverage` | **Date**: 2026-06-08 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `specs/032-resolver-test-coverage/spec.md`
+
+## Summary
+
+Add unit test files for the 15 GraphQL resolvers currently missing `.resolver.spec.ts` files in `libs/backend/graphql`. Tests are written contract-first (from method signatures and GraphQL types, not by reading the implementation). A second pass validates implementation details. In parallel, produce a committed `audit.md` covering all 33 resolvers, and wire a `test:coverage:all` npm script that runs every non-legacy test suite with lcov + text reporting and an enforced coverage threshold.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (Node 20)  
+**Primary Dependencies**: NestJS, `@nestjs/testing`, Jest (via `@nx/jest`), Sequelize-typescript, `@badman/backend-database`, `@badman/backend-authorization`  
+**Storage**: PostgreSQL via Sequelize (mocked in tests — no real DB)  
+**Testing**: Jest, configured per-lib via `jest.config.ts`; root `jest.config.ts` uses `getJestProjectsAsync()`; preset in `jest.preset.js`  
+**Target Platform**: Node 20, Linux CI (GitHub Actions)  
+**Project Type**: NestJS Nx monorepo — backend GraphQL lib  
+**Performance Goals**: New test suite must not add more than 60 s to baseline wall-clock  
+**Constraints**: No real DB or Redis; all mocks in-memory; `forceExit: true` already set in preset  
+**Scale/Scope**: 15 new `.resolver.spec.ts` files; 1 new `jest.coverage.config.ts`; 1 `audit.md`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| **I — Code-First GraphQL** | ✅ Pass | No new models or SDL; tests only |
+| **II — Translation Discipline** | ✅ Pass | No i18n changes |
+| **III — Transactional Mutations** | ✅ Pass | Tests *verify* the transaction pattern; no mutations added |
+| **IV — Resolver Test Discipline** | ✅ Primary target | This PR closes the test gap |
+| **V — Legacy Frontend Boundary** | ✅ Pass | Coverage command explicitly excludes `apps/badman/` and `libs/frontend/` |
+
+No violations. No Complexity Tracking required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/032-resolver-test-coverage/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── audit.md             # Committed audit artifact (produced during implementation)
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+# New test files (co-located with resolvers)
+libs/backend/graphql/src/resolvers/
+├── availability/
+│   └── availability.resolver.spec.ts          [NEW]
+├── club/
+│   └── club-membership.resolver.spec.ts       [NEW]
+├── cronJobs/
+│   └── cronJob.resolver.spec.ts               [NEW]
+├── event/competition/
+│   ├── assembly.resolver.spec.ts              [NEW]
+│   ├── encounter-change.resolver.spec.ts      [NEW]
+│   └── event.resolver.spec.ts                 [NEW]
+├── event/tournament/
+│   ├── draw.resolver.spec.ts                  [NEW]
+│   ├── event.resolver.spec.ts                 [NEW]
+│   └── subevent.resolver.spec.ts              [NEW]
+├── faq/
+│   └── faq.resolver.spec.ts                   [NEW]
+├── notification/
+│   └── notification.resolver.spec.ts          [NEW]
+├── ranking/
+│   └── rankingSystemGroup.resolver.spec.ts    [NEW]
+├── security/
+│   ├── claim.resolver.spec.ts                 [NEW]
+│   └── role.resolver.spec.ts                  [NEW]
+└── services/
+    └── service.resolver.spec.ts               [NEW]
+
+# Coverage configuration
+jest.coverage.config.ts                        [NEW]
+
+# Package script update
+package.json                                   [UPDATE — add test:coverage:all]
+
+# Documentation updates
+AGENTS.md                                      [UPDATE — coverage threshold docs]
+```
+
+**Structure Decision**: All test files co-located beside their resolver source per Constitution Principle IV and CLAUDE.md resolver test convention. Coverage config is a separate root-level file rather than modifying the shared `jest.config.ts`, so the coverage command is opt-in and does not slow normal `nx test` runs.
+
+---
+
+## Phase 0: Research
+
+**Output**: `specs/032-resolver-test-coverage/research.md`
+
+### Research questions
+
+1. **Coverage config approach**: Should the `test:coverage:all` script use `nx run-many --target=test --all --coverage` filtered by project tags, or a dedicated root `jest.coverage.config.ts` that calls `getJestProjectsAsync()` with path-based exclusions?
+
+2. **Legacy exclusion mechanism**: Jest `testPathIgnorePatterns` vs `coveragePathIgnorePatterns` — which must be set and where to ensure `apps/badman/` and `libs/frontend/` are absent from both test execution and the coverage report?
+
+3. **Integration test exclusion**: The preset already has `passWithNoTests: true`. Confirm that adding `testPathIgnorePatterns: ['integration\\.spec\\.ts']` in the coverage config is sufficient to skip integration tests without affecting normal runs.
+
+4. **lcov + text reporters**: Confirm `coverageReporters: ['text', 'lcov']` works with `@nx/jest` and `ts-jest`; identify the output directory for the lcov file.
+
+5. **Resolver dependency injection audit**: For each of the 15 resolvers, what NestJS providers (beyond `Sequelize`) must be added to `Test.createTestingModule`? Some resolvers inject Bull queue services, ranking services, or loader services that will need stubs.
+
+---
+
+## Phase 1: Design & Contracts
+
+**Prerequisites**: `research.md` complete
+
+### Data model
+
+No new persistent entities. The key "entities" for this feature are test infrastructure types:
+
+| Concept | Type | Description |
+|---------|------|-------------|
+| `MockTransaction` | Local type | `{ commit: jest.Mock; rollback: jest.Mock }` |
+| `UserWithPermission` | Helper fn | Returns `Player` stub with `hasAnyPermission: jest.fn().mockResolvedValue(allowed)` |
+| `ModelSpy` | jest.SpyInstance | `jest.spyOn(Model, 'staticMethod')` — restored in `afterEach` |
+| Provider stub | Object literal | Minimal stub for injected services (queue, loader, ranking service) |
+
+See `data-model.md` for the per-resolver provider map (injected services per resolver → stub shape).
+
+### Test structure per resolver (standard template)
+
+```typescript
+describe('<Name>Resolver', () => {
+  let resolver: <Name>Resolver;
+  let mockTransaction: { commit: jest.Mock; rollback: jest.Mock };
+
+  const buildUser = (allowed: boolean) =>
+    ({ hasAnyPermission: jest.fn().mockResolvedValue(allowed) }) as unknown as Player;
+
+  beforeEach(async () => {
+    mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
+    const module = await Test.createTestingModule({
+      providers: [
+        <Name>Resolver,
+        { provide: Sequelize, useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) } },
+        // ... resolver-specific service stubs
+      ],
+    }).compile();
+    resolver = module.get(<Name>Resolver);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  // --- Queries ---
+  it('returns data on happy path', ...)
+  it('returns null/[] when not found', ...)
+
+  // --- Mutations (write operations) ---
+  it('throws UnauthorizedException for unauthorized user', ...)
+  it('throws NotFoundException when entity not found', ...)
+  it('commits transaction on success', ...)
+  it('rolls back transaction on error', ...)
+
+  // --- ResolveFields ---
+  it('<fieldName>: returns associated entity', ...)
+});
+```
+
+### Coverage command design
+
+**File**: `jest.coverage.config.ts` (root)
+
+```typescript
+import { getJestProjectsAsync } from '@nx/jest';
+
+export default async () => ({
+  projects: await getJestProjectsAsync(),
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    'apps/badman/',
+    'libs/frontend/',
+    '\\.integration\\.spec\\.ts$',
+  ],
+  coveragePathIgnorePatterns: [
+    '/node_modules/',
+    'apps/badman/',
+    'libs/frontend/',
+  ],
+  coverageReporters: ['text', 'lcov'],
+  coverageDirectory: '<rootDir>/coverage/all',
+  collectCoverage: true,
+  coverageThreshold: {
+    global: {
+      lines: 0,       // PLACEHOLDER — update after first run (see AGENTS.md)
+      branches: 0,    // PLACEHOLDER
+      functions: 0,   // PLACEHOLDER
+      statements: 0,  // PLACEHOLDER
+    },
+  },
+});
+```
+
+**npm script** (`package.json`):
+```json
+"test:coverage:all": "npx jest --config jest.coverage.config.ts --forceExit"
+```
+
+### Audit document structure
+
+`specs/032-resolver-test-coverage/audit.md` sections:
+
+1. **Summary** — total findings by category
+2. **Missing Authorization** — resolvers that write without `user.hasAnyPermission()`
+3. **Duplication** — near-identical logic blocks across resolvers
+4. **Performance Quick Wins** — N+1-prone field resolvers lacking dataloader usage; sequential queries that could be batched
+5. **Code Quality** — structural issues (dead code, inconsistent error handling, logging gaps)
+6. **Bugs** — behavioral discrepancies found during first-pass testing
+7. **Deferred Follow-up** — findings requiring a separate feature spec (linked when created)
+
+Each finding: `| Category | File | Line | Issue | Suggested Remedy | Status |`
+
+### Agent context update
+
+Update the `<!-- SPECKIT START -->` / `<!-- SPECKIT END -->` block in `CLAUDE.md` / `AGENTS.md` to reference `specs/032-resolver-test-coverage/plan.md`.
+
+Also add to `AGENTS.md` under **Common Commands**:
+
+```bash
+# Run full coverage report (all non-legacy libs, no DB required)
+npm run test:coverage:all
+
+# Update coverage threshold after adding tests:
+# 1. Run: npm run test:coverage:all
+# 2. Note the "Lines" % from the console summary
+# 3. Round down to nearest 5%
+# 4. Update coverageThreshold.global.* in jest.coverage.config.ts
+# 5. Commit the change
+```
+
+---
+
+## Complexity Tracking
+
+No constitution violations. No complexity tracking required.

--- a/specs/032-resolver-test-coverage/quickstart.md
+++ b/specs/032-resolver-test-coverage/quickstart.md
@@ -1,0 +1,81 @@
+# Quickstart: Resolver Test Coverage
+
+**Branch**: `032-resolver-test-coverage`
+
+---
+
+## Running the new tests
+
+```bash
+# Run all backend-graphql tests (includes new resolver specs)
+nx test backend-graphql
+
+# Run only the 15 new resolver specs
+nx test backend-graphql --testPathPattern="availability|club-membership|cronJob|assembly|encounter-change|event\.resolver|draw\.resolver|subevent\.resolver|faq|notification|rankingSystemGroup|claim|role|service"
+
+# Run a single resolver spec
+npx jest --config libs/backend/graphql/jest.config.ts --testPathPattern="faq.resolver"
+```
+
+---
+
+## Running the full coverage report
+
+```bash
+# Full coverage across all non-legacy libs and apps (no DB required)
+npm run test:coverage:all
+```
+
+Output:
+- **Console**: text summary table per lib
+- **Files**: `coverage/libs/<name>/lcov.info` and `coverage/apps/<name>/lcov.info` per project
+
+---
+
+## Updating the coverage threshold
+
+After running `npm run test:coverage:all`, note the `Lines %` from the `backend-graphql` summary line. Round down to the nearest 5% and update:
+
+**File**: `libs/backend/graphql/jest.config.ts`
+
+```typescript
+coverageThreshold: {
+  global: {
+    lines: <new-value>,       // e.g. 65
+    branches: <new-value>,
+    functions: <new-value>,
+    statements: <new-value>,
+  },
+},
+```
+
+Commit the change together with any test additions that caused the improvement.
+
+---
+
+## Adding a new resolver spec
+
+1. Create `<resolver-name>.resolver.spec.ts` beside `<resolver-name>.resolver.ts`
+2. Follow the pattern in `libs/backend/graphql/src/resolvers/setting/setting.resolver.spec.ts`
+3. Consult `specs/032-resolver-test-coverage/data-model.md` for the correct provider stub shape
+4. Run `nx test backend-graphql --testPathPattern="<resolver-name>"` to verify
+
+---
+
+## Reading the audit
+
+`specs/032-resolver-test-coverage/audit.md` is a permanent artifact. When a finding is addressed in a separate PR:
+1. Update its `Status` column to `fixed` (or `deferred — specs/NNN-...`)
+2. Commit the change alongside the fix PR
+
+---
+
+## Key files changed by this feature
+
+| File | Change |
+|------|--------|
+| `libs/backend/graphql/src/resolvers/*/` | 15 new `*.resolver.spec.ts` files |
+| `libs/backend/graphql/jest.config.ts` | Added `coverageThreshold` + `coverageReporters` |
+| `package.json` | Added `test:coverage:all` script |
+| `AGENTS.md` | Added coverage command + threshold update instructions |
+| `specs/032-resolver-test-coverage/audit.md` | Permanent audit artifact |

--- a/specs/032-resolver-test-coverage/research.md
+++ b/specs/032-resolver-test-coverage/research.md
@@ -1,0 +1,109 @@
+# Research: Resolver Test Coverage
+
+**Branch**: `032-resolver-test-coverage` | **Date**: 2026-06-08
+
+---
+
+## R1 — Coverage command approach
+
+**Decision**: Use `nx run-many --target=test --all --exclude=<angular-projects> --coverage --skip-nx-cache`
+
+**Rationale**: The Angular projects (`apps/badman`, `libs/frontend/*`) each have a `jest.config.ts` using `jest-preset-angular`, which would be picked up by `getJestProjectsAsync()` in a root jest config. Angular's transformer is incompatible with the NestJS test context, causing compile errors even if `testPathIgnorePatterns` excludes test files. Using `nx run-many` with explicit `--exclude` avoids this entirely: nx knows which projects use which executors and runs each in its own context. Coverage is produced per-lib under `coverage/libs/...` and `coverage/apps/...` — standard for nx monorepos.
+
+**Alternatives considered**:
+- Root `jest.coverage.config.ts` with `getJestProjectsAsync()` + `testPathIgnorePatterns`: rejected because Angular jest configs are loaded even when no tests run, causing transformer conflicts.
+- Manual project list in root config: rejected — maintenance burden every time a lib is added.
+
+**Excluded projects** (Angular legacy):
+- `badman` (`apps/badman/`)
+- `frontend-models`, `frontend-components`, `frontend-html-injects`, `frontend-vitals`, `frontend-translation`, `frontend-auth`, `frontend-excel`, `frontend-pdf`, `frontend-utils`, `frontend-graphql`, `frontend-queue`, `frontend-cp`, `frontend-twizzit`, `frontend-seo`, `frontend-club`, `frontend-ranking`, `frontend-role`, `frontend-general`, `frontend-tournament`, `frontend-transfers`, `frontend-team`, `frontend-job`, `frontend-rule`, `frontend-team-assembly`, `frontend-change-encounter`, `frontend-team-enrollment`, `frontend-event`, `frontend-notifications`, `frontend-player`
+
+The `badman-e2e`, `badman-e2e-desktop`, `badman-e2e-mobile` apps have no jest config (Playwright only) — `nx run-many --all` will skip them automatically (`passWithNoTests: true`).
+
+**Final npm script** (`package.json`):
+```json
+"test:coverage:all": "nx run-many --target=test --all --coverage --skip-nx-cache --exclude=badman,frontend-models,frontend-components,frontend-html-injects,frontend-vitals,frontend-translation,frontend-auth,frontend-excel,frontend-pdf,frontend-utils,frontend-graphql,frontend-queue,frontend-cp,frontend-twizzit,frontend-seo,frontend-club,frontend-ranking,frontend-role,frontend-general,frontend-tournament,frontend-transfers,frontend-team,frontend-job,frontend-rule,frontend-team-assembly,frontend-change-encounter,frontend-team-enrollment,frontend-event,frontend-notifications,frontend-player"
+```
+
+---
+
+## R2 — Legacy exclusion: test execution vs coverage report
+
+**Decision**: `--exclude` flag on `nx run-many` handles test execution; each lib's jest config controls its own `coverageDirectory`. No additional `coveragePathIgnorePatterns` needed because the excluded projects never run at all.
+
+**Rationale**: `nx run-many --exclude` prevents those projects from being invoked entirely. Coverage can only be collected for code that is tested. Since the Angular projects are never invoked, they produce no coverage data and no files appear in the output.
+
+---
+
+## R3 — Integration test exclusion
+
+**Decision**: Add `testPathIgnorePatterns: ['\\.integration\\.spec\\.ts$']` to the backend-graphql `jest.config.ts`, so it applies to both `nx test backend-graphql` and `test:coverage:all`.
+
+**Rationale**: The pattern `*.integration.spec.ts` already guards themselves with `process.env["RUN_INTEGRATION_TESTS"] === "1"` — they skip internally. But including them in the coverage run could still add startup time. Adding the ignore pattern is clean and has no side effects. The coverage command does not pass `RUN_INTEGRATION_TESTS=1`, so integration tests are double-skipped.
+
+---
+
+## R4 — Coverage reporters (lcov + text)
+
+**Decision**: Set `coverageReporters: ['text', 'lcov']` in each non-legacy lib's jest config **only when running coverage**. Since this is an nx monorepo and each project has its own jest config, the coverage reporter is already configured at the lib level. No root-level change is needed.
+
+**Rationale**: `text` prints the table to console. `lcov` writes `lcov.info` under each lib's `coverageDirectory`. CI tools (Codecov, SonarCloud) can consume multiple lcov files by globbing `coverage/**/lcov.info`.
+
+**Output locations** (per lib, example):
+- `coverage/libs/backend/graphql/lcov.info`
+- `coverage/libs/backend/database/lcov.info`
+- `coverage/apps/api/lcov.info`
+
+**Note**: The backend-graphql jest config already has `coverageDirectory: '../../../coverage/libs/backend/graphql'`. Adding `coverageReporters` to it is sufficient.
+
+---
+
+## R5 — Provider injection map per resolver (TestingModule stubs)
+
+| Resolver | Injected dependencies | Stub strategy |
+|----------|----------------------|---------------|
+| `availability.resolver.ts` | `Sequelize` | `{ transaction: jest.fn() }` |
+| `club-membership.resolver.ts` | none (no constructor) | `providers: [ClubPlayerMembershipsResolver]` only |
+| `cronJob.resolver.ts` | `Sequelize`, `CronService` | Sequelize stub + `{ listCrons: jest.fn(), updateCron: jest.fn() }` |
+| `assembly.resolver.ts` | `AssemblyValidationService`, `RankingSystemService` | Both as object stubs; NO Sequelize |
+| `encounter-change.resolver.ts` | `Sequelize`, `Queue (SyncQueue)`, `NotificationService`, `EncounterValidationService` | Sequelize stub + `getQueueToken(SyncQueue)` → `{ add: jest.fn() }` + service stubs |
+| `event/competition/event.resolver.ts` | `Sequelize`, `PointsService`, `Queue (SyncQueue)`, `RankingSystemService` | All stubbed |
+| `event/tournament/draw.resolver.ts` | `Sequelize`, `PointsService`, `Queue (SyncQueue)`, `RankingSystemService` | All stubbed |
+| `event/tournament/event.resolver.ts` | `Sequelize`, `PointsService`, `Queue (SyncQueue)`, `RankingSystemService` | All stubbed |
+| `event/tournament/subevent.resolver.ts` | `Sequelize`, `PointsService`, `Queue (SyncQueue)`, `RankingSystemService` | All stubbed |
+| `faq.resolver.ts` | `Sequelize` | `{ transaction: jest.fn() }` |
+| `notification.resolver.ts` | `Sequelize` | `{ transaction: jest.fn() }` |
+| `rankingSystemGroup.resolver.ts` | `Sequelize`, `PointsService` | Both stubbed |
+| `claim.resolver.ts` | `Sequelize` | `{ transaction: jest.fn() }` |
+| `role.resolver.ts` | `Sequelize` | `{ transaction: jest.fn() }` |
+| `service.resolver.ts` | none (no constructor) | `providers: [ServiceResolver]` only |
+
+**Bull queue injection pattern** (from existing tests in this codebase):
+```typescript
+import { getQueueToken } from '@nestjs/bull';
+import { SyncQueue } from '@badman/backend-queue';
+
+// In TestingModule providers:
+{ provide: getQueueToken(SyncQueue), useValue: { add: jest.fn() } }
+```
+
+---
+
+## R6 — Coverage threshold approach
+
+**Decision**: Add `coverageThreshold` to `libs/backend/graphql/jest.config.ts` only (the primary lib being tested). Start at 0% across all metrics. Measure after implementation and pin to actual value rounded down to nearest 5%.
+
+**Rationale**: Adding thresholds to all libs would fail CI for libs that have no tests (e.g., pure model/type libs). Scoping to `backend-graphql` targets exactly the lib this feature improves. Other libs can have thresholds added as their own test coverage improves in future features.
+
+**Configuration snippet** (added to `libs/backend/graphql/jest.config.ts`):
+```typescript
+coverageThreshold: {
+  global: {
+    lines: 0,       // PLACEHOLDER — update after first run
+    branches: 0,    // PLACEHOLDER
+    functions: 0,   // PLACEHOLDER
+    statements: 0,  // PLACEHOLDER
+  },
+},
+coverageReporters: ['text', 'lcov'],
+```

--- a/specs/032-resolver-test-coverage/spec.md
+++ b/specs/032-resolver-test-coverage/spec.md
@@ -1,0 +1,218 @@
+# Feature Specification: Resolver Test Coverage
+
+**Feature Branch**: `032-resolver-test-coverage`  
+**Created**: 2026-06-08  
+**Status**: Draft  
+**Input**: User description: "write tests for all of our resolvers"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Security resolvers tested (Priority: P1)
+
+Developers can trust that the claim and role resolvers behave correctly under authorized and unauthorized access — covering queries, mutations, and field resolution.
+
+**Why this priority**: Security resolvers directly guard access control. A regression here has platform-wide impact.
+
+**Independent Test**: Run `nx test backend-graphql --testPathPattern="claim|role"` and see passing tests for both resolvers.
+
+**Acceptance Scenarios**:
+
+1. **Given** an unauthorized user, **When** a mutation is called on `claim` or `role` resolver, **Then** an `UnauthorizedException` is thrown and no data is written.
+2. **Given** an authorized user, **When** `assignClaim` / `assignClaims` / `createRole` / `updateRole` / `deleteRole` / `addPlayerToRole` / `removePlayerFromRole` / `updateRolePlayers` are called, **Then** the mutation succeeds and the transaction is committed.
+3. **Given** valid IDs, **When** `claim`, `claims`, `role`, `roles` queries are called, **Then** data is returned.
+4. **Given** an invalid or missing ID, **When** a query by ID is called, **Then** `null` or an appropriate error is returned.
+
+---
+
+### User Story 2 - Event resolvers tested (Priority: P2)
+
+Developers can trust that competition and tournament event resolvers — queries, mutations, and field resolvers — behave correctly, including auth guards on write operations.
+
+**Why this priority**: Events drive the core scheduling and results domain; bugs here surface to all club administrators.
+
+**Independent Test**: Run `nx test backend-graphql --testPathPattern="event\\.resolver|draw\\.resolver|subevent\\.resolver"` and see all tests pass.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid event ID, **When** `eventCompetition` or `eventTournament` query runs, **Then** the correct entity is returned.
+2. **Given** a list query, **When** `eventCompetitions` or `eventTournaments` is called, **Then** a paged result is returned.
+3. **Given** an unauthorized user, **When** `updateEventCompetition`, `updateEventTournament`, `removeEventTournament`, `copyEventCompetition`, `syncEvent`, or `recalculate*` mutations are called, **Then** `UnauthorizedException` is thrown.
+4. **Given** an authorized user, **When** those mutations are called, **Then** the transaction commits and the updated entity is returned.
+5. **Given** a `DrawTournament` parent, **When** `eventEntries` or `games` field resolvers run, **Then** associated entities are returned.
+6. **Given** a `SubEventTournament` parent, **When** `drawTournaments` or `eventTournament` field resolvers run, **Then** the correct associations are returned.
+
+---
+
+### User Story 3 - Encounter-change resolver tested (Priority: P2)
+
+Developers can trust that `encounterChange` queries and the `addChangeEncounter` / `updateEncounterChange` mutations are covered, including authorization.
+
+**Why this priority**: Encounter rescheduling is club-facing and time-sensitive; silent regressions are hard to detect manually.
+
+**Independent Test**: Run `nx test backend-graphql --testPathPattern="encounter-change"` and see passing tests.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid ID, **When** `encounterChange` query runs, **Then** the entity is returned.
+2. **Given** list args, **When** `encounterChanges` runs, **Then** paged results are returned.
+3. **Given** an unauthorized user, **When** `addChangeEncounter` or `updateEncounterChange` is called, **Then** `UnauthorizedException` is thrown.
+4. **Given** an authorized user, **When** mutations succeed, **Then** transaction commits and updated entity is returned.
+5. **Given** an `EncounterChange` parent, **When** `dates` field resolver runs, **Then** associated dates are returned.
+
+---
+
+### User Story 4 - Availability, FAQ, Notification, CronJob, Service resolvers tested (Priority: P3)
+
+Developers can trust that all remaining resolvers — availability, FAQ, notifications, cron jobs, and services — have baseline query and mutation coverage.
+
+**Why this priority**: Lower operational criticality, but needed for full coverage and regression safety.
+
+**Independent Test**: Run `nx test backend-graphql --testPathPattern="availability|faq|notification|cronJob|service"` and see tests pass.
+
+**Acceptance Scenarios**:
+
+1. **Given** valid input, **When** any list or single-entity query runs, **Then** correct data is returned.
+2. **Given** unauthorized access, **When** any write mutation is called (createFaq, updateFaq, deleteFaq, createAvailability, updateAvailability, updateCronJob, updateNotification), **Then** `UnauthorizedException` is thrown.
+3. **Given** authorized access, **When** write mutations are called with valid data, **Then** transaction commits and the result is returned.
+4. **Given** a `CronJob` parent, **When** `nextRun` field resolver runs, **Then** a formatted date string is returned.
+
+---
+
+### User Story 5 - Assembly and RankingSystemGroup resolvers tested (Priority: P3)
+
+Developers can trust that the assembly validation query, `createAssembly` mutation, and ranking group mutations are covered.
+
+**Why this priority**: Assembly validation and ranking group changes are admin operations; correctness is required before any competition starts.
+
+**Independent Test**: Run `nx test backend-graphql --testPathPattern="assembly|rankingSystemGroup"` and see tests pass.
+
+**Acceptance Scenarios**:
+
+1. **Given** valid assembly input, **When** `validateAssembly` query runs, **Then** the validation result is returned.
+2. **Given** an unauthorized user, **When** `createAssembly`, `addSubEventsToRankingGroup`, or `removeSubEventsToRankingGroup` is called, **Then** `UnauthorizedException` is thrown.
+3. **Given** authorized access and valid IDs, **When** ranking group mutations succeed, **Then** transaction commits and the updated group is returned.
+
+---
+
+### User Story 6 - ClubMembership resolver tested (Priority: P3)
+
+Developers can trust that `clubPlayerMemberships` query and its `club` / `player` field resolvers work correctly.
+
+**Why this priority**: Club membership is a read-heavy query path with field-level associations that must be correct.
+
+**Independent Test**: Run `nx test backend-graphql --testPathPattern="club-membership"` and see tests pass.
+
+**Acceptance Scenarios**:
+
+1. **Given** list args, **When** `clubPlayerMemberships` query runs, **Then** a paged result is returned.
+2. **Given** a `ClubPlayerMembership` parent, **When** `club` field resolver runs, **Then** the associated club is returned.
+3. **Given** a `ClubPlayerMembership` parent, **When** `player` field resolver runs, **Then** the associated player is returned.
+
+---
+
+### User Story 7 - Single coverage command for CI and local use (Priority: P1)
+
+Developers and CI pipelines can run one command to produce a consolidated coverage report across the entire active codebase, excluding the legacy Angular frontend.
+
+**Why this priority**: Without a coverage gate, newly written tests provide no ongoing assurance — coverage can silently regress on future PRs.
+
+**Independent Test**: Run the coverage command locally; a coverage report is generated and exits 0. Confirm legacy `apps/badman/` and `libs/frontend/` paths are absent from the report.
+
+**Acceptance Scenarios**:
+
+1. **Given** the project root, **When** the coverage command is run, **Then** it collects coverage from all non-legacy libs and apps and exits with code 0 when thresholds are met.
+2. **Given** a CI environment, **When** the same command is run, **Then** it behaves identically to local execution with no interactive prompts required.
+3. **Given** the output, **When** the report is inspected, **Then** no paths under `apps/badman/` or `libs/frontend/` appear.
+4. **Given** coverage falls below the defined threshold, **When** the command runs, **Then** it exits non-zero so CI fails.
+
+---
+
+### User Story 8 - Audit report: missing auth, duplication, and quick wins (Priority: P2)
+
+After tests are written, a structured audit of all resolver implementations is produced — flagging gaps in authentication/authorization, duplicated logic across resolvers, and areas with quick wins in performance, deduplication, or code quality.
+
+**Why this priority**: Tests reveal surface-level behavior. The audit surfaces structural issues that tests alone won't catch, giving a prioritized action list before they compound.
+
+**Independent Test**: A written audit document (`specs/032-resolver-test-coverage/audit.md`) exists, covering all 33 resolvers, with findings grouped by category and each finding linked to a specific file and line.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resolver that performs writes but does not call `user.hasAnyPermission()`, **When** the audit runs, **Then** that resolver is flagged under "Missing Authorization".
+2. **Given** two or more resolvers with identical or near-identical logic blocks, **When** the audit runs, **Then** they are flagged under "Duplication".
+3. **Given** a resolver that issues multiple sequential queries that could be batched or that lacks dataloader usage on an N+1-prone field resolver, **When** the audit runs, **Then** it is flagged under "Performance Quick Wins".
+4. **Given** any finding, **When** it appears in the audit, **Then** it includes: resolver file path, description of the issue, and a suggested fix or next step.
+5. **Given** the audit is complete, **When** findings are reviewed, **Then** each finding is classified as: `bug`, `missing-auth`, `duplication`, `performance`, or `code-quality`.
+
+---
+
+### Edge Cases
+
+- What happens when a query by ID receives a UUID vs. a slug?
+- How are field resolvers handled when the parent has no associated data (null relations)?
+- How does a mutation behave when a transaction commit fails — is it rolled back?
+- How does `validateAssembly` respond when the assembly is invalid (returns errors vs. throws)?
+- What if a first-pass test written from the contract fails because the implementation is wrong — is that a bug or an incorrect expectation?
+- What if a resolver has no auth check but handles only read-only public data — is missing auth a finding or intentional?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Each of the 15 resolvers currently missing a `.resolver.spec.ts` file MUST receive a co-located spec file.
+- **FR-002**: Every spec file MUST follow the resolver test convention in `CLAUDE.md` (TestingModule + model static spies + auth mocks + `afterEach(jest.restoreAllMocks)`).
+- **FR-003**: Each spec MUST cover: query returns data, query returns null/empty when nothing found, mutation rejects unauthorized users, mutation succeeds and commits transaction, mutation rolls back on error.
+- **FR-004**: ResolveField methods MUST each have at least one test verifying the correct association is returned.
+- **FR-005**: Auth-guarded mutations MUST verify both the authorized and unauthorized paths.
+- **FR-006**: All tests MUST run successfully via `nx test backend-graphql` without requiring real database or external services.
+- **FR-007**: No test MUST import or instantiate real Sequelize models or a real database connection.
+- **FR-008**: Tests MUST be written from the resolver's declared interface (GraphQL schema, method names, argument shapes) — not by reading the implementation first. Implementation is consulted only in the second pass to add deeper coverage.
+- **FR-009**: Any behavioral discrepancy discovered during testing (test written from expected contract fails against actual implementation) MUST be documented as a finding. A fix MAY be applied in the same PR only if it meets all three: ≤5 lines changed, touches exactly one method, and requires no model or GraphQL schema change. All other bugs MUST be filed as separate work and linked from `audit.md`.
+- **FR-010**: After all behavioral tests pass, an audit document (`specs/032-resolver-test-coverage/audit.md`) MUST be produced covering all 33 resolvers, identifying: missing or insufficient authorization checks, duplicated logic, N+1 / performance risks, and code-quality issues. The file is committed to the repo as a permanent artifact. Findings that require follow-up work MUST be noted with a placeholder link to the feature spec that will address them.
+- **FR-011**: Each audit finding MUST include: category (`bug` / `missing-auth` / `duplication` / `performance` / `code-quality`), file path, description, and suggested remedy.
+- **FR-012**: A single npm script (e.g. `npm run test:coverage`) MUST run all non-legacy tests with coverage collection enabled, print a text summary to the console, and write an lcov report file for future CI upload integrations.
+- **FR-013**: The coverage command MUST exclude `apps/badman/` and `libs/frontend/` (legacy Angular) from both test execution and coverage collection.
+- **FR-014**: The coverage command MUST enforce a minimum line/branch/function/statement coverage threshold; falling below it MUST cause a non-zero exit code. The threshold is initially set to 0% (placeholder); it MUST be pinned to the measured post-implementation value (rounded down to nearest 5%) in the same PR that introduces the tests.
+- **FR-016**: Both the project README and the AI harness context file (CLAUDE.md / AGENTS.md) MUST document how to update the coverage threshold, including where the value lives and the command to re-measure current coverage.
+- **FR-015**: The same command MUST be usable in CI without modification (no interactive prompts, no TTY requirements).
+
+### Key Entities
+
+- **Resolver spec file**: Co-located `*.resolver.spec.ts` file exercising one resolver in isolation.
+- **Auth mock**: Fake `Player` instance with `hasAnyPermission` jest.fn() returning `true` or `false`.
+- **Model mock**: `jest.spyOn(Model, 'staticMethod')` replacing Sequelize model statics.
+- **Transaction mock**: Fake `{ commit: jest.fn(), rollback: jest.fn() }` injected via mocked `Sequelize.transaction`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All 15 missing `.resolver.spec.ts` files exist and are non-empty after the feature is complete.
+- **SC-002**: `nx test backend-graphql` passes with zero failures introduced by the new tests.
+- **SC-003**: Each new spec file covers at minimum: one query success path, one not-found/empty path, one unauthorized mutation rejection, one authorized mutation success (with commit), and one rollback on error — 5 cases minimum per resolver.
+- **SC-004**: No new tests are marked `.skip` or `xit` at the time of PR merge.
+- **SC-005**: Test suite runtime does not increase by more than 60 seconds compared to baseline (tests are purely in-memory mocks).
+- **SC-006**: A single documented command runs the full coverage report locally and in CI, producing a console text summary and an lcov file, with no additional flags or environment setup required beyond what CI already provides.
+- **SC-007**: The coverage report excludes all legacy paths; zero legacy files appear in the report output.
+- **SC-008**: Coverage thresholds are enforced — the command exits non-zero when any threshold is breached. The final pinned threshold value is documented in both README and AGENTS.md with instructions for updating it.
+- **SC-009**: `specs/032-resolver-test-coverage/audit.md` is committed to the repo, covers all 33 resolvers, every finding is categorized and linked to a specific file, and deferred findings reference the follow-up feature spec that will address them.
+- **SC-010**: Any behavioral bugs discovered during the first-pass testing phase are documented; none are silently ignored.
+
+## Clarifications
+
+### Session 2026-06-08
+
+- Q: What format should the coverage report produce? → A: Text summary to console + lcov file (for future CI upload integrations).
+- Q: How should the initial coverage threshold be handled? → A: Wire at 0% placeholder; measure post-implementation and pin the real threshold (rounded down to nearest 5%) in the same PR. Document how to update it in both README and AGENTS.md.
+- Q: What happens to audit.md after it is produced? → A: Committed to repo permanently. Findings requiring follow-up are linked from the feature specs that will address them.
+- Q: What qualifies as a "trivial fix" during first-pass testing? → A: ≤5 lines changed, touches exactly one method, no model or GraphQL schema change. Anything beyond that is filed separately and linked from audit.md.
+
+## Assumptions
+
+- Resolver correctness is NOT assumed. Tests are written from expected behavior (method name, input/output shape, GraphQL contract) rather than trusting the implementation. If a test reveals a bug, the bug is documented — and fixed if trivial, flagged if complex.
+- A second pass digs into implementation details after the first-pass behavioral tests are green: inspecting branching logic, edge-case handling, and internal correctness.
+- Field resolvers that delegate entirely to Sequelize associations (no business logic) need only a single happy-path test.
+- The `services/service.resolver.ts` (read-only, single query) requires only a query-returns-data test and a query-returns-empty test.
+- `syncDraw`, `syncSubEvent`, `syncEvent` mutations dispatch to external workers; testing that they dispatch (call the queue service) is sufficient — end-to-end sync behavior is out of scope.
+- `recalculate*` mutations similarly only need to verify that the queue/service is called and the transaction is handled; full ranking recalculation is out of scope.
+- Coverage thresholds will be set based on current baseline after the new tests are added — not pre-set to an arbitrary number. The initial threshold will be the measured post-implementation coverage rounded down to the nearest 5%.
+- Integration tests (`*.integration.spec.ts`) are excluded from the coverage command by default (they require a live database).

--- a/specs/032-resolver-test-coverage/tasks.md
+++ b/specs/032-resolver-test-coverage/tasks.md
@@ -1,0 +1,254 @@
+# Tasks: Resolver Test Coverage
+
+**Input**: Design documents from `specs/032-resolver-test-coverage/`
+**Prerequisites**: plan.md ✅ | spec.md ✅ | research.md ✅ | data-model.md ✅
+
+**Organization**: Tasks grouped by user story to enable independent implementation and parallel execution.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Configure jest to support coverage reporting and integration test exclusion in `backend-graphql`.
+
+- [ ] T001 Update `libs/backend/graphql/jest.config.ts` — add `coverageReporters: ['text', 'lcov']`, `coverageThreshold` (all metrics at 0% placeholder), and `testPathIgnorePatterns: ['\\.integration\\.spec\\.ts$']`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Wire the coverage command so US7 verification and CI integration are unblocked.
+
+**⚠️ CRITICAL**: US7 verification cannot begin until this phase is complete.
+
+- [ ] T002 Update `package.json` — add `"test:coverage:all"` script: `nx run-many --target=test --all --coverage --skip-nx-cache --exclude=badman,frontend-models,frontend-components,frontend-html-injects,frontend-vitals,frontend-translation,frontend-auth,frontend-excel,frontend-pdf,frontend-utils,frontend-graphql,frontend-queue,frontend-cp,frontend-twizzit,frontend-seo,frontend-club,frontend-ranking,frontend-role,frontend-general,frontend-tournament,frontend-transfers,frontend-team,frontend-job,frontend-rule,frontend-team-assembly,frontend-change-encounter,frontend-team-enrollment,frontend-event,frontend-notifications,frontend-player`
+
+**Checkpoint**: Foundation ready — coverage command available, resolver spec phases can proceed in parallel.
+
+---
+
+## Phase 3: User Story 7 — Coverage Command (Priority: P1)
+
+**Goal**: A single `npm run test:coverage:all` command runs all non-legacy tests with lcov output and exits non-zero below threshold.
+
+**Independent Test**: Run `npm run test:coverage:all` and confirm: (a) exits 0, (b) text summary printed to console, (c) `coverage/libs/backend/graphql/lcov.info` exists, (d) no paths containing `apps/badman` or `libs/frontend` appear.
+
+- [ ] T003 [US7] Verify `npm run test:coverage:all` runs cleanly against the existing test suite — confirm text summary appears, lcov files are written to `coverage/`, and no Angular/frontend paths appear. Document any unexpected failures in `specs/032-resolver-test-coverage/audit.md` under a "Setup issues" note.
+
+**Checkpoint**: Coverage command verified working end-to-end.
+
+---
+
+## Phase 4: User Story 1 — Security Resolvers (Priority: P1)
+
+**Goal**: `claim.resolver.spec.ts` and `role.resolver.spec.ts` exist with full contract-first coverage.
+
+**Independent Test**: `nx test backend-graphql --testPathPattern="claim|role"` passes. Both unauthorized and authorized mutation paths are verified. Field resolvers `players` and `claims` on role are covered.
+
+**Reference pattern**: `libs/backend/graphql/src/resolvers/setting/setting.resolver.spec.ts`  
+**DI group**: Group A (Sequelize only) for both resolvers.  
+**Stub pattern**: `{ provide: Sequelize, useValue: { transaction: jest.fn().mockResolvedValue(mockTransaction) } }`
+
+- [ ] T004 [P] [US1] Write `libs/backend/graphql/src/resolvers/security/claim.resolver.spec.ts` — cover: `claim` query (returns data / null), `claims` list query, `assignClaim` unauthorized → UnauthorizedException, `assignClaim` success → commit, `assignClaims` unauthorized → UnauthorizedException, `assignClaims` success → commit
+- [ ] T005 [P] [US1] Write `libs/backend/graphql/src/resolvers/security/role.resolver.spec.ts` — cover: `role` query (returns data / null), `roles` list query, `createRole` / `updateRole` / `deleteRole` unauthorized → UnauthorizedException, `createRole` success → commit, `updateRole` not-found → NotFoundException, `updateRole` success → commit, `deleteRole` not-found → NotFoundException, `deleteRole` success → commit, `addPlayerToRole` / `removePlayerFromRole` / `updateRolePlayers` unauthorized → UnauthorizedException + success paths, `players` ResolveField returns array, `claims` ResolveField returns array
+
+**Checkpoint**: Security resolvers fully tested. `nx test backend-graphql --testPathPattern="claim|role"` passes.
+
+---
+
+## Phase 5: User Story 2 — Event Resolvers (Priority: P2)
+
+**Goal**: Four event resolver spec files (competition event, tournament draw, tournament event, tournament subevent) fully tested.
+
+**Independent Test**: `nx test backend-graphql --testPathPattern="event\.resolver|draw\.resolver|subevent\.resolver"` passes.
+
+**DI group**: Group D (Sequelize + PointsService + `getQueueToken(SyncQueue)` + RankingSystemService) for all four.  
+**Bull queue stub**: `{ provide: getQueueToken(SyncQueue), useValue: { add: jest.fn() } }` (import `getQueueToken` from `@nestjs/bull`, `SyncQueue` from `@badman/backend-queue`).
+
+- [ ] T006 [P] [US2] Write `libs/backend/graphql/src/resolvers/event/competition/event.resolver.spec.ts` — cover: `eventCompetition` query (by id / null), `eventCompetitions` paged query, `eventCompetitionSeasons` list, `updateEventCompetition` unauthorized → UnauthorizedException / success → commit / rollback on error, `copyEventCompetition` unauthorized / success, `subEventCompetitions` ResolveField, `comments` ResolveField, `exceptions` ResolveField, `infoEvents` ResolveField
+- [ ] T007 [P] [US2] Write `libs/backend/graphql/src/resolvers/event/tournament/draw.resolver.spec.ts` — cover: `drawTournament` query (by id / null), `drawTournaments` list, `recalculateDrawTournamentRankingPoints` unauthorized / success → queue.add called, `syncDraw` unauthorized / success → queue.add called, `subEventTournament` ResolveField, `eventEntries` ResolveField, `games` ResolveField
+- [ ] T008 [P] [US2] Write `libs/backend/graphql/src/resolvers/event/tournament/event.resolver.spec.ts` — cover: `eventTournament` query (by id / null), `eventTournaments` paged query, `updateEventTournament` unauthorized / success → commit / rollback, `removeEventTournament` unauthorized / not-found → NotFoundException / success, `recalculateEventTournamentRankingPoints` unauthorized / success → queue.add called, `syncEvent` unauthorized / success → queue.add called, `subEventTournaments` ResolveField
+- [ ] T009 [P] [US2] Write `libs/backend/graphql/src/resolvers/event/tournament/subevent.resolver.spec.ts` — cover: `subEventTournament` query (by id / null), `subEventTournaments` list, `recalculateSubEventTournamentwRankingPoints` unauthorized / success → queue.add called, `syncSubEvent` unauthorized / success → queue.add called, `drawTournaments` ResolveField, `eventTournament` ResolveField, `rankingGroups` ResolveField
+
+**Checkpoint**: Event resolvers fully tested. `nx test backend-graphql --testPathPattern="event\.resolver|draw\.resolver|subevent\.resolver"` passes.
+
+---
+
+## Phase 6: User Story 3 — Encounter-Change Resolver (Priority: P2)
+
+**Goal**: `encounter-change.resolver.spec.ts` exists with full coverage including the complex multi-service dependencies.
+
+**Independent Test**: `nx test backend-graphql --testPathPattern="encounter-change"` passes.
+
+**DI group**: Group F — Sequelize + `getQueueToken(SyncQueue)` + NotificationService stub + EncounterValidationService stub.
+
+- [ ] T010 [US3] Write `libs/backend/graphql/src/resolvers/event/competition/encounter-change.resolver.spec.ts` — cover: `encounterChange` query (by id / null), `encounterChanges` paged query, `addChangeEncounter` unauthorized → UnauthorizedException / success → commit / rollback on error, `updateEncounterChange` unauthorized / success → commit / rollback, `dates` ResolveField on EncounterChange returns array, `dates` ResolveField on EncounterChangeDate returns Location
+
+**Checkpoint**: Encounter-change resolver fully tested.
+
+---
+
+## Phase 7: User Story 4 — Availability, FAQ, Notification, CronJob, Service (Priority: P3)
+
+**Goal**: Five resolver spec files exist for lower-criticality but commonly used resolvers.
+
+**Independent Test**: `nx test backend-graphql --testPathPattern="availability|faq|notification|cronJob|service"` passes.
+
+**DI groups**: availability/faq/notification → Group A (Sequelize only); cronJob → Group C (Sequelize + CronService); service → Group B (no DI).
+
+- [ ] T011 [P] [US4] Write `libs/backend/graphql/src/resolvers/availability/availability.resolver.spec.ts` — cover: `availability` query (by id / null), `availabilities` list, `createAvailability` unauthorized / success → commit / rollback, `updateAvailability` unauthorized / not-found / success → commit / rollback, `days` ResolveField (nullable), `exceptions` ResolveField (nullable)
+- [ ] T012 [P] [US4] Write `libs/backend/graphql/src/resolvers/faq/faq.resolver.spec.ts` — cover: `faq` query (by id / null), `faqs` list, `createFaq` unauthorized / success → commit / rollback, `updateFaq` unauthorized / not-found → NotFoundException / success → commit / rollback, `deleteFaq` unauthorized / not-found → NotFoundException / success → commit and returns true
+- [ ] T013 [P] [US4] Write `libs/backend/graphql/src/resolvers/notification/notification.resolver.spec.ts` — cover: `notification` query (by id / null), `notifications` list, `updateNotification` unauthorized / not-found / success → commit / rollback, `encounter` ResolveField, `competition` ResolveField, `tournament` ResolveField, `club` ResolveField
+- [ ] T014 [P] [US4] Write `libs/backend/graphql/src/resolvers/cronJobs/cronJob.resolver.spec.ts` — cover: `cronJobs` list query, `updateCronJob` unauthorized → UnauthorizedException / success → commit / rollback, `nextRun` ResolveField returns a string, `arguments` ResolveField on CronJobMeta returns serialized string. Use `{ provide: CronService, useValue: { ... } }` stub matching the methods called in the resolver.
+- [ ] T015 [P] [US4] Write `libs/backend/graphql/src/resolvers/services/service.resolver.spec.ts` — cover: `services` list returns data, `services` list returns empty array. No DI needed (no constructor). Model static `Service.findAll` spied via `jest.spyOn`.
+
+**Checkpoint**: All P3 misc resolvers tested. `nx test backend-graphql --testPathPattern="availability|faq|notification|cronJob|service"` passes.
+
+---
+
+## Phase 8: User Story 5 — Assembly & RankingSystemGroup (Priority: P3)
+
+**Goal**: `assembly.resolver.spec.ts` and `rankingSystemGroup.resolver.spec.ts` exist.
+
+**Independent Test**: `nx test backend-graphql --testPathPattern="assembly|rankingSystemGroup"` passes.
+
+**DI groups**: assembly → Group E (AssemblyValidationService + RankingSystemService, no Sequelize); rankingSystemGroup → Group C+ (Sequelize + PointsService).
+
+- [ ] T016 [P] [US5] Write `libs/backend/graphql/src/resolvers/event/competition/assembly.resolver.spec.ts` — cover: `validateAssembly` query returns AssemblyOutput, `createAssembly` unauthorized → UnauthorizedException / success → commit / rollback. Note: AssemblyResolver takes no Sequelize — check constructor: uses `AssemblyValidationService` and `RankingSystemService`. `titularsPlayers` ResolveField returns array, `baseTeamPlayers` ResolveField returns array.
+- [ ] T017 [P] [US5] Write `libs/backend/graphql/src/resolvers/ranking/rankingSystemGroup.resolver.spec.ts` — cover: `rankingGroup` query (by id / null), `rankingGroups` list, `addSubEventsToRankingGroup` unauthorized / success → commit / rollback, `removeSubEventsToRankingGroup` unauthorized / success → commit / rollback, `subEventCompetitions` ResolveField, `subEventTournaments` ResolveField
+
+**Checkpoint**: Assembly and RankingSystemGroup resolvers tested.
+
+---
+
+## Phase 9: User Story 6 — Club Membership Resolver (Priority: P3)
+
+**Goal**: `club-membership.resolver.spec.ts` covers the read-only query and both ResolveField associations.
+
+**Independent Test**: `nx test backend-graphql --testPathPattern="club-membership"` passes.
+
+**DI group**: Group B (no constructor, no DI — `ClubPlayerMembershipsResolver` has no injected dependencies). Model statics spied via `jest.spyOn`.
+
+- [ ] T018 [US6] Write `libs/backend/graphql/src/resolvers/club/club-membership.resolver.spec.ts` — cover: `clubPlayerMemberships` query returns paged result (`{ count, rows }`), `clubPlayerMemberships` returns empty result when no memberships, `club` ResolveField returns associated Club, `player` ResolveField returns associated Player. No Sequelize in TestingModule providers.
+
+**Checkpoint**: All 15 resolver spec files written. `nx test backend-graphql` passes.
+
+---
+
+## Phase 10: User Story 8 — Resolver Audit Report (Priority: P2)
+
+**Goal**: `specs/032-resolver-test-coverage/audit.md` committed — covers all 33 resolvers with findings by category.
+
+**Independent Test**: File `specs/032-resolver-test-coverage/audit.md` exists, contains a summary table with `missing-auth` / `duplication` / `performance` / `code-quality` / `bug` / `missing-idempotency` rows, and each finding has file path + line reference + suggested remedy.
+
+**Prerequisite**: All 15 resolver spec files must be complete (Phases 4–9 done). The audit is a second pass that reads the actual implementations. US8 is sequenced here despite its P2 priority because the audit requires all spec files to exist first — it cannot run alongside Phases 4–9.
+
+- [ ] T019 [US8] Produce `specs/032-resolver-test-coverage/audit.md` — read all 33 resolver implementations (`libs/backend/graphql/src/resolvers/**/*.resolver.ts`). For each resolver, check: (1) write mutations without `user.hasAnyPermission()` → `missing-auth`; (2) near-identical logic duplicated across resolvers → `duplication`; (3) field resolvers issuing N queries instead of using existing dataloader pattern → `performance`; (4) structural code quality issues (inconsistent error handling, dead code, missing Logger calls on errors) → `code-quality`; (5) any bugs found during spec-writing that were documented as findings → `bug`; (6) create mutations with a natural uniqueness key that are NOT idempotent (do not return `alreadyExisted: boolean`) → `missing-idempotency` (Constitution Principle III violation). Apply the trivial-fix rule: ≤5 lines, one method, no model/schema change → fix in place and mark `fixed`; else mark `deferred` with a placeholder link.
+
+**Checkpoint**: Audit committed. All findings categorized and linked.
+
+---
+
+## Phase 11: Polish & Cross-Cutting Concerns
+
+**Purpose**: Pin coverage threshold, validate end-to-end, update docs.
+
+- [ ] T020 Run `npm run test:coverage:all` after all resolver specs are written — record the `Lines %` for `backend-graphql` from the console output, round down to nearest 5%, update `coverageThreshold.global` in `libs/backend/graphql/jest.config.ts` with the measured values, and commit
+- [ ] T021 [P] Verify `AGENTS.md` coverage threshold update instructions are accurate and match the actual location of `coverageThreshold` in `libs/backend/graphql/jest.config.ts` — adjust wording if needed
+- [ ] T021b [P] Update `README.md` — add `test:coverage:all` command to the testing section and document how to update the coverage threshold (same instructions as AGENTS.md: run command → note Lines % → round down to nearest 5% → update `coverageThreshold.global` in `libs/backend/graphql/jest.config.ts` → commit)
+- [ ] T022 [P] Second-pass review of the four complex resolver specs (encounter-change, competition/event, rankingSystemGroup, assembly) — read each resolver implementation and add any missing edge-case tests that behavioral contract-first testing did not surface (e.g. internal branching on `IsUUID`, idempotency guards, error re-throw paths). Document any implementation bugs found per FR-009.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: After Phase 1
+- **Phase 3 (US7)**: After Phase 2 — verifies the coverage command
+- **Phases 4–9 (US1–US6)**: All can run in parallel after Phase 2; no cross-story dependencies
+- **Phase 10 (US8 Audit)**: After Phases 4–9 complete (needs all specs written)
+- **Phase 11 (Polish)**: After Phase 10 complete
+
+### User Story Dependencies
+
+- **US7 (P1)**: Phase 2 complete → can verify immediately
+- **US1 (P1)**: Phase 2 complete → T004, T005 in parallel
+- **US2 (P2)**: Phase 2 complete → T006, T007, T008, T009 in parallel
+- **US3 (P2)**: Phase 2 complete → T010
+- **US4 (P3)**: Phase 2 complete → T011, T012, T013, T014, T015 in parallel
+- **US5 (P3)**: Phase 2 complete → T016, T017 in parallel
+- **US6 (P3)**: Phase 2 complete → T018
+- **US8 (P2)**: Phases 4–9 complete → T019
+- **Polish**: All above complete → T020, T021, T021b, T022
+
+### Parallel Opportunities
+
+Within each phase, tasks marked `[P]` can run simultaneously (different files). Phase 3 (US7) through Phase 9 (US6) can all run in parallel once Phase 2 completes — except US8 which waits for all specs.
+
+---
+
+## Parallel Example: Phases 4–9 (after Phase 2 completes)
+
+```text
+Parallel batch — all start simultaneously:
+  T004  [US1] claim.resolver.spec.ts
+  T005  [US1] role.resolver.spec.ts
+  T006  [US2] event/competition/event.resolver.spec.ts
+  T007  [US2] event/tournament/draw.resolver.spec.ts
+  T008  [US2] event/tournament/event.resolver.spec.ts
+  T009  [US2] event/tournament/subevent.resolver.spec.ts
+  T010  [US3] encounter-change.resolver.spec.ts
+  T011  [US4] availability.resolver.spec.ts
+  T012  [US4] faq.resolver.spec.ts
+  T013  [US4] notification.resolver.spec.ts
+  T014  [US4] cronJob.resolver.spec.ts
+  T015  [US4] service.resolver.spec.ts
+  T016  [US5] assembly.resolver.spec.ts
+  T017  [US5] rankingSystemGroup.resolver.spec.ts
+  T018  [US6] club-membership.resolver.spec.ts
+
+After all 15 complete:
+  T019  [US8] audit.md
+
+After T019:
+  T020, T021, T022  (Polish — T021 and T022 parallel)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US7 + US1)
+
+1. Phase 1: Configure jest (T001)
+2. Phase 2: Add npm script (T002)
+3. Phase 3: Verify coverage command (T003)
+4. Phase 4: Write claim + role specs (T004, T005)
+5. **STOP and VALIDATE**: `npm run test:coverage:all` passes, security resolvers green
+
+### Full Delivery
+
+1. Phases 1–2: Setup
+2. Phase 3: Verify command
+3. Phases 4–9 in parallel: All 15 resolver specs
+4. Phase 10: Audit
+5. Phase 11: Pin threshold, second pass, docs
+
+---
+
+## Notes
+
+- All resolver specs follow the pattern in `libs/backend/graphql/src/resolvers/setting/setting.resolver.spec.ts`
+- DI stubs per resolver: see `specs/032-resolver-test-coverage/data-model.md` (provider map table)
+- Bull queue injection: `{ provide: getQueueToken(SyncQueue), useValue: { add: jest.fn() } }` from `@nestjs/bull` / `@badman/backend-queue`
+- Write tests from the method signature and GraphQL contract FIRST. Only consult implementation if a test unexpectedly fails.
+- `assembly.resolver.ts` has NO Sequelize constructor arg — do not add it to TestingModule
+- `club-membership.resolver.ts` and `service.resolver.ts` have NO constructor — providers list contains only the resolver class itself
+- Trivial fix rule (FR-009): ≤5 lines, one method, no model/schema change → fix allowed in same PR


### PR DESCRIPTION
## Summary
- Unit tests for all 15 previously uncovered GraphQL resolvers
- Coverage baseline: statements 50%, branches 31%, functions 26%, lines 48%
- Thresholds pinned in jest.config.ts (rounded down 5%)
- `npm run test:coverage:all` script for CI/local use

## Deliverables
✅ 15 new resolver specs (470 passing tests)
✅ Coverage infrastructure (thresholds, lcov+text reporters)
✅ Resolver audit (specs/032-resolver-test-coverage/audit.md) — all 33 resolvers across 6 categories
✅ 10 Linear issues (BAD-239–248) for critical/high findings
✅ Environment setup docs (LINEAR_API_KEY in .env.local)

## Testing
All tests green. Run locally:
\`\`\`bash
npm run test:coverage:all
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)