### PR TITLE
test(transfer-loan): add unit tests for controller and services

### DIFF
--- a/packages/backend-competition/transfer-loans/src/controllers/transfer-loan.controller.spec.ts
+++ b/packages/backend-competition/transfer-loans/src/controllers/transfer-loan.controller.spec.ts
@@ -1,0 +1,85 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { UploadGuard } from "@badman/backend-utils";
+import { MultipartFile, MultipartValue } from "@fastify/multipart";
+import { FastifyReply } from "fastify";
+import { TransferLoanController } from "./transfer-loan.controller";
+import { TransferService } from "../services/transfers.service";
+import { LoansService } from "../services/loans.service.ts";
+
+describe("TransferLoanController", () => {
+  let controller: TransferLoanController;
+  let transferService: jest.Mocked<Pick<TransferService, "process">>;
+  let loansService: jest.Mocked<Pick<LoansService, "process">>;
+
+  beforeEach(async () => {
+    transferService = { process: jest.fn().mockResolvedValue(undefined) };
+    loansService = { process: jest.fn().mockResolvedValue(undefined) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TransferLoanController],
+      providers: [
+        { provide: TransferService, useValue: transferService },
+        { provide: LoansService, useValue: loansService },
+      ],
+    })
+      .overrideGuard(UploadGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<TransferLoanController>(TransferLoanController);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  function makeFile(transferOrLoan: string, season: string | number): MultipartFile {
+    return {
+      toBuffer: jest.fn().mockResolvedValue(Buffer.from("test")),
+      fields: {
+        transferOrLoan: { value: transferOrLoan } as MultipartValue,
+        season: { value: `${season}` } as MultipartValue,
+      },
+    } as unknown as MultipartFile;
+  }
+
+  function makeRes(): FastifyReply {
+    return { send: jest.fn() } as unknown as FastifyReply;
+  }
+
+  describe("POST process", () => {
+    it("routes to TransferService when transferOrLoan=transfer", async () => {
+      const res = makeRes();
+      await controller.process(makeFile("transfer", 2025), res);
+      expect(transferService.process).toHaveBeenCalledWith(expect.any(Buffer), 2025);
+      expect(loansService.process).not.toHaveBeenCalled();
+      expect(res.send).toHaveBeenCalledWith({ message: true });
+    });
+
+    it("routes to LoansService when transferOrLoan=loan", async () => {
+      const res = makeRes();
+      await controller.process(makeFile("loan", 2025), res);
+      expect(loansService.process).toHaveBeenCalledWith(expect.any(Buffer), 2025);
+      expect(transferService.process).not.toHaveBeenCalled();
+      expect(res.send).toHaveBeenCalledWith({ message: true });
+    });
+
+    it("sends { message: false } for unknown transferOrLoan value", async () => {
+      const res = makeRes();
+      await controller.process(makeFile("unknown", 2025), res);
+      expect(transferService.process).not.toHaveBeenCalled();
+      expect(loansService.process).not.toHaveBeenCalled();
+      expect(res.send).toHaveBeenCalledWith({ message: false });
+    });
+
+    it("sends { message: false } for non-numeric season", async () => {
+      const res = makeRes();
+      await controller.process(makeFile("unknown", "not-a-number"), res);
+      expect(res.send).toHaveBeenCalledWith({ message: false });
+    });
+
+    it("parses season as integer before passing to service", async () => {
+      const res = makeRes();
+      await controller.process(makeFile("transfer", "2024"), res);
+      expect(transferService.process).toHaveBeenCalledWith(expect.any(Buffer), 2024);
+    });
+  });
+});

--- a/packages/backend-competition/transfer-loans/src/services/loans.service.spec.ts
+++ b/packages/backend-competition/transfer-loans/src/services/loans.service.spec.ts
@@ -1,0 +1,145 @@
+import { ClubMembershipType } from "@badman/utils";
+import * as XLSX from "xlsx";
+import { Club, ClubPlayerMembership, Player } from "@badman/backend-database";
+import { LoansService } from "./loans.service.ts";
+
+jest.mock("xlsx");
+jest.mock("@badman/backend-database", () => ({
+  Player: { findAll: jest.fn() },
+  Club: { findAll: jest.fn() },
+  ClubPlayerMembership: Object.assign(jest.fn(), { findAll: jest.fn() }),
+}));
+
+const SEASON = 2025;
+
+function mockXlsxRows(rows: object[]) {
+  (XLSX.read as jest.Mock).mockReturnValue({ Sheets: { Sheet1: {} }, SheetNames: ["Sheet1"] });
+  (XLSX.utils.sheet_to_json as jest.Mock).mockReturnValue(rows);
+}
+
+function makeLoanRow(lidnummer = 1001, ontLenendeClubNummer = 42) {
+  return {
+    Lidnummer: lidnummer,
+    Voornaam: "Test",
+    Naam: "Player",
+    uitlenendeClub: "Lending Club",
+    uitlenendeClubNummer: 10,
+    ontLenendeClub: "Borrowing Club",
+    ontLenendeClubNummer,
+  };
+}
+
+function makePlayer(id: string, memberId: string) {
+  return { id, memberId, fullName: `Player ${id}` } as unknown as Player;
+}
+
+function makeClub(id: string, clubId: number) {
+  return { id, clubId } as unknown as Club;
+}
+
+function makeMembership(
+  overrides: Partial<{
+    id: string;
+    playerId: string;
+    clubId: string;
+    start: Date;
+    end: Date;
+    membershipType: ClubMembershipType;
+  }> = {}
+) {
+  return {
+    id: "m1",
+    playerId: "p1",
+    clubId: "c1",
+    membershipType: ClubMembershipType.LOAN,
+    start: new Date(SEASON, 6, 1),
+    end: new Date(SEASON + 1, 5, 30),
+    save: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as ClubPlayerMembership;
+}
+
+describe("LoansService", () => {
+  let service: LoansService;
+
+  beforeEach(() => {
+    service = new LoansService();
+    (ClubPlayerMembership as unknown as jest.Mock).mockImplementation(() => ({
+      save: jest.fn().mockResolvedValue(undefined),
+      end: null,
+    }));
+  });
+
+  afterEach(() => jest.resetAllMocks());
+
+  describe("process", () => {
+    it("returns { message: false } when file is empty", async () => {
+      mockXlsxRows([]);
+      const result = await service.process(Buffer.from(""), SEASON);
+      expect(result).toEqual({ message: false });
+    });
+
+    it("skips row when player not found in DB", async () => {
+      mockXlsxRows([makeLoanRow()]);
+      (Player.findAll as jest.Mock).mockResolvedValue([]);
+      (Club.findAll as jest.Mock).mockResolvedValue([makeClub("c1", 42)]);
+      (ClubPlayerMembership.findAll as jest.Mock).mockResolvedValue([]);
+
+      await service.process(Buffer.from(""), SEASON);
+
+      expect(ClubPlayerMembership as unknown as jest.Mock).not.toHaveBeenCalled();
+    });
+
+    it("skips row when borrowing club not found in DB", async () => {
+      mockXlsxRows([makeLoanRow(1001, 42)]);
+      (Player.findAll as jest.Mock).mockResolvedValue([makePlayer("p1", "1001")]);
+      (Club.findAll as jest.Mock).mockResolvedValue([]);
+      (ClubPlayerMembership.findAll as jest.Mock).mockResolvedValue([]);
+
+      await service.process(Buffer.from(""), SEASON);
+
+      expect(ClubPlayerMembership as unknown as jest.Mock).not.toHaveBeenCalled();
+    });
+
+    it("creates new loan membership when none exists for player", async () => {
+      mockXlsxRows([makeLoanRow(1001, 42)]);
+      (Player.findAll as jest.Mock).mockResolvedValue([makePlayer("p1", "1001")]);
+      (Club.findAll as jest.Mock).mockResolvedValue([makeClub("c1", 42)]);
+      (ClubPlayerMembership.findAll as jest.Mock).mockResolvedValue([]);
+
+      await service.process(Buffer.from(""), SEASON);
+
+      expect(ClubPlayerMembership as unknown as jest.Mock).toHaveBeenCalled();
+      const instance = (ClubPlayerMembership as unknown as jest.Mock).mock.results[0].value;
+      expect(instance.save).toHaveBeenCalled();
+    });
+
+    it("does not create duplicate when loan already exists for same club", async () => {
+      mockXlsxRows([makeLoanRow(1001, 42)]);
+      (Player.findAll as jest.Mock).mockResolvedValue([makePlayer("p1", "1001")]);
+      (Club.findAll as jest.Mock).mockResolvedValue([makeClub("c1", 42)]);
+      (ClubPlayerMembership.findAll as jest.Mock).mockResolvedValue([
+        makeMembership({ playerId: "p1", clubId: "c1" }),
+      ]);
+
+      await service.process(Buffer.from(""), SEASON);
+
+      expect(ClubPlayerMembership as unknown as jest.Mock).not.toHaveBeenCalled();
+    });
+
+    it("creates new loan when existing one is for a different club", async () => {
+      mockXlsxRows([makeLoanRow(1001, 42)]);
+      (Player.findAll as jest.Mock).mockResolvedValue([makePlayer("p1", "1001")]);
+      (Club.findAll as jest.Mock).mockResolvedValue([makeClub("c1", 42)]);
+      (ClubPlayerMembership.findAll as jest.Mock).mockResolvedValue([
+        makeMembership({ playerId: "p1", clubId: "other-club" }),
+      ]);
+
+      await service.process(Buffer.from(""), SEASON);
+
+      expect(ClubPlayerMembership as unknown as jest.Mock).toHaveBeenCalled();
+      const instance = (ClubPlayerMembership as unknown as jest.Mock).mock.results[0].value;
+      expect(instance.save).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend-competition/transfer-loans/src/services/transfers.service.spec.ts
+++ b/packages/backend-competition/transfer-loans/src/services/transfers.service.spec.ts
@@ -1,0 +1,191 @@
+import { ClubMembershipType } from "@badman/utils";
+import * as XLSX from "xlsx";
+import { Club, ClubPlayerMembership, Player } from "@badman/backend-database";
+import { TransferService } from "./transfers.service";
+
+jest.mock("xlsx");
+jest.mock("@badman/backend-database", () => ({
+  Player: { findAll: jest.fn() },
+  Club: { findAll: jest.fn() },
+  ClubPlayerMembership: Object.assign(jest.fn(), { findAll: jest.fn() }),
+}));
+
+const SEASON = 2025;
+
+function mockXlsxRows(rows: object[]) {
+  (XLSX.read as jest.Mock).mockReturnValue({ Sheets: { Sheet1: {} }, SheetNames: ["Sheet1"] });
+  (XLSX.utils.sheet_to_json as jest.Mock).mockReturnValue(rows);
+}
+
+function makeTransferRow(lidnummer = 1001, nieuwClubnummer = 42) {
+  return {
+    Lidnummer: lidnummer,
+    Voornaam: "Test",
+    Naam: "Player",
+    OudeClub: "Old Club",
+    OudClubnummer: 10,
+    NieuweClub: "New Club",
+    NieuwClubnummer: nieuwClubnummer,
+  };
+}
+
+function makePlayer(id: string, memberId: string) {
+  return { id, memberId, fullName: `Player ${id}` } as unknown as Player;
+}
+
+function makeClub(id: string, clubId: number) {
+  return { id, clubId } as unknown as Club;
+}
+
+function makeMembership(
+  overrides: Partial<{
+    id: string;
+    playerId: string;
+    clubId: string;
+    start: Date;
+    end: Date | null;
+    confirmed: boolean;
+    membershipType: ClubMembershipType;
+  }> = {}
+) {
+  return {
+    id: "m1",
+    playerId: "p1",
+    clubId: "old-club",
+    membershipType: ClubMembershipType.NORMAL,
+    confirmed: true,
+    end: null,
+    start: new Date(SEASON - 1, 6, 1),
+    save: jest.fn().mockResolvedValue(undefined),
+    destroy: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as ClubPlayerMembership;
+}
+
+describe("TransferService", () => {
+  let service: TransferService;
+
+  beforeEach(() => {
+    service = new TransferService();
+    (ClubPlayerMembership as unknown as jest.Mock).mockImplementation(() => ({
+      save: jest.fn().mockResolvedValue(undefined),
+      destroy: jest.fn().mockResolvedValue(undefined),
+      end: null,
+    }));
+  });
+
+  afterEach(() => jest.resetAllMocks());
+
+  describe("process", () => {
+    it("returns { message: false } when file is empty", async () => {
+      mockXlsxRows([]);
+      const result = await service.process(Buffer.from(""), SEASON);
+      expect(result).toEqual({ message: false });
+    });
+
+    it("skips row when player not found in DB", async () => {
+      mockXlsxRows([makeTransferRow()]);
+      (Player.findAll as jest.Mock).mockResolvedValue([]);
+      (Club.findAll as jest.Mock).mockResolvedValue([makeClub("c1", 42)]);
+      // outer memberships call only — per-player call never reached when player missing
+      (ClubPlayerMembership.findAll as jest.Mock).mockResolvedValueOnce([]);
+
+      await service.process(Buffer.from(""), SEASON);
+
+      expect(ClubPlayerMembership as unknown as jest.Mock).not.toHaveBeenCalled();
+    });
+
+    it("skips row when target club not found in DB", async () => {
+      mockXlsxRows([makeTransferRow(1001, 42)]);
+      (Player.findAll as jest.Mock).mockResolvedValue([makePlayer("p1", "1001")]);
+      (Club.findAll as jest.Mock).mockResolvedValue([]);
+      // outer memberships call only — per-player call never reached when club missing
+      (ClubPlayerMembership.findAll as jest.Mock).mockResolvedValueOnce([]);
+
+      await service.process(Buffer.from(""), SEASON);
+
+      expect(ClubPlayerMembership as unknown as jest.Mock).not.toHaveBeenCalled();
+    });
+
+    it("creates new membership and ends old ones when player moves to new club", async () => {
+      mockXlsxRows([makeTransferRow(1001, 42)]);
+
+      const player = makePlayer("p1", "1001");
+      const club = makeClub("c1", 42);
+      const oldMembership = makeMembership({ playerId: "p1", clubId: "old-club", confirmed: true });
+
+      (Player.findAll as jest.Mock).mockResolvedValue([player]);
+      (Club.findAll as jest.Mock).mockResolvedValue([club]);
+      (ClubPlayerMembership.findAll as jest.Mock)
+        .mockResolvedValueOnce([oldMembership]) // open memberships
+        .mockResolvedValueOnce([]); // this-season check
+
+      await service.process(Buffer.from(""), SEASON);
+
+      // new membership created
+      expect(ClubPlayerMembership as unknown as jest.Mock).toHaveBeenCalled();
+      const instance = (ClubPlayerMembership as unknown as jest.Mock).mock.results[0].value;
+      expect(instance.save).toHaveBeenCalled();
+
+      // old membership closed
+      expect(oldMembership.save).toHaveBeenCalled();
+      expect((oldMembership as any).end).not.toBeNull();
+    });
+
+    it("does not create new membership when player already has one at same club this season", async () => {
+      mockXlsxRows([makeTransferRow(1001, 42)]);
+
+      const player = makePlayer("p1", "1001");
+      const club = makeClub("c1", 42);
+      const existingMembership = makeMembership({
+        playerId: "p1",
+        clubId: "c1",
+        start: new Date(SEASON, 6, 1),
+        end: null,
+      });
+
+      (Player.findAll as jest.Mock).mockResolvedValue([player]);
+      (Club.findAll as jest.Mock).mockResolvedValue([club]);
+      (ClubPlayerMembership.findAll as jest.Mock)
+        .mockResolvedValueOnce([]) // open memberships
+        .mockResolvedValueOnce([existingMembership]); // this-season check
+
+      await service.process(Buffer.from(""), SEASON);
+
+      expect(ClubPlayerMembership as unknown as jest.Mock).not.toHaveBeenCalled();
+      expect(existingMembership.end).toBeNull();
+      expect(existingMembership.save).toHaveBeenCalled();
+    });
+
+    it("keeps latest and destroys older when multiple same-season memberships exist", async () => {
+      mockXlsxRows([makeTransferRow(1001, 42)]);
+
+      const player = makePlayer("p1", "1001");
+      const club = makeClub("c1", 42);
+      const older = makeMembership({
+        id: "m-old",
+        playerId: "p1",
+        clubId: "c1",
+        start: new Date(SEASON, 6, 1),
+      });
+      const newer = makeMembership({
+        id: "m-new",
+        playerId: "p1",
+        clubId: "c1",
+        start: new Date(SEASON, 8, 1),
+      });
+
+      (Player.findAll as jest.Mock).mockResolvedValue([player]);
+      (Club.findAll as jest.Mock).mockResolvedValue([club]);
+      (ClubPlayerMembership.findAll as jest.Mock)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([older, newer]);
+
+      await service.process(Buffer.from(""), SEASON);
+
+      expect(older.destroy).toHaveBeenCalled();
+      expect(newer.destroy).not.toHaveBeenCalled();
+      expect(newer.save).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `TransferLoanController` spec: routing to transfer/loan service, invalid type, invalid season, int parsing
- Add `TransferService` spec: empty file, skip unknown player/club, new membership + end old, dedup same-season, keep-latest on duplicates
- Add `LoansService` spec: empty file, skip unknown player/club, create loan, skip duplicate, replace wrong-club loan

## Test plan

- [ ] `pnpm turbo run test --filter=@badman/backend-transfer-loan` passes (17 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)