### PR TITLE
ci(generate-cp): switch from npm to pnpm for dependency install

### DIFF
--- a/.github/workflows/generate-cp.yml
+++ b/.github/workflows/generate-cp.yml
@@ -24,9 +24,13 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Install pnpm
+        run: npm install -g pnpm@10.33.0
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Fetch payload from Gist
         shell: bash


### PR DESCRIPTION
Workflow was failing because setup-node detected pnpm from packageManager field but pnpm was never installed, and npm ci has no lockfile to use.