### PR TITLE
fix(cp): harden webhook — error isolation, validation, idempotency, logging

### DIFF
--- a/.maqa/state.json
+++ b/.maqa/state.json
@@ -36,10 +36,7 @@
       "mvp_scope": "T001-T025 (Phases 1-4: US1 + US2)",
       "tasks_completed": "T001-T025 (25/36)",
       "deferred": "T026-T036 (Phases 5-7: US4 hook refactor, US3 perf, polish)",
-      "implementation_commits": [
-        "b7de5cf39",
-        "ae63d6a61"
-      ],
+      "implementation_commits": ["b7de5cf39", "ae63d6a61"],
       "tests_passed": 126,
       "tests_skipped": 2,
       "qa_status": "approved",
@@ -66,10 +63,7 @@
       "tasks_total": 24,
       "tasks_completed": "T001, T003-T020 (19/24)",
       "deferred": "T002 (docker check), T021 (nx affected:test), T022 (manual quickstart walk), T023 (verify only), T024 (frontend PR \u2014 separate repo)",
-      "implementation_commits": [
-        "e407d0553",
-        "cf539101b"
-      ],
+      "implementation_commits": ["e407d0553", "cf539101b"],
       "tests_passed": 12,
       "tests_total": 12,
       "qa_status": "approved",
@@ -98,12 +92,7 @@
       "tasks_total": 23,
       "tasks_completed": "T001-T021, T023 (22/23)",
       "deferred": "T022 (manual quickstart walk \u2014 needs running API + docker DB)",
-      "spec_kit_commits": [
-        "fba14cd80",
-        "0a1254a79",
-        "a5a66aca7",
-        "14c6286bf"
-      ],
+      "spec_kit_commits": ["fba14cd80", "0a1254a79", "a5a66aca7", "14c6286bf"],
       "implementation_commits": [
         "16bc84aee",
         "1df5d7521",
@@ -144,19 +133,12 @@
         "plan": "plan.md",
         "research": "research.md",
         "data_model": "data-model.md",
-        "contracts": [
-          "team-renumber-mutation.md",
-          "team-renumbering-service.md"
-        ],
+        "contracts": ["team-renumber-mutation.md", "team-renumbering-service.md"],
         "frontend_impact": "frontend-impact.md",
         "quickstart": "quickstart.md",
         "tasks": "tasks.md"
       },
