### PR TITLE
fix(ci): release-please must target main, not the repo default branch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,3 +27,6 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # Without this the action targets the repo DEFAULT branch (develop)
+          # and opens release PRs there — releases must cut from main.
+          target-branch: main


### PR DESCRIPTION
The first post-cutover release-please run opened **#1030 against `develop`** with branch `release-please--branches--develop`. Cause: `googleapis/release-please-action` defaults `target-branch` to the **repository default branch** (develop for us), not the branch whose push triggered the run. Merging #1030 as-is would have tagged v7.0.0 off develop — outside the release lane.

One-line fix: pin `target-branch: main`.

Sequence after merge: this flows develop → staging → main; the next main push re-runs release-please which opens the v7.0.0 release PR **against main** (manifest 6.188.0 + the `Release-As: 7.0.0` footer in history). #1030 should be closed (done, with comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)