### PR TITLE
fix(cp): correct webhook callback URL to /v1 + add deploy version assert

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -133,6 +133,40 @@ jobs:
           WORKER_RANKING_HOOK: ${{ secrets.PROD_WORKER_RANKING_HOOK }}
           GH_TOKEN_CP: ${{ secrets.GH_TOKEN_CP }}
 
+  # The Render deploy hook is fire-and-forget: deploy-prod returns as soon as
+  # the hook POST succeeds, NOT when the new build is live. This job polls the
+  # public /api/version endpoint until the server reports the freshly-released
+  # version, catching a stale build cache (or failed Render build) that would
+  # otherwise silently keep serving old code. Skipped when no version bump
+  # happened (NEW_VERSION empty) since there is nothing new to assert against.
+  verify-prod-version:
+    needs: [build, deploy-prod]
+    if: github.ref == 'refs/heads/main' && needs.build.outputs.NEW_VERSION != ''
+    runs-on: ubuntu-latest
+    env:
+      EXPECTED_VERSION: ${{ needs.build.outputs.NEW_VERSION }}
+      # URI versioning (defaultVersion "1" in main.ts) puts every route under /api/v1.
+      API_URL: https://api.badman.app/api/v1/version
+    steps:
+      - name: Wait for live server to report released version
+        run: |
+          set -euo pipefail
+          echo "Expecting version '$EXPECTED_VERSION' at $API_URL"
+          deadline=$((SECONDS + 900)) # 15 min — covers Render build + boot
+          attempt=0
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            attempt=$((attempt + 1))
+            live="$(curl -fsS --max-time 10 "$API_URL" | jq -r '.version // empty' 2>/dev/null || true)"
+            echo "Attempt $attempt: live version='${live:-<unreachable>}'"
+            if [ "$live" = "$EXPECTED_VERSION" ]; then
+              echo "Live server is serving $EXPECTED_VERSION"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::Live server never reported version '$EXPECTED_VERSION' within 15 min — stale build cache or failed Render deploy."
+          exit 1
+
   sentry-release:
     needs: [build, deploy-prod]
     if: github.ref == 'refs/heads/main' && needs.build.outputs.NEW_VERSION != ''

--- a/apps/api/src/app/controllers/app.controller.spec.ts
+++ b/apps/api/src/app/controllers/app.controller.spec.ts
@@ -1,0 +1,19 @@
+import { AppController } from "./app.controller";
+import versionPackage from "../../version.json";
+
+describe("AppController", () => {
+  describe("getVersion", () => {
+    it("reports the version baked into the build", () => {
+      // getVersion has no runtime dependencies, so the injected collaborators
+      // are irrelevant here — pass nulls and assert the pure response shape.
+      const controller = new AppController(
+        null as never,
+        null as never,
+        null as never,
+        null as never
+      );
+
+      expect(controller.getVersion()).toEqual({ version: versionPackage.version });
+    });
+  });
+});

--- a/apps/api/src/app/controllers/app.controller.ts
+++ b/apps/api/src/app/controllers/app.controller.ts
@@ -1,4 +1,4 @@
-import { User } from "@badman/backend-authorization";
+import { AllowAnonymous, User } from "@badman/backend-authorization";
 
 import { Player } from "@badman/backend-database";
 import { PlannerService } from "@badman/backend-generator";
