### PR TITLE
ci(generate-cp): install pnpm before setup-node cache step

### DIFF
--- a/.github/workflows/generate-cp.yml
+++ b/.github/workflows/generate-cp.yml
@@ -21,13 +21,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Install pnpm
+        run: npm install -g pnpm@10.33.0
+
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
-
-      - name: Install pnpm
-        run: npm install -g pnpm@10.33.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
setup-node with cache: pnpm requires pnpm on PATH to locate the lockfile. Moving install-pnpm step before setup-node fixes the ordering.