-      "spec_kit_commits": [
-        "038b5ca10",
-        "666d98c6d",
-        "f67027148"
-      ],
+      "spec_kit_commits": ["038b5ca10", "666d98c6d", "f67027148"],
       "tasks_total": 43,
       "tasks_completed": "T001-T021, T024, T029-T033, T034-T036, T038-T041 (37/43)",
       "deferred": [
@@ -228,11 +210,7 @@
       "tasks_total": 33,
       "tasks_completed": "T001-T014, T017-T027, T029, T030, T032",
       "tasks_deferred": "T015-T016 (operational manual verification), T028 (nx affected:test \u2014 empty test_command), T031 (operational Quickstart walk), T033 (no checked-in schema.gql)",
-      "implementation_commits": [
-        "2de5cdc1f",
-        "fcdedeaa7",
-        "db6fcad0a"
-      ],
+      "implementation_commits": ["2de5cdc1f", "fcdedeaa7", "db6fcad0a"],
       "feature_status": "done",
       "qa_status": "approved",
       "qa_checks": {
@@ -247,10 +225,7 @@
       "status": "in_review_qa_approved",
       "board": "local",
       "branch": "029-evententry-team-standing-loaders",
-      "implementation_commits": [
-        "96d85a710",
-        "3011f172b"
-      ],
+      "implementation_commits": ["96d85a710", "3011f172b"],
       "tests_passed": 29,
       "feature_status": "done",
       "qa_status": "approved",
@@ -273,6 +248,29 @@
       "status": "todo",
       "board": "linear",
       "branch": "032-resolver-test-coverage"
+    },
+    "034-cp-webhook-hardening": {
+      "status": "in_review_qa_approved",
+      "board": "local",
+      "branch": "034-cp-webhook-hardening",
+      "tasks_done": "19/19",
+      "tests_passed": 25,
+      "feature_status": "done",
+      "qa_status": "approved",
+      "qa_checks": {
+        "text": "PASS",
+        "links": "PASS",
+        "security": "PASS"
+      },
+      "constitution_check": {
+        "principle_i_codefirst_graphql": "PASS",
+        "principle_ii_i18n": "PASS (no diff)",
+        "principle_iii_transactional_mutations": "PASS (REST controller)",
+        "principle_iv_resolver_tests": "PASS",
+        "principle_v_legacy_frontend": "PASS (no diff)"
+      },
+      "ci_gate": "none",
+      "next_step": "open PR targeting develop"
     }
   },
   "board": "linear",

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/032-resolver-test-coverage"
+  "feature_directory": "specs/034-cp-webhook-hardening"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ source /path/to/badman/.env.local
 ```
 
 **Variables needed for scripts:**
+
 - `LINEAR_API_KEY` — for creating Linear issues from CLI
 
 ## Project Overview
@@ -244,15 +245,15 @@ Pattern:
 
 Workflows live in [`.github/workflows/`](.github/workflows/). Match the workflow to the branch you are working on — see [Branching](#branching) for base-branch rules.
 
-| Workflow | Trigger | Purpose |
-|---|---|---|
-| [`pull-request.yml`](.github/workflows/pull-request.yml) | `pull_request`, `merge_group` | Fast PR gate: `nx affected -t lint test -c ci` against `develop` (or PR base). Build is **deliberately excluded** — deploy workflows handle it. Legacy frontend + e2e excluded (Constitution V). |
-| [`deploy-staging.yml`](.github/workflows/deploy-staging.yml) | `push` to `staging`, `workflow_dispatch` | Build affected → run migrations against staging DB → deploy. Calls `_shared-migrate.yml`. |
-| [`deploy-production.yml`](.github/workflows/deploy-production.yml) | `push` to `main`, `workflow_dispatch` | Build affected (NX_BASE = last `v*` tag) → create release tag → run migrations against prod DB → deploy. The `main` → `develop` back-merge step is **currently commented out** (main intentionally diverges from develop); re-enable once branches align. Calls `_shared-migrate.yml`. |
-| [`_shared-migrate.yml`](.github/workflows/_shared-migrate.yml) | `workflow_call` (reusable) | Applies pending Sequelize migrations against `target-environment` input (`staging` \| `production`). Production env requires manual reviewer approval. Concurrency group `migrate-<env>` with `cancel-in-progress: false` so a mid-flight migration cannot be cancelled. Pre-flight invalid-index check guards against interrupted `CREATE INDEX CONCURRENTLY`. |
-| [`claude-code-review.yml`](.github/workflows/claude-code-review.yml) | `pull_request` against `main` | Auto Claude review on PRs targeting `main`. |
-| [`claude.yml`](.github/workflows/claude.yml) | `@claude` mention in issues / PR comments / reviews | On-demand Claude agent for repo. |
-| [`cla.yaml`](.github/workflows/cla.yaml) | PRs from external contributors | CLA signature gate. |
+| Workflow                                                             | Trigger                                             | Purpose                                                                                                                                                                                                                                                                                                                                                         |
+| -------------------------------------------------------------------- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`pull-request.yml`](.github/workflows/pull-request.yml)             | `pull_request`, `merge_group`                       | Fast PR gate: `nx affected -t lint test -c ci` against `develop` (or PR base). Build is **deliberately excluded** — deploy workflows handle it. Legacy frontend + e2e excluded (Constitution V).                                                                                                                                                                |
+| [`deploy-staging.yml`](.github/workflows/deploy-staging.yml)         | `push` to `staging`, `workflow_dispatch`            | Build affected → run migrations against staging DB → deploy. Calls `_shared-migrate.yml`.                                                                                                                                                                                                                                                                       |
+| [`deploy-production.yml`](.github/workflows/deploy-production.yml)   | `push` to `main`, `workflow_dispatch`               | Build affected (NX_BASE = last `v*` tag) → create release tag → run migrations against prod DB → deploy. The `main` → `develop` back-merge step is **currently commented out** (main intentionally diverges from develop); re-enable once branches align. Calls `_shared-migrate.yml`.                                                                          |
+| [`_shared-migrate.yml`](.github/workflows/_shared-migrate.yml)       | `workflow_call` (reusable)                          | Applies pending Sequelize migrations against `target-environment` input (`staging` \| `production`). Production env requires manual reviewer approval. Concurrency group `migrate-<env>` with `cancel-in-progress: false` so a mid-flight migration cannot be cancelled. Pre-flight invalid-index check guards against interrupted `CREATE INDEX CONCURRENTLY`. |
+| [`claude-code-review.yml`](.github/workflows/claude-code-review.yml) | `pull_request` against `main`                       | Auto Claude review on PRs targeting `main`.                                                                                                                                                                                                                                                                                                                     |
+| [`claude.yml`](.github/workflows/claude.yml)                         | `@claude` mention in issues / PR comments / reviews | On-demand Claude agent for repo.                                                                                                                                                                                                                                                                                                                                |
+| [`cla.yaml`](.github/workflows/cla.yaml)                             | PRs from external contributors                      | CLA signature gate.                                                                                                                                                                                                                                                                                                                                             |
 
 ### Main → develop back-merge (currently disabled)
 
@@ -284,6 +285,6 @@ Long-form internal docs live under [`docs/`](docs/). Skim the relevant ones befo
 
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-[specs/032-resolver-test-coverage/plan.md](specs/032-resolver-test-coverage/plan.md)
+[specs/034-cp-webhook-hardening/plan.md](specs/034-cp-webhook-hardening/plan.md)
 
 <!-- SPECKIT END -->

--- a/apps/api/src/app/controllers/cp.controller.spec.ts
+++ b/apps/api/src/app/controllers/cp.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { ConfigService } from "@nestjs/config";
 import {
   BadGatewayException,
+  BadRequestException,
   ConflictException,
   ForbiddenException,
   NotFoundException,
@@ -287,6 +288,132 @@ describe("CpController", () => {
         run_id: "gh-run-789",
         user_id: "user-1",
         status: "failed",
+      });
+
+      expect(result).toEqual({ ok: true });
+    });
+
+    // T012
+    it("should return 400 if run_id is missing", async () => {
+      await expect(
+        controller.webhook("test-secret", { run_id: "", user_id: "user-1", status: "completed" })
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    // T013
+    it("should return 400 if user_id is missing", async () => {
+      await expect(
+        controller.webhook("test-secret", { run_id: "run-1", user_id: "", status: "completed" })
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    // T014
+    it("should return 400 if status is missing", async () => {
+      await expect(
+        controller.webhook("test-secret", { run_id: "run-1", user_id: "user-1", status: "" })
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    // T015
+    it("should return 400 for invalid status value", async () => {
+      await expect(
+        controller.webhook("test-secret", {
+          run_id: "run-1",
+          user_id: "user-1",
+          status: "success",
+        })
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    // T016
+    it("should return { ok: true } even when email dispatch throws", async () => {
+      const user = mockUser();
+      mockFetch
+        .mockResolvedValueOnce({
+          status: 201,
+          json: jest.fn().mockResolvedValue({ id: "gist-abc" }),
+        })
+        .mockResolvedValueOnce({ status: 204 }) // dispatch
+        .mockResolvedValueOnce({ status: 204 }); // _deleteGist on webhook
+      await controller.generate(user, { eventId: "a0000000-0000-4000-8000-000000000001" });
+
+      jest.spyOn(Player, "findByPk").mockResolvedValue({
+        email: "user@test.be",
+        fullName: "Test User",
+      } as any);
+
+      // Make the mailing service throw
+      const mailingService = (controller as any).mailingService;
+      jest
+        .spyOn(mailingService, "sendCpExportReadyMail")
+        .mockRejectedValue(new Error("SMTP error"));
+
+      const result = await controller.webhook("test-secret", {
+        run_id: "gh-run-email-throws",
+        user_id: "user-1",
+        status: "completed",
+      });
+
+      expect(result).toEqual({ ok: true });
+    });
+
+    // T017
+    it("should return { ok: true } for duplicate run_id without re-sending email", async () => {
+      const user = mockUser();
+      mockFetch
+        .mockResolvedValueOnce({
+          status: 201,
+          json: jest.fn().mockResolvedValue({ id: "gist-abc" }),
+        })
+        .mockResolvedValueOnce({ status: 204 }) // dispatch
+        .mockResolvedValueOnce({ status: 204 }); // _deleteGist on webhook
+      await controller.generate(user, { eventId: "a0000000-0000-4000-8000-000000000001" });
+
+      jest.spyOn(Player, "findByPk").mockResolvedValue({
+        email: "user@test.be",
+        fullName: "Test User",
+      } as any);
+
+      const mailingService = (controller as any).mailingService;
+      const sendMailSpy = jest.spyOn(mailingService, "sendCpExportReadyMail");
+
+      // First delivery
+      await controller.webhook("test-secret", {
+        run_id: "gh-run-dup",
+        user_id: "user-1",
+        status: "completed",
+      });
+
+      // Second delivery with same run_id (idempotency guard)
+      const result = await controller.webhook("test-secret", {
+        run_id: "gh-run-dup",
+        user_id: "user-1",
+        status: "completed",
+      });
+
+      expect(result).toEqual({ ok: true });
+      // Mail must have been sent exactly once, not twice
+      expect(sendMailSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // T018
+    it("should return { ok: true } when Player.findByPk returns null", async () => {
+      const user = mockUser();
+      mockFetch
+        .mockResolvedValueOnce({
+          status: 201,
+          json: jest.fn().mockResolvedValue({ id: "gist-abc" }),
+        })
+        .mockResolvedValueOnce({ status: 204 }) // dispatch
+        .mockResolvedValueOnce({ status: 204 }); // _deleteGist on webhook
+      await controller.generate(user, { eventId: "a0000000-0000-4000-8000-000000000001" });
+
+      jest.spyOn(Player, "findByPk").mockResolvedValue(null);
+
+      const result = await controller.webhook("test-secret", {
+        run_id: "gh-run-nullplayer",
+        user_id: "user-1",
+        status: "completed",
       });
 
       expect(result).toEqual({ ok: true });

--- a/apps/api/src/app/controllers/cp.controller.ts
+++ b/apps/api/src/app/controllers/cp.controller.ts
@@ -16,6 +16,7 @@ import {
   HttpException,
   Logger,
   NotFoundException,
+  OnModuleInit,
   Param,
   Post,
   Res,
@@ -37,7 +38,7 @@ interface CpGenerationRecord {
 }
 
 @Controller("cp")
-export class CpController {
+export class CpController implements OnModuleInit {
   private readonly logger = new Logger(CpController.name);
 
   /**
@@ -54,6 +55,13 @@ export class CpController {
     private mailingService: MailingService
   ) {}
 
+  onModuleInit() {
+    const secret = this.configService.get("CP_WEBHOOK_SECRET");
+    if (!secret) {
+      this.logger.warn("CP_WEBHOOK_SECRET is not configured — all webhook calls will be rejected");
+    }
+  }
+
   @Post("generate")
   async generate(@User() user: Player, @Body() body: { eventId: string; locale?: string }) {
     if (!user?.id) {
@@ -65,6 +73,8 @@ export class CpController {
     if (!hasPermission) {
       throw new ForbiddenException("Insufficient permissions");
     }
+
+    this._cleanupExpiredRecords();
 
     const { eventId, locale = "nl_BE" } = body;
     if (!eventId || !IsUUID(eventId)) {
@@ -176,9 +186,36 @@ export class CpController {
       throw new UnauthorizedException("Invalid webhook secret");
     }
 
-    this.logger.log(
-      `CP webhook received: run_id=${body.run_id}, status=${body.status}, user_id=${body.user_id}`
-    );
+    this._cleanupExpiredRecords();
+
+    // T007: Validate required fields
+    if (!body.run_id || !body.user_id || !body.status) {
+      throw new BadRequestException("run_id, user_id, and status are required");
+    }
+
+    // T008: Validate status enum
+    if (body.status !== "completed" && body.status !== "failed") {
+      throw new BadRequestException(
+        `Invalid status: ${body.status}. Must be "completed" or "failed"`
+      );
+    }
+
+    // T009: Idempotency guard
+    const existingRecord = this.generations.get(body.run_id);
+    if (existingRecord && existingRecord.status !== "pending") {
+      this.logger.warn("Duplicate webhook delivery", {
+        runId: body.run_id,
+        existingStatus: existingRecord.status,
+      });
+      return { ok: true };
+    }
+
+    // T010: Structured receipt log
+    this.logger.log("Webhook received", {
+      runId: body.run_id,
+      userId: body.user_id,
+      status: body.status,
+    });
 
     // Find the pending record for this user and update it with the real run_id
     let matchedTrackingId: string | undefined;
@@ -188,11 +225,18 @@ export class CpController {
         record.status = body.status === "completed" ? "completed" : "failed";
         matchedTrackingId = trackingId;
 
-        // Best-effort Gist cleanup
+        // T004: Best-effort Gist cleanup wrapped in try/catch
         if (record.gistId) {
           const githubToken = this.configService.get("GH_TOKEN_CP");
           if (githubToken) {
-            await this._deleteGist(record.gistId, githubToken);
+            try {
+              await this._deleteGist(record.gistId, githubToken);
+            } catch (e) {
+              this.logger.warn("Gist cleanup failed", {
+                gistId: record.gistId,
+                error: String(e),
+              });
+            }
           }
         }
 
@@ -200,6 +244,19 @@ export class CpController {
         this.pendingByEvent.delete(record.eventId);
         break;
       }
+    }
+
+    // T011: Structured record-match log
+    if (matchedTrackingId) {
+      this.logger.log("Matched pending record", {
+        runId: body.run_id,
+        trackingId: matchedTrackingId,
+      });
+    } else {
+      this.logger.warn("No pending record found — storing by run_id directly", {
+        runId: body.run_id,
+        userId: body.user_id,
+      });
     }
 
     // Also store by run_id for download lookups
@@ -220,11 +277,35 @@ export class CpController {
       });
     }
 
-    // Send email notification
+    // T005/T006: Send email notification wrapped in try/catch
     if (body.status === "completed") {
-      await this._sendCompletionEmail(body.user_id, body.run_id);
+      try {
+        await this._sendCompletionEmail(body.user_id, body.run_id);
+        this.logger.log("Completion email dispatched", {
+          runId: body.run_id,
+          userId: body.user_id,
+        });
+      } catch (e) {
+        this.logger.error("Failed to send completion email", {
+          runId: body.run_id,
+          userId: body.user_id,
+          error: String(e),
+        });
+      }
     } else {
-      await this._sendFailureEmail(body.user_id);
+      try {
+        await this._sendFailureEmail(body.user_id);
+        this.logger.log("Failure email dispatched", {
+          runId: body.run_id,
+          userId: body.user_id,
+        });
+      } catch (e) {
+        this.logger.error("Failed to send failure email", {
+          runId: body.run_id,
+          userId: body.user_id,
+          error: String(e),
+        });
+      }
     }
 
     return { ok: true };

--- a/specs/034-cp-webhook-hardening/checklists/requirements.md
+++ b/specs/034-cp-webhook-hardening/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: CP Webhook Hardening & Email Diagnostics
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. Spec is ready for `/speckit-plan`.

--- a/specs/034-cp-webhook-hardening/data-model.md
+++ b/specs/034-cp-webhook-hardening/data-model.md
@@ -1,0 +1,39 @@
+# Data Model: CP Webhook Hardening
+
+No new persistent entities. No database migrations required.
+
+## Modified In-Memory Structures
+
+### CpGenerationRecord (existing, no field changes)
+
+```
+runId      : string   — tracking key (eventId-timestamp initially; replaced by real run_id via webhook)
+userId     : string   — player UUID
+eventId    : string   — competition event UUID
+locale     : string   — default "nl_BE"
+status     : "pending" | "completed" | "failed"
+createdAt  : Date
+gistId?    : string   — GitHub Gist ID (present until cleaned up)
+```
+
+**State transitions** (unchanged):
+
+```
+[generate called] → pending
+[webhook completed] → completed
+[webhook failed]    → failed
+```
+
+### WebhookBody (new validated input shape, in-controller only)
+
+```
+run_id   : string   — non-empty; GitHub Actions run ID
+user_id  : string   — non-empty; player UUID
+status   : "completed" | "failed"
+```
+
+Validation is manual (guard clauses), consistent with project conventions. No DTO class is introduced.
+
+## Idempotency Key
+
+`this.generations.has(body.run_id)` with status !== `"pending"` → already processed. The Map is keyed by both the internal tracking ID and the real `run_id` after webhook receipt. A second delivery of the same `run_id` hits the already-existing key and is short-circuited.

--- a/specs/034-cp-webhook-hardening/plan.md
+++ b/specs/034-cp-webhook-hardening/plan.md
@@ -1,0 +1,181 @@
+# Implementation Plan: CP Webhook Hardening & Email Diagnostics
+
+**Branch**: `034-cp-webhook-hardening` | **Date**: 2026-06-09 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/034-cp-webhook-hardening/spec.md`
+
+## Summary
+
+Harden `POST /cp/webhook` in `CpController` to fix silent email delivery failures. Changes: wrap email dispatch in try/catch so webhook always returns 2xx on valid input, add body validation (400 on missing/invalid fields), add idempotency guard for duplicate `run_id` deliveries, add `OnModuleInit` startup warning for missing `CP_WEBHOOK_SECRET`, call `_cleanupExpiredRecords` on every request, and add structured log entries throughout the flow. Update `cp.controller.spec.ts` with matching test cases.
+
+## Technical Context
+
+**Language/Version**: TypeScript, Node.js 20  
+**Primary Dependencies**: NestJS (Fastify adapter), `@badman/backend-mailing`, `@badman/backend-database` (Player model), ConfigService  
+**Storage**: In-memory `Map<string, CpGenerationRecord>` — no DB changes  
+**Testing**: Jest via `npx jest --config apps/api/jest.config.ts` (or `nx test api`)  
+**Target Platform**: NestJS API server, `apps/api/`  
+**Project Type**: web-service  
+**Performance Goals**: Webhook response < 500ms; no new I/O paths added  
+**Constraints**: No DB migration, no new dependencies, no change to mailing service internals  
+**Scale/Scope**: Once-a-year operation, < 10 concurrent users
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle                    | Applies?                                                                                                                          | Status                                         |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| I. Code-First GraphQL        | No — REST controller, no new entities                                                                                             | ✅ PASS                                        |
+| II. Translation Discipline   | No — no user-facing strings in scope                                                                                              | ✅ PASS                                        |
+| III. Transactional Mutations | No — REST controller, not a GraphQL mutation                                                                                      | ✅ PASS                                        |
+| IV. Resolver Test Discipline | Partial — controller spec must be updated with new test cases, following `jest.spyOn` + `afterEach(jest.restoreAllMocks)` pattern | ✅ PASS (spec already exists; new cases added) |
+| V. Legacy Frontend Boundary  | No — backend only                                                                                                                 | ✅ PASS                                        |
+
+**Post-design re-check**: No new entities, no i18n changes, no GraphQL mutations. Constitution fully satisfied.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/034-cp-webhook-hardening/
+├── plan.md           ← this file
+├── spec.md
+├── research.md
+├── data-model.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (files modified)
+
+```text
+apps/api/src/app/controllers/
+├── cp.controller.ts       ← main changes
+└── cp.controller.spec.ts  ← new test cases
+```
+
+No new files. No migrations.
+
+## Implementation Design
+
+### Changes to `cp.controller.ts`
+
+#### 1. Implement `OnModuleInit` for startup warning
+
+```typescript
+import { OnModuleInit } from "@nestjs/common";
+
+export class CpController implements OnModuleInit {
+  onModuleInit() {
+    const secret = this.configService.get("CP_WEBHOOK_SECRET");
+    if (!secret) {
+      this.logger.warn("CP_WEBHOOK_SECRET is not configured — all webhook calls will be rejected");
+    }
+  }
+}
+```
+
+#### 2. Add body validation to `webhook()`
+
+At the top of the handler, before any processing:
+
+```typescript
+if (!body.run_id || !body.user_id || !body.status) {
+  throw new BadRequestException("run_id, user_id, and status are required");
+}
+if (body.status !== "completed" && body.status !== "failed") {
+  throw new BadRequestException(`Invalid status: ${body.status}. Must be "completed" or "failed"`);
+}
+```
+
+#### 3. Add idempotency guard
+
+After validation, before record lookup:
+
+```typescript
+const existing = this.generations.get(body.run_id);
+if (existing && existing.status !== "pending") {
+  this.logger.warn(
+    `Duplicate webhook delivery for run_id=${body.run_id}, status=${existing.status} — ignoring`
+  );
+  return { ok: true };
+}
+```
+
+#### 4. Wrap email dispatch in try/catch
+
+Replace the bare awaits with isolated try/catch blocks:
+
+```typescript
+if (body.status === "completed") {
+  try {
+    await this._sendCompletionEmail(body.user_id, body.run_id);
+    this.logger.log(`Completion email dispatched`, { runId: body.run_id, userId: body.user_id });
+  } catch (e) {
+    this.logger.error(`Failed to send completion email`, {
+      runId: body.run_id,
+      userId: body.user_id,
+      error: String(e),
+    });
+  }
+} else {
+  try {
+    await this._sendFailureEmail(body.user_id);
+    this.logger.log(`Failure email dispatched`, { runId: body.run_id, userId: body.user_id });
+  } catch (e) {
+    this.logger.error(`Failed to send failure email`, {
+      runId: body.run_id,
+      userId: body.user_id,
+      error: String(e),
+    });
+  }
+}
+```
+
+#### 5. Add structured log entries at receipt and record-match
+
+```typescript
+this.logger.log(`Webhook received`, {
+  runId: body.run_id,
+  userId: body.user_id,
+  status: body.status,
+});
+// ... after record lookup:
+if (matchedTrackingId) {
+  this.logger.log(`Matched pending record`, { runId: body.run_id, trackingId: matchedTrackingId });
+} else {
+  this.logger.warn(`No pending record found — storing by run_id directly`, {
+    runId: body.run_id,
+    userId: body.user_id,
+  });
+}
+```
+
+#### 6. Call `_cleanupExpiredRecords` at start of `generate` and `webhook`
+
+Add as first line of each handler body, after auth/validation:
+
+```typescript
+this._cleanupExpiredRecords();
+```
+
+### Changes to `cp.controller.spec.ts`
+
+New test cases to add under `describe("POST /cp/webhook")`:
+
+| Test                                   | Expected outcome                        |
+| -------------------------------------- | --------------------------------------- |
+| Missing `run_id`                       | Throws `BadRequestException`            |
+| Missing `user_id`                      | Throws `BadRequestException`            |
+| Missing `status`                       | Throws `BadRequestException`            |
+| Invalid `status` value (`"success"`)   | Throws `BadRequestException`            |
+| Email dispatch throws                  | Webhook still returns `{ ok: true }`    |
+| Duplicate `run_id` (already processed) | Returns `{ ok: true }`, no second email |
+| `Player.findByPk` returns null         | Returns `{ ok: true }`, warning logged  |
+
+Existing tests must continue to pass unchanged.
+
+## Complexity Tracking
+
+No constitution violations. No complexity tracking needed.