@@ -19,6 +19,7 @@ import {
 import { ConfigService } from "@nestjs/config";
 import { Queue } from "bull";
 import { FastifyReply } from "fastify";
+import versionPackage from "../../version.json";
 
 @Controller()
 export class AppController {
@@ -131,6 +132,17 @@ export class AppController {
       default:
         throw new HttpException("Unknown queue", 500);
     }
+  }
+
+  /**
+   * Reports the version baked into this running build. Used by the deploy
+   * pipeline to assert the live server actually serves the freshly-released
+   * artifact (guards against a stale build cache silently shipping old code).
+   */
+  @Get("version")
+  @AllowAnonymous()
+  getVersion() {
+    return { version: versionPackage.version };
   }
 
   @Get("planner")

--- a/apps/api/src/app/controllers/cp.controller.spec.ts
+++ b/apps/api/src/app/controllers/cp.controller.spec.ts
@@ -58,7 +58,7 @@ describe("CpController", () => {
       GH_TOKEN_CP: "ghp_test_token",
       GITHUB_REPO_OWNER: "Badminton-Apps",
       GITHUB_REPO_NAME: "badman",
-      CP_CALLBACK_URL: "https://api.test.com/api/cp/webhook",
+      CP_CALLBACK_URL: "https://api.test.com/api/v1/cp/webhook",
       CP_WEBHOOK_SECRET: "test-secret",
       CLIENT_URL: "https://badman.app",
     };

--- a/apps/api/tsconfig.spec.json
+++ b/apps/api/tsconfig.spec.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
+    "resolveJsonModule": true,
     "types": ["jest", "node"]
   },
   "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]

--- a/docs/guides/cp-export-deployment.md
+++ b/docs/guides/cp-export-deployment.md
@@ -7,6 +7,7 @@ Step-by-step guide for deploying the CP file export feature end-to-end.
 ## 1. GitHub Setup
 
 ### Create a Personal Access Token (PAT)
+
 - [ ] Go to GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens
 - [ ] Click "Generate new token"
 - [ ] **Name:** `badman-cp-export`
@@ -17,11 +18,13 @@ Step-by-step guide for deploying the CP file export feature end-to-end.
 - [ ] Copy the token value -- you'll need it for Render
 
 ### Add Repository Secrets
+
 - [ ] Go to the repo → Settings → Secrets and variables → Actions
 - [ ] Add secret: `CP_PASS` = the Access database password (ask the team / check existing env config for the value)
 - [ ] Add secret: `CP_WEBHOOK_SECRET` = generate a random string (e.g., `openssl rand -hex 32`)
 
 ### Verify Workflow
+
 - [ ] Push the `feat/cp-export-cross-platform` branch to the repo
 - [ ] Go to Actions tab → confirm "Generate CP File" workflow appears in the left sidebar
 - [ ] Click on it → verify it shows `workflow_dispatch` trigger with the 3 inputs
@@ -31,20 +34,22 @@ Step-by-step guide for deploying the CP file export feature end-to-end.
 ## 2. Render Backend Setup
 
 ### Add Environment Variables
+
 - [ ] Go to Render dashboard → your API service → Environment
 - [ ] Add the following environment variables:
 
-| Variable | Value | Notes |
-|----------|-------|-------|
-| `GITHUB_TOKEN_CP` | The PAT created above | Fine-grained token with actions:read+write |
-| `CP_WEBHOOK_SECRET` | Same value as the GitHub repo secret | Must match exactly! |
-| `CP_CALLBACK_URL` | `https://<your-api-domain>/api/cp/webhook` | Must be publicly accessible |
-| `GITHUB_REPO_OWNER` | `Badminton-Apps` | Optional -- defaults to this value |
-| `GITHUB_REPO_NAME` | `badman` | Optional -- defaults to this value |
+| Variable            | Value                                         | Notes                                                                                                                                                               |
+| ------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GITHUB_TOKEN_CP`   | The PAT created above                         | Fine-grained token with actions:read+write                                                                                                                          |
+| `CP_WEBHOOK_SECRET` | Same value as the GitHub repo secret          | Must match exactly!                                                                                                                                                 |
+| `CP_CALLBACK_URL`   | `https://<your-api-domain>/api/v1/cp/webhook` | Must be publicly accessible. **Note the `/v1`** — the API uses URI versioning (`defaultVersion: "1"`), so every route is under `/api/v1`. Omitting it yields a 404. |
+| `GITHUB_REPO_OWNER` | `Badminton-Apps`                              | Optional -- defaults to this value                                                                                                                                  |
+| `GITHUB_REPO_NAME`  | `badman`                                      | Optional -- defaults to this value                                                                                                                                  |
 
 ### Verify Callback URL
+
 - [ ] Ensure `CP_CALLBACK_URL` is reachable from the public internet (not behind VPN/firewall)
-- [ ] Test with: `curl -s -o /dev/null -w "%{http_code}" https://<your-api-domain>/api/cp/webhook` (should return 401, not timeout or 404)
+- [ ] Test with: `curl -s -o /dev/null -w "%{http_code}" -X POST https://<your-api-domain>/api/v1/cp/webhook` (should return 401, not timeout or 404)
 
 ---
 
@@ -62,12 +67,13 @@ Step-by-step guide for deploying the CP file export feature end-to-end.
 ## 4. Test Run
 
 ### Manual Test via GitHub UI
+
 - [ ] Go to Actions → "Generate CP File" → "Run workflow"
 - [ ] For `payload`, paste a base64-encoded test payload:
   ```bash
   echo '{"event":{"name":"Test","season":2025},"subEvents":[],"clubs":[],"locations":[],"teams":[],"players":[],"teamPlayers":[],"entries":[],"memos":[],"settings":{"tournamentName":"Test"}}' | base64
   ```
-- [ ] For `callback_url`, use your staging API URL + `/api/cp/webhook`
+- [ ] For `callback_url`, use your staging API URL + `/api/v1/cp/webhook`
 - [ ] For `requesting_user_id`, use your own player ID from the database
 - [ ] Click "Run workflow"
 - [ ] Verify:
@@ -76,6 +82,7 @@ Step-by-step guide for deploying the CP file export feature end-to-end.
   - [ ] Backend logs show webhook received
 
 ### End-to-End Test via API
+
 - [ ] Use curl or Postman to call the generate endpoint:
   ```bash
   curl -X POST https://<api-domain>/api/cp/generate \
@@ -91,6 +98,7 @@ Step-by-step guide for deploying the CP file export feature end-to-end.
   - [ ] Download endpoint returns the zip file
 
 ### Security Tests
+
 - [ ] Test unauthenticated request → 401:
   ```bash
   curl -X POST https://<api-domain>/api/cp/generate \
@@ -101,6 +109,7 @@ Step-by-step guide for deploying the CP file export feature end-to-end.
 - [ ] Test duplicate generation → 409 (call generate twice quickly)
 
 ### CP File Validation
+
 - [ ] Download the artifact zip from GitHub Actions
 - [ ] Extract the `.cp` file
 - [ ] Open it in Competition Planner
@@ -122,43 +131,57 @@ Step-by-step guide for deploying the CP file export feature end-to-end.
 ## Pitfalls & Troubleshooting
 
 ### PAT Expiration
+
 The GitHub PAT expires after the duration you set. When it expires:
+
 - CP generation will fail with a 502 error
 - **Fix:** Create a new PAT and update `GITHUB_TOKEN_CP` on Render
 - **Prevention:** Set a calendar reminder for 2 weeks before expiry
 
 ### Webhook Secret Mismatch
+
 If `CP_WEBHOOK_SECRET` doesn't match between GitHub secrets and Render env vars:
+
 - The webhook callback will be rejected (401)
 - The generation will complete but the user won't get an email
 - The download endpoint won't have a record for the run_id
 - **Fix:** Ensure both values are identical
 
 ### Callback URL Not Reachable
+
 If the Render API is behind a VPN or the URL is wrong:
+
 - GitHub Actions will complete but the curl callback will fail
 - The user won't get an email
 - **Fix:** Ensure the URL is publicly accessible
 
 ### Private Repo Artifact Downloads
+
 If the repo is private:
+
 - The PAT must have `actions:read` permission to download artifacts
 - This is already included in the recommended permissions above
 
 ### Windows Runner Changes
+
 Microsoft occasionally updates the `windows-latest` runner image. If a runner update removes Jet OLEDB:
+
 - The file writer will fail with an ADODB error
 - **Fix:** Pin the runner to a specific version: `runs-on: windows-2022`
 - **Monitor:** Check the [GitHub Actions runner images changelog](https://github.com/actions/runner-images)
 
 ### The `empty.cp` Template
+
 The template file at `libs/backend/generator/assets/empty.cp` must be present in the repo:
+
 - The GitHub Actions checkout includes it automatically
 - If it's gitignored or deleted, generation will fail
 - **Verify:** `git ls-files libs/backend/generator/assets/empty.cp` should return the path
 
 ### In-Memory Generation Records
+
 Generation records are stored in-memory on the backend. If the backend restarts between triggering and the webhook callback:
+
 - The webhook will still succeed (it creates a new record)
 - But the `pendingByEvent` guard will be lost (allowing duplicate triggers)
 - This is acceptable for a once-a-year operation


### PR DESCRIPTION
## Why

The CP webhook callback was hitting `/api/cp/webhook` and getting a **404**. Root cause: the API enables URI versioning (`defaultVersion: "1"` in `apps/api/src/main.ts`), so every controller route lives under `/api/v1`. The webhook only exists at `/api/v1/cp/webhook`. Earlier fix `b9cdcbb66` added `/api` but missed `/v1`.

Verified by reproducing locally: a fully-booted API 404s on `/api/cp/webhook` but returns **401** (route exists, auth works) on `/api/v1/cp/webhook`. Never a build-cache problem.

## Changes

- **Docs + test fixture** → `CP_CALLBACK_URL` references use `/api/v1/cp/webhook` ([cp-export-deployment.md](docs/guides/cp-export-deployment.md), [cp.controller.spec.ts](apps/api/src/app/controllers/cp.controller.spec.ts))
- **`GET /api/v1/version`** endpoint reporting the build's bundled `version.json` ([app.controller.ts](apps/api/src/app/controllers/app.controller.ts) + unit test)
- **`verify-prod-version` job** in [deploy-production.yml](.github/workflows/deploy-production.yml): after deploy, polls the live server until it reports the released version (15-min timeout), failing the deploy if a stale artifact keeps serving old code. This guards against the silent "deploy green but old code live" class of failure.
- **`resolveJsonModule`** in `apps/api/tsconfig.spec.json` so the version import compiles under jest

## Runtime action (already done on Render)

`CP_CALLBACK_URL` env var updated to `https://api.badman.app/api/v1/cp/webhook`. This PR is repo hygiene; the live fix was the env var.

## Notes

- Prod-only assert: prod deploys always bump the version. Staging deploys don't, so staging coverage would need a build-time git SHA (not in scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)