### PR TITLE
fix(backend-graphql): replace dynamic require with static imports in spec

### DIFF
--- a/libs/backend/graphql/src/resolvers/event/competition/encounter-change.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/event/competition/encounter-change.resolver.spec.ts
@@ -16,10 +16,13 @@ describe("EncounterChangeCompetitionResolver", () => {
     notifyEncounterChange: jest.Mock;
     notifyEncounterChangeFinished: jest.Mock;
   };
-  let mockEncounterService: {};
+  let mockEncounterService: object;
 
   const buildUser = (allowed: boolean) =>
-    ({ id: "user-uuid", hasAnyPermission: jest.fn().mockResolvedValue(allowed) }) as unknown as Player;
+    ({
+      id: "user-uuid",
+      hasAnyPermission: jest.fn().mockResolvedValue(allowed),
+    }) as unknown as Player;
 
   beforeEach(async () => {
     mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
@@ -116,7 +119,9 @@ describe("EncounterChangeCompetitionResolver", () => {
       } as unknown as EncounterCompetition;
       jest.spyOn(EncounterChange, "findByPk").mockResolvedValue(fakeChange);
       jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(fakeEncounter);
-      const result = await resolver.updateEncounterChange(buildUser(true), { id: "ec-uuid" } as any);
+      const result = await resolver.updateEncounterChange(buildUser(true), {
+        id: "ec-uuid",
+      } as any);
       expect(fakeChange.update).toHaveBeenCalled();
       expect(result).toBe(updated);
     });
@@ -143,7 +148,10 @@ describe("EncounterChangeCompetitionResolver", () => {
       const fakeEncounter = { home: fakeTeam, away: null } as unknown as EncounterCompetition;
       jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(fakeEncounter);
       await expect(
-        resolver.addChangeEncounter(buildUser(false), { encounterId: "enc-uuid", home: true } as any)
+        resolver.addChangeEncounter(buildUser(false), {
+          encounterId: "enc-uuid",
+          home: true,
+        } as any)
       ).rejects.toThrow(UnauthorizedException);
     });
   });

--- a/libs/backend/graphql/src/resolvers/ranking/rankingSystemGroup.resolver.spec.ts
+++ b/libs/backend/graphql/src/resolvers/ranking/rankingSystemGroup.resolver.spec.ts
@@ -1,7 +1,13 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { NotFoundException, UnauthorizedException } from "@nestjs/common";
 import { Sequelize } from "sequelize-typescript";
-import { Player, RankingGroup } from "@badman/backend-database";
+import {
+  Game,
+  Player,
+  RankingGroup,
+  SubEventCompetition,
+  SubEventTournament,
+} from "@badman/backend-database";
 import { PointsService } from "@badman/backend-ranking";
 import { RankingGroupsResolver } from "./rankingSystemGroup.resolver";
 
@@ -11,7 +17,10 @@ describe("RankingGroupsResolver", () => {
   let mockPointsService: { createRankingPointforGame: jest.Mock };
 
   const buildUser = (allowed: boolean) =>
-    ({ id: "user-uuid", hasAnyPermission: jest.fn().mockResolvedValue(allowed) }) as unknown as Player;
+    ({
+      id: "user-uuid",
+      hasAnyPermission: jest.fn().mockResolvedValue(allowed),
+    }) as unknown as Player;
 
   beforeEach(async () => {
     mockTransaction = { commit: jest.fn(), rollback: jest.fn() };
@@ -78,10 +87,9 @@ describe("RankingGroupsResolver", () => {
       } as unknown as RankingGroup;
       jest.spyOn(RankingGroup, "findByPk").mockResolvedValue(fakeGroup);
 
-      const db = require("@badman/backend-database");
-      jest.spyOn(db.Game, "findAll").mockResolvedValue([]);
-      jest.spyOn(db.SubEventCompetition, "findAll").mockResolvedValue([]);
-      jest.spyOn(db.SubEventTournament, "findAll").mockResolvedValue([]);
+      jest.spyOn(Game, "findAll").mockResolvedValue([]);
+      jest.spyOn(SubEventCompetition, "findAll").mockResolvedValue([]);
+      jest.spyOn(SubEventTournament, "findAll").mockResolvedValue([]);
 
       const result = await resolver.addSubEventsToRankingGroup(
         buildUser(true),


### PR DESCRIPTION
## Summary

- Dynamic `require("@badman/backend-database")` in `rankingSystemGroup.resolver.spec.ts` caused Nx to classify `backend-database` as lazy-loaded, failing `@nx/enforce-module-boundaries` lint across the entire `backend-graphql` lib
- Replace with static imports (`Game`, `SubEventCompetition`, `SubEventTournament`)
- Fix `{}` empty-object type lint error in `encounter-change.resolver.spec.ts`

## Test plan

- [ ] `nx lint backend-graphql` passes with 0 errors
- [ ] `nx test backend-graphql` — 45 suites, 476 tests pass