--- a/specs/034-cp-webhook-hardening/research.md
+++ b/specs/034-cp-webhook-hardening/research.md
@@ -1,0 +1,62 @@
+# Research: CP Webhook Hardening & Email Diagnostics
+
+## Decision 1: Input validation approach
+
+**Decision**: Manual validation inside the controller handler (guard clauses + `BadRequestException`), consistent with the existing `generate` handler pattern.
+
+**Rationale**: No global `ValidationPipe` is configured in `main.ts`. The existing controllers (`cp.controller.ts`, `app.controller.ts`) use plain body types with manual checks. Introducing class-validator DTOs would be inconsistent and out of scope for this targeted hardening.
+
+**Alternatives considered**:
+
+- Class-validator + `@UsePipes(ValidationPipe)`: Correct for a greenfield NestJS app but inconsistent with current style; deferred to a future unified validation pass.
+
+---
+
+## Decision 2: Startup configuration warning
+
+**Decision**: Implement `OnModuleInit` on `CpController`. Log a warning (not an error) if `CP_WEBHOOK_SECRET` is absent or empty.
+
+**Rationale**: `OnModuleInit` is the established pattern in this codebase (see `DatabaseModule`, `CompileService`, `EnrollmentModule`). A warning at boot gives operators immediate visibility without blocking startup.
+
+**Alternatives considered**:
+
+- Throw at startup: Too disruptive — the controller is rarely used. A warning is sufficient.
+
+---
+
+## Decision 3: Error isolation for email dispatch
+
+**Decision**: Wrap each `_sendCompletionEmail` / `_sendFailureEmail` call in an independent try/catch inside the webhook handler. Log error with `run_id`, `user_id`, and error message. Always return `{ ok: true }` when the secret is valid and body is well-formed.
+
+**Rationale**: GitHub Actions retries on 5xx. If email dispatch fails and the webhook returns 500, GitHub retries — potentially sending duplicate emails when the transient failure clears, or triggering a retry storm that never succeeds if the email failure is permanent. Returning 2xx on email failure matches the webhook contract: "we received your notification" vs "we successfully emailed the user".
+
+**Alternatives considered**:
+
+- Return 500 on email failure and let GitHub retry: Causes duplicate emails; the retry loop never helps if the email system is down.
+- Fire-and-forget (don't await email): Hides errors entirely; no improvement over current state.
+
+---
+
+## Decision 4: Idempotency guard for duplicate webhook deliveries
+
+**Decision**: Before processing, check if `body.run_id` is already a key in `this.generations` with a non-pending status. If found, log a warning and return `{ ok: true }` immediately.
+
+**Rationale**: GitHub may deliver the same webhook twice on transient HTTP errors. A duplicate delivery should not re-send email or overwrite the already-processed record.
+
+**Implementation note**: The tracking ID key (`${eventId}-${timestamp}`) and the real `run_id` are both stored as keys. A duplicate delivery arrives with the same `run_id`, which is already a key after first processing. Simple `Map.has(body.run_id)` check suffices.
+
+---
+
+## Decision 5: `_cleanupExpiredRecords` invocation
+
+**Decision**: Call at the start of both `generate` and `webhook` handlers (lazy cleanup, no timer).
+
+**Rationale**: The method already exists and is fully implemented. It just needs to be called. Timer-based cleanup is unnecessary for a once-a-year operation. Lazy cleanup on request is consistent with the original design intent (per the existing comment in the code).
+
+---
+
+## Decision 6: Structured logging fields
+
+**Decision**: Add `context` object to log calls in the webhook handler, including `{ runId, userId, status }`. Use existing `this.logger` (NestJS Logger), which feeds into the winston transport already configured.
+
+**Rationale**: The existing logger is already wired to winston via `app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER))`. Structured log objects are supported. No new logging infrastructure needed.

--- a/specs/034-cp-webhook-hardening/spec.md
+++ b/specs/034-cp-webhook-hardening/spec.md
@@ -1,0 +1,106 @@
+# Feature Specification: CP Webhook Hardening & Email Diagnostics
+
+**Feature Branch**: `034-cp-webhook-hardening`  
+**Created**: 2026-06-09  
+**Status**: Draft  
+**Input**: Improve and harden `/cp/webhook`; fix silent email delivery failures with no visible errors
+
+## Context
+
+The CP export flow triggers a GitHub Actions workflow, which calls back `/cp/webhook` when done. The webhook is supposed to send a notification email to the requesting user. Emails are not being received and no errors are surfacing. Code review reveals several silent failure paths and missing validation.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Webhook completes and email is delivered (Priority: P1)
+
+A competition admin triggers CP generation. GitHub Actions completes the workflow and calls the webhook. The admin receives an email with a download link.
+
+**Why this priority**: Core success path. Currently broken — emails are not received and there is no error trace.
+
+**Independent Test**: Trigger a generation, send a webhook call with `status: "completed"`, verify email is sent (or logged as attempted with reason if skipped).
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid webhook secret and a completed generation record, **When** the webhook receives `status: "completed"`, **Then** a completion email is dispatched and the webhook returns `{ ok: true }`.
+2. **Given** a valid webhook secret and `status: "failed"`, **When** the webhook is called, **Then** a failure email is dispatched and the webhook returns `{ ok: true }`.
+3. **Given** email dispatch throws an internal error, **When** the webhook processes it, **Then** the error is logged with full context (user ID, run ID, error message) and the webhook still returns `{ ok: true }` — the caller never receives a 5xx.
+4. **Given** the user record cannot be found in the database, **When** the webhook tries to send an email, **Then** a warning is logged with user ID and the webhook returns `{ ok: true }`.
+
+---
+
+### User Story 2 - Webhook rejects invalid or malformed requests (Priority: P2)
+
+The webhook endpoint is public (no auth guard). It must reject unauthorized callers and invalid payloads before doing any work.
+
+**Why this priority**: Security hardening. Without this, anyone who discovers the URL can inject fake completion events.
+
+**Independent Test**: Send requests with wrong secret, missing secret, missing required fields — each must be rejected with an appropriate 4xx, no side effects.
+
+**Acceptance Scenarios**:
+
+1. **Given** a request with a missing or incorrect `x-webhook-secret` header, **When** the webhook is called, **Then** it returns 401 and no record is modified.
+2. **Given** `CP_WEBHOOK_SECRET` is not configured in the environment, **When** the server starts, **Then** a startup warning is logged so operators know the endpoint is misconfigured.
+3. **Given** a request body missing `run_id`, `user_id`, or `status`, **When** the webhook is called, **Then** it returns 400 with a clear error indicating which field is missing.
+4. **Given** `status` is a value other than `"completed"` or `"failed"`, **When** the webhook is called, **Then** it returns 400.
+
+---
+
+### User Story 3 - Webhook flow is fully traceable in logs (Priority: P3)
+
+An operator or developer can follow the entire webhook execution path in logs: receipt, record lookup result, gist cleanup result, email dispatch attempt, and outcome.
+
+**Why this priority**: Without this, diagnosing "emails don't seem to get sent" requires adding logging under pressure. Having it from the start prevents the next silent failure.
+
+**Independent Test**: Tail server logs while sending a webhook call; confirm a structured trace covering receipt → record match → email attempt → outcome.
+
+**Acceptance Scenarios**:
+
+1. **Given** a webhook call arrives, **When** it is processed, **Then** logs include: run ID, user ID, status, whether a pending record was matched, and whether email dispatch was attempted.
+2. **Given** email dispatch is skipped (e.g., user has no email, mailing not configured), **When** the webhook processes, **Then** a warning log explains why, with enough context to diagnose in production.
+3. **Given** gist cleanup fails, **When** the webhook processes, **Then** the failure is logged as a warning (not an error) and processing continues normally.
+
+---
+
+### Edge Cases
+
+- What happens when the webhook is called for a `user_id` with no matching pending record (e.g., API restarted between generate and webhook)? → Record created from webhook data; email attempted using the provided `user_id`.
+- What if `Player.findByPk` returns null (user deleted)? → Warn and skip email; webhook returns `{ ok: true }`.
+- What if email sending fails (SMTP error, missing config)? → Log error with context; webhook returns `{ ok: true }`.
+- What if the same `run_id` arrives twice (GitHub retry after a transient failure)? → Second call should be idempotent — log a warning and return `{ ok: true }` without re-sending email.
+- What if `CP_WEBHOOK_SECRET` is configured but empty string? → Treat as misconfigured; reject all requests.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The webhook MUST wrap all email dispatch calls in a try/catch so that email failures never cause the endpoint to return a 5xx response.
+- **FR-002**: The webhook MUST validate that `run_id`, `user_id`, and `status` are present non-empty strings; return 400 if any are missing.
+- **FR-003**: The webhook MUST validate that `status` is one of `"completed"` or `"failed"`; return 400 for other values.
+- **FR-004**: At startup, the controller MUST log a warning if `CP_WEBHOOK_SECRET` is not configured or is an empty string.
+- **FR-005**: Each webhook invocation MUST produce structured log entries covering: arrival, record match result, email dispatch attempt, and final outcome.
+- **FR-006**: The webhook MUST be idempotent for duplicate `run_id` deliveries: detect an already-processed record and return `{ ok: true }` without re-sending email.
+- **FR-007**: Gist cleanup failures MUST be logged as warnings and MUST NOT abort normal webhook processing.
+- **FR-008**: The `_cleanupExpiredRecords` method MUST be called at the start of each `generate` and `webhook` request to prevent unbounded in-memory growth.
+
+### Key Entities
+
+- **CpGenerationRecord**: In-memory record tracking a generation run. Fields: `runId`, `userId`, `eventId`, `locale`, `status`, `createdAt`, `gistId`. Status transitions: `pending` → `completed` | `failed`.
+- **WebhookBody**: Validated input shape for the webhook. Required: `run_id` (non-empty string), `user_id` (non-empty string), `status` (`"completed"` | `"failed"`). Optional: `download_url` (reserved for future use).
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: A webhook call that previously failed silently now either sends an email or emits a log entry explaining exactly why it did not, in 100% of cases.
+- **SC-002**: A malformed webhook request (missing fields, wrong secret) returns a 4xx response within 200ms with no state changes.
+- **SC-003**: Webhook endpoint returns `{ ok: true }` (2xx) in all scenarios where the secret is valid and the body is well-formed, even if email dispatch fails — eliminating spurious GitHub retry storms.
+- **SC-004**: Duplicate webhook deliveries (same `run_id`) are handled gracefully: no duplicate emails, no errors, `{ ok: true }` returned.
+- **SC-005**: All webhook log entries include `run_id` and `user_id` as structured fields, enabling log search/filter by those identifiers.
+
+## Assumptions
+
+- `MAIL_ENABLED`, `DEV_EMAIL_DESTINATION`, and SMTP config are owned by the mailing service; this feature adds logging around the call but does not change mailing service internals.
+- The in-memory store is intentional for this once-a-year operation; this feature does not replace it with a persistent store.
+- GitHub Actions retries a webhook on 5xx but not on 2xx, so returning `{ ok: true }` even on email failure is the correct contract.
+- The duplicate-delivery guard uses `run_id` as the idempotency key; the same `run_id` arriving twice means the first delivery already set status to `completed` or `failed`.
+- Startup warning for missing `CP_WEBHOOK_SECRET` is sufficient; the endpoint does not need to be disabled at startup (it will reject all calls anyway).

--- a/specs/034-cp-webhook-hardening/tasks.md
+++ b/specs/034-cp-webhook-hardening/tasks.md
@@ -1,0 +1,156 @@
+# Tasks: CP Webhook Hardening & Email Diagnostics
+
+**Input**: Design documents from `specs/034-cp-webhook-hardening/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅
+
+**Organization**: Tasks follow user story priority order. All implementation changes land in 2 files:
+
+- `apps/api/src/app/controllers/cp.controller.ts` — controller
+- `apps/api/src/app/controllers/cp.controller.spec.ts` — tests
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to
+
+---
+
+## Phase 1: Foundational — Controller Lifecycle Hook
+
+**Purpose**: `OnModuleInit` must be in place before anything else; startup warning depends on it.
+
+**⚠️ CRITICAL**: Implement before any user story work. Affects controller class signature.
+
+- [ ] T001 Add `OnModuleInit` to `CpController` class and implement `onModuleInit()` that reads `CP_WEBHOOK_SECRET` and logs `this.logger.warn("CP_WEBHOOK_SECRET is not configured — all webhook calls will be rejected")` when absent or empty in `apps/api/src/app/controllers/cp.controller.ts`
+
+**Checkpoint**: Controller boots with startup warning visible when `CP_WEBHOOK_SECRET` env var is unset.
+
+---
+
+## Phase 2: User Story 1 — Email delivery robustness (Priority: P1) 🎯 MVP
+
+**Goal**: Webhook always returns `{ ok: true }` on valid input regardless of email outcome; expired records cleaned up; email failures produce log entries with full context.
+
+**Independent Test**: Send a valid webhook call with `status: "completed"` where `MailingService.sendCpExportReadyMail` is mocked to throw — confirm `{ ok: true }` is returned and the error is logged.
+
+- [ ] T002 [US1] Call `this._cleanupExpiredRecords()` as the first statement inside `generate()` after the auth and permission checks in `apps/api/src/app/controllers/cp.controller.ts`
+- [ ] T003 [US1] Call `this._cleanupExpiredRecords()` as the first statement inside `webhook()` after the secret check in `apps/api/src/app/controllers/cp.controller.ts`
+- [ ] T004 [US1] Wrap the `await this._deleteGist(record.gistId, githubToken)` call inside the webhook record-lookup loop in a `try/catch`; on catch log `this.logger.warn("Gist cleanup failed", { gistId: record.gistId, error: String(e) })` and continue processing in `apps/api/src/app/controllers/cp.controller.ts`
+- [ ] T005 [US1] Replace the bare `await this._sendCompletionEmail(body.user_id, body.run_id)` with a `try/catch` block; on success log `this.logger.log("Completion email dispatched", { runId: body.run_id, userId: body.user_id })`; on catch log `this.logger.error("Failed to send completion email", { runId: body.run_id, userId: body.user_id, error: String(e) })` in `apps/api/src/app/controllers/cp.controller.ts`
+- [ ] T006 [US1] Replace the bare `await this._sendFailureEmail(body.user_id)` with a `try/catch` block; on success log `this.logger.log("Failure email dispatched", { runId: body.run_id, userId: body.user_id })`; on catch log `this.logger.error("Failed to send failure email", { runId: body.run_id, userId: body.user_id, error: String(e) })` in `apps/api/src/app/controllers/cp.controller.ts`
+
+**Checkpoint**: All existing `POST /cp/webhook` tests pass. Email throwing does not crash the webhook.
+
+---
+
+## Phase 3: User Story 2 — Input validation & idempotency (Priority: P2)
+
+**Goal**: Webhook returns 400 for malformed bodies; duplicate `run_id` deliveries are short-circuited with `{ ok: true }`.
+
+**Independent Test**: POST `/cp/webhook` with valid secret but `run_id: ""` → expect 400. POST twice with same `run_id` → second call returns `{ ok: true }` immediately.
+
+- [ ] T007 [US2] Add guard clauses immediately after the `expectedSecret` check in `webhook()`: throw `new BadRequestException("run_id, user_id, and status are required")` if any of `body.run_id`, `body.user_id`, or `body.status` is falsy in `apps/api/src/app/controllers/cp.controller.ts`
+- [ ] T008 [US2] Add status enum guard directly after T007: throw `new BadRequestException(\`Invalid status: \${body.status}. Must be "completed" or "failed"\`)`if`body.status !== "completed" && body.status !== "failed"`in`apps/api/src/app/controllers/cp.controller.ts`
+- [ ] T009 [US2] Add idempotency guard after the cleanup call and validation guards: `const existingRecord = this.generations.get(body.run_id); if (existingRecord && existingRecord.status !== "pending") { this.logger.warn("Duplicate webhook delivery", { runId: body.run_id, existingStatus: existingRecord.status }); return { ok: true }; }` in `apps/api/src/app/controllers/cp.controller.ts`
+
+**Checkpoint**: Malformed requests return 400. Sending the same webhook twice does not double-send email.
+
+---
+
+## Phase 4: User Story 3 — Structured logging throughout flow (Priority: P3)
+
+**Goal**: Every webhook invocation leaves a log trail: receipt, record match result, email dispatch attempt and outcome.
+
+**Independent Test**: With `Logger` spied (`jest.spyOn(controller['logger'], 'log')`), send a valid webhook — confirm log calls with `runId` and `userId` in their context argument.
+
+- [ ] T010 [US3] Add `this.logger.log("Webhook received", { runId: body.run_id, userId: body.user_id, status: body.status })` immediately after all validation guards (after T007–T009 logic) in `apps/api/src/app/controllers/cp.controller.ts`
+- [ ] T011 [US3] After the pending-record lookup `for` loop, add a conditional log: `if (matchedTrackingId) { this.logger.log("Matched pending record", { runId: body.run_id, trackingId: matchedTrackingId }); } else { this.logger.warn("No pending record found — storing by run_id directly", { runId: body.run_id, userId: body.user_id }); }` in `apps/api/src/app/controllers/cp.controller.ts`
+
+**Checkpoint**: Tailing server logs during a webhook call shows receipt, record match, and email outcome entries with `runId` and `userId`.
+
+---
+
+## Phase 5: Tests
+
+**Purpose**: Cover all new behavior with unit tests; ensure existing tests remain green.
+
+- [ ] T012 [US2] Add test in `describe("POST /cp/webhook")`: `it("should return 400 if run_id is missing")` — call `controller.webhook("test-secret", { run_id: "", user_id: "user-1", status: "completed" })` and expect `BadRequestException` in `apps/api/src/app/controllers/cp.controller.spec.ts`
+- [ ] T013 [US2] Add test: `it("should return 400 if user_id is missing")` — expect `BadRequestException` when `user_id` is empty string in `apps/api/src/app/controllers/cp.controller.spec.ts`
+- [ ] T014 [US2] Add test: `it("should return 400 if status is missing")` — expect `BadRequestException` when `status` is empty string in `apps/api/src/app/controllers/cp.controller.spec.ts`
+- [ ] T015 [US2] Add test: `it("should return 400 for invalid status value")` — call with `status: "success"` and expect `BadRequestException` in `apps/api/src/app/controllers/cp.controller.spec.ts`
+- [ ] T016 [US1] Add test: `it("should return { ok: true } even when email dispatch throws")` — mock `MailingService.sendCpExportReadyMail` to `jest.fn().mockRejectedValue(new Error("SMTP error"))`; set up a pending record via `generate()`; send webhook with valid secret and `status: "completed"`; expect result to equal `{ ok: true }` in `apps/api/src/app/controllers/cp.controller.spec.ts`
+- [ ] T017 [US2] Add test: `it("should return { ok: true } for duplicate run_id without re-sending email")` — process a webhook once (status completed); spy on `MailingService`; send same `run_id` again; confirm mail spy called only once total and result is `{ ok: true }` in `apps/api/src/app/controllers/cp.controller.spec.ts`
+- [ ] T018 [US1] Add test: `it("should return { ok: true } when Player.findByPk returns null")` — mock `Player.findByPk` to return `null`; set up pending record; send webhook; expect `{ ok: true }` and no exception in `apps/api/src/app/controllers/cp.controller.spec.ts`
+- [ ] T019 Run full controller test suite and confirm all tests pass: `npx jest --config apps/api/jest.config.ts apps/api/src/app/controllers/cp.controller.spec.ts`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Foundational)**: No dependencies — start immediately
+- **Phase 2 (US1)**: Depends on Phase 1 — `OnModuleInit` must be in place
+- **Phase 3 (US2)**: Can start after Phase 1; independent of Phase 2 (different code paths in the method)
+- **Phase 4 (US3)**: Depends on Phase 2 and Phase 3 — log entries reference the guards and cleanup calls added there
+- **Phase 5 (Tests)**: Can be written from Phase 3 onward; T016/T018 depend on Phase 2; T012–T015/T017 depend on Phase 3
+
+### User Story Dependencies
+
+- **US1 (P1)**: After Phase 1 — no dependency on US2 or US3
+- **US2 (P2)**: After Phase 1 — no dependency on US1 or US3
+- **US3 (P3)**: After US1 and US2 — log entries for email and record-match reference both
+
+### Within Each Phase
+
+- T002, T003 can be done together (both add the same 1-line call, different methods)
+- T004, T005, T006 are sequential edits to the same webhook method body
+- T007, T008 must be sequential (T008 comes right after T007 in the method)
+- T009 comes after T007 + T008
+- T012–T018 are sequential additions to the same spec file
+
+---
+
+## Parallel Opportunities
+
+```bash
+# Phase 2 + Phase 3 can run in parallel (different code paths):
+Task Agent A: "Implement US1 email try/catch and cleanup (T002–T006)"
+Task Agent B: "Implement US2 body validation and idempotency (T007–T009)"
+
+# Tests can be written in parallel with Phase 4 (US3 logging):
+Task Agent A: "Add US3 structured log entries (T010–T011)"
+Task Agent B: "Write test cases T012–T015 for validation"
+Task Agent C: "Write test cases T016–T018 for email error isolation"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 (T001) — OnModuleInit
+2. Complete Phase 2 (T002–T006) — email error isolation + cleanup
+3. Add T016 + T018 from Phase 5 tests
+4. Run T019 — verify tests pass
+5. **STOP and VALIDATE**: webhook no longer returns 500 on email failure
+
+### Incremental Delivery
+
+1. Phase 1 + Phase 2 → Fix silent email failures (MVP)
+2. Phase 3 → Harden input validation + idempotency
+3. Phase 4 → Add full structured logging
+4. Phase 5 → Complete test coverage
+5. Each phase adds value and is independently verifiable
+
+---
+
+## Notes
+
+- All changes are in 2 files — no migrations, no new dependencies, no new files
+- `_deleteGist` already logs unexpected HTTP status codes; T004 adds `try/catch` around the `fetch` call itself (network errors)
+- Existing tests must pass throughout — do not remove or modify existing test cases
+- `_cleanupExpiredRecords` already exists and is fully implemented; tasks T002/T003 just call it
+- `BadRequestException` is already imported in `cp.controller.ts`; no new imports needed for T007/T008
+- `OnModuleInit` needs to be imported from `@nestjs/common` (add to existing import list in T001)


### PR DESCRIPTION
## Summary

- **Root cause of missing emails**: `_sendCompletionEmail`/`_sendFailureEmail` errors propagated out of the webhook handler, returning 500 to GitHub Actions — which triggered retry storms, not emails. This PR wraps both calls in try/catch so the webhook always returns `{ ok: true }` on valid input regardless of mail service outcome.
- Add body validation (`run_id`, `user_id`, `status` required; `status` must be `"completed"` or `"failed"`) — returns 400 on malformed input.
- Add idempotency guard: duplicate `run_id` deliveries return `{ ok: true }` immediately without re-sending email.
- Add `OnModuleInit` startup warning when `CP_WEBHOOK_SECRET` is unconfigured.
- Wrap `_deleteGist` in try/catch (best-effort cleanup, logs warn on failure).
- Call `_cleanupExpiredRecords()` on every `generate` and `webhook` request (method existed but was never called).
- Add structured log entries: receipt, record-match, email dispatch attempt and outcome.

## Test plan

- [ ] All 25 unit tests pass (`npx jest --config apps/api/jest.config.ts apps/api/src/app/controllers/cp.controller.spec.ts`)
- [ ] 7 new test cases cover: missing fields (×3), invalid status, email throws, duplicate run_id, null Player
- [ ] Existing 18 tests unchanged and green
- [ ] Constitution check: all 5 principles pass (REST controller — no GraphQL mutations, no i18n, no new entities, no legacy frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)