### PR TITLE
ci(deploy): pass GH_TOKEN_CP to deploy jobs

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -131,6 +131,7 @@ jobs:
           API_HOOK: ${{ secrets.PROD_API_HOOK }}
           WORKER_SYNC_HOOK: ${{ secrets.PROD_WORKER_SYNC_HOOK }}
           WORKER_RANKING_HOOK: ${{ secrets.PROD_WORKER_RANKING_HOOK }}
+          GH_TOKEN_CP: ${{ secrets.GH_TOKEN_CP }}
 
   sentry-release:
     needs: [build, deploy-prod]

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -59,3 +59,4 @@ jobs:
           API_HOOK: ${{ secrets.STAGING_API_HOOK }}
           WORKER_SYNC_HOOK: ${{ secrets.STAGING_WORKER_SYNC_HOOK }}
           WORKER_RANKING_HOOK: ${{ secrets.STAGING_WORKER_RANKING_HOOK }}
+          GH_TOKEN_CP: ${{ secrets.GH_TOKEN_CP }}


### PR DESCRIPTION
Secret must be exported as env var at runtime; GitHub repository secret alone does not reach deployed apps.