### PR TITLE
fix(ci): pass Render hook env vars through turbo's strict env mode

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -56,9 +56,11 @@ jobs:
         # Each deployable app's `deploy` script POSTs its Render deploy hook.
         run: pnpm turbo run deploy
         env:
-          # NOTE: the staging Render hook secrets are named BETA_* (legacy
-          # naming, predates the staging branch) — do not "fix" to STAGING_*.
-          API_HOOK: ${{ secrets.BETA_API_HOOK }}
-          WORKER_SYNC_HOOK: ${{ secrets.BETA_WORKER_SYNC_HOOK }}
-          WORKER_RANKING_HOOK: ${{ secrets.BETA_WORKER_RANKING_HOOK }}
+          # STAGING_*_HOOK live on the `staging` environment (env-scoped).
+          # Repo-level BETA_*_HOOK are legacy duplicates — don't use them.
+          # These vars only reach render.js because turbo.json declares them
+          # in the deploy task's passThroughEnv (turbo strips undeclared vars).
+          API_HOOK: ${{ secrets.STAGING_API_HOOK }}
+          WORKER_SYNC_HOOK: ${{ secrets.STAGING_WORKER_SYNC_HOOK }}
+          WORKER_RANKING_HOOK: ${{ secrets.STAGING_WORKER_RANKING_HOOK }}
           GH_TOKEN_CP: ${{ secrets.GH_TOKEN_CP }}

--- a/turbo.json
+++ b/turbo.json
@@ -19,7 +19,11 @@
       "persistent": true
     },
     "deploy": {
-      "cache": false
+      "cache": false,
+      // Turborepo runs tasks in strict env mode: vars not declared here are
+      // stripped from the task environment. The deploy scripts read their
+      // Render hook URLs from these vars (see scripts/render.js).
+      "passThroughEnv": ["API_HOOK", "WORKER_SYNC_HOOK", "WORKER_RANKING_HOOK", "GH_TOKEN_CP"]
     }
   }
 }


### PR DESCRIPTION
Second staging deploy failure after #1011 — and the actual root cause this time (#1019 chased the wrong one).

## Root cause

Turborepo 2.x runs tasks in **strict env mode**: env vars not declared in `turbo.json` are stripped from the task environment. The workflow set `API_HOOK` etc. on the step, GitHub resolved the secrets fine, and turbo then stripped the vars before `scripts/render.js` ran → `Env key API_HOOK does not exist`.

Proven with a throwaway secret-presence probe (lengths only): **both** `STAGING_*` (env-scoped) and `BETA_*` (repo-level) hook secrets resolve at length 70 inside an `environment: staging` job. The secret names were never the problem.

## Fix

- **turbo.json**: `deploy` task gets `passThroughEnv: [API_HOOK, WORKER_SYNC_HOOK, WORKER_RANKING_HOOK, GH_TOKEN_CP]`. Pass-through keeps them out of the task hash (deploy is `cache:false` anyway). This also fixes the identical latent failure in `deploy-production.yml` (`PROD_*`).
- **deploy-staging.yml**: back to the env-scoped `STAGING_*_HOOK` secrets (per our own env-scoping rule in AGENTS.md); repo-level `BETA_*` are legacy duplicates.

## Verified locally (exact CI command)

```
API_HOOK=https://example.com pnpm turbo run deploy --filter=api
```

fails with the exact CI error without the turbo.json change, succeeds with it.

After merge: develop → staging, approve the staging environment gate, deploy should POST all three hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)