### PR TITLE
fix(ci): staging deploy hooks use the real BETA_* secret names

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -56,7 +56,9 @@ jobs:
         # Each deployable app's `deploy` script POSTs its Render deploy hook.
         run: pnpm turbo run deploy
         env:
-          API_HOOK: ${{ secrets.STAGING_API_HOOK }}
-          WORKER_SYNC_HOOK: ${{ secrets.STAGING_WORKER_SYNC_HOOK }}
-          WORKER_RANKING_HOOK: ${{ secrets.STAGING_WORKER_RANKING_HOOK }}
+          # NOTE: the staging Render hook secrets are named BETA_* (legacy
+          # naming, predates the staging branch) — do not "fix" to STAGING_*.
+          API_HOOK: ${{ secrets.BETA_API_HOOK }}
+          WORKER_SYNC_HOOK: ${{ secrets.BETA_WORKER_SYNC_HOOK }}
+          WORKER_RANKING_HOOK: ${{ secrets.BETA_WORKER_RANKING_HOOK }}
           GH_TOKEN_CP: ${{ secrets.GH_TOKEN_CP }}


### PR DESCRIPTION
First staging deploy after #1011 failed at the deploy step:

```
Error: Env key API_HOOK does not exist
```

Root cause: the rewritten [deploy-staging.yml](.github/workflows/deploy-staging.yml) mapped `API_HOOK` from `secrets.STAGING_API_HOOK` etc., but the actual repo secrets are named `BETA_*_HOOK` (legacy naming from 2024, predating the staging branch). The mapped values resolved empty and `scripts/render.js` bailed before POSTing any Render hook.

- Build + migrate stages of the staging run were green — only the hook step failed, nothing half-deployed.
- Production workflow already uses the correct `PROD_*_HOOK` names (verified via `gh secret list`).
- Added a comment so nobody "fixes" the names back to `STAGING_*`.

After merge: merge develop → staging again to re-run the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)