### PR TITLE
ci(generate-cp): revert to npm, remove stale packageManager field

### DIFF
--- a/.github/workflows/generate-cp.yml
+++ b/.github/workflows/generate-cp.yml
@@ -21,16 +21,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install pnpm
-        run: npm install -g pnpm@10.33.0
-
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".nvmrc"
-          cache: "pnpm"
+          cache: "npm"
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: npm ci
 
       - name: Fetch payload from Gist
         shell: bash

--- a/package.json
+++ b/package.json
@@ -270,6 +270,5 @@
     "string-length": {
       "strip-ansi": "^6.0.0"
     }
-  },
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
+  }
 }


### PR DESCRIPTION
Project has package-lock.json and no pnpm-lock.yaml — pnpm was never actually in use. Stale packageManager field caused setup-node to require pnpm. Use npm ci with npm cache instead.