### PR TITLE
ci(deploy): pass GH_TOKEN_CP to deploy jobs

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -138,6 +138,7 @@ jobs:
           API_HOOK: ${{ secrets.PROD_API_HOOK }}
           WORKER_SYNC_HOOK: ${{ secrets.PROD_WORKER_SYNC_HOOK }}
           WORKER_RANKING_HOOK: ${{ secrets.PROD_WORKER_RANKING_HOOK }}
+          GH_TOKEN_CP: ${{ secrets.GH_TOKEN_CP }}
 
   sentry-release:
     needs: [build, deploy-prod]

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -28,18 +28,6 @@ jobs:
       NEW_VERSION: ${{ steps.create_release.outputs.new_version }}
     steps:
       - uses: actions/checkout@v5
-
-      - name: Merge develop -> main
-        if: github.ref == 'refs/heads/main'
-        uses: devmasx/merge-branch@master
-        with:
-          type: now
-          from_branch: develop
-          target_branch: main
-          message: "chore(merge): merge develop into main"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -54,3 +54,4 @@ jobs:
           API_HOOK: ${{ secrets.STAGING_API_HOOK }}
           WORKER_SYNC_HOOK: ${{ secrets.STAGING_WORKER_SYNC_HOOK }}
           WORKER_RANKING_HOOK: ${{ secrets.STAGING_WORKER_RANKING_HOOK }}
+          GH_TOKEN_CP: ${{ secrets.GH_TOKEN_CP }}


### PR DESCRIPTION
Secret must be exported as env var at runtime; GitHub repository secret alone does not reach deployed apps.