### PR TITLE
docs: record squash-vs-merge convention for PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,8 @@ Descriptive kebab-case after the type prefix: `feat/enrollment-settings`, `fix/l
 
 ## Releases (release-please)
 
+**Merge methods (matters for the changelog):** **squash-merge feature PRs** (squash commit takes the PR title — keep PR titles conventional); **merge-commit the promotion PRs** (develop→staging→main) — never squash those, or branch histories diverge permanently. Rationale: with merge commits on feature PRs, release-please parses both the PR title and the underlying commits, producing duplicate changelog entries (observed in v7.0.0).
+
 Versioning is **commit-driven** — contributors never hand-author release metadata. Write Conventional Commits (`feat:`, `fix:`, `feat!:`/`BREAKING CHANGE:`); [`release-please.yml`](.github/workflows/release-please.yml) maintains a release PR on `main`. Merging that PR bumps the single repo-wide version (`package.json` + every app's `src/version.json` via `release-please-config.json`), writes `CHANGELOG.md`, tags `vX.Y.Z` and creates the GitHub release. `deploy-production.yml` ships whatever version the current `main` commit carries and verifies the live `/api/v1/version` afterwards.
 
 ## Testing


### PR DESCRIPTION
Companion to a repo-settings change just applied (`squash_merge_commit_title: PR_TITLE`, `squash_merge_commit_message: PR_BODY`):

- **Squash** feature PRs — PR title becomes the single conventional commit release-please sees
- **Merge-commit** promotion PRs (develop→staging→main) — squashing those would rewrite SHAs and permanently diverge the branch trio

Why: the v7.0.0 release notes were full of duplicates because release-please parses merge commits via their PR title *and* the underlying commits — every conventional-titled PR appeared twice (triples where the old hotfix lane added a cherry-picked twin).

One AGENTS.md paragraph in the Releases section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)