### PR TITLE
perf(encounter): fix 6.3s playerEncounterCompetitions slow query

### DIFF
--- a/database/migrations/20260612000000-add_player_encounter_lookup_indexes.js
+++ b/database/migrations/20260612000000-add_player_encounter_lookup_indexes.js
@@ -1,0 +1,73 @@
+"use strict";
+
+/**
+ * Indexes supporting the playerEncounterCompetitions query (CTE + UNION rewrite).
+ *
+ * Targets:
+ *  - completed CTE: partial index on Games(linkId) for competition games with a
+ *    winner — tiny, index-only GROUP BY with no heap access needed.
+ *  - encounter-level player fields: gameLeaderId, tempHomeCaptainId,
+ *    tempAwayCaptainId — one index each, used by UNION branch 1.
+ *  - Teams(captainId) — used by UNION branches 2 & 3.
+ *
+ * TeamPlayerMemberships(playerId, teamId) already exists as player_team_index.
+ * GamePlayerMemberships(playerId) already exists via Sequelize @Index decorator.
+ * Games(linkId, linkType) already exists as game_parent_index.
+ *
+ * All created CONCURRENTLY to avoid table locks in production.
+ */
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  useTransaction: false,
+
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "games_completed_competition_idx"
+       ON event."Games" ("linkId")
+       WHERE "linkType" = 'competition' AND "winner" IS NOT NULL AND "winner" != 0`
+    );
+
+    await queryInterface.sequelize.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "encounter_game_leader_idx"
+       ON event."EncounterCompetitions" ("gameLeaderId")
+       WHERE "gameLeaderId" IS NOT NULL`
+    );
+
+    await queryInterface.sequelize.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "encounter_temp_home_captain_idx"
+       ON event."EncounterCompetitions" ("tempHomeCaptainId")
+       WHERE "tempHomeCaptainId" IS NOT NULL`
+    );
+
+    await queryInterface.sequelize.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "encounter_temp_away_captain_idx"
+       ON event."EncounterCompetitions" ("tempAwayCaptainId")
+       WHERE "tempAwayCaptainId" IS NOT NULL`
+    );
+
+    await queryInterface.sequelize.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "teams_captain_idx"
+       ON public."Teams" ("captainId")
+       WHERE "captainId" IS NOT NULL`
+    );
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.sequelize.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS event."games_completed_competition_idx"`
+    );
+    await queryInterface.sequelize.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS event."encounter_game_leader_idx"`
+    );
+    await queryInterface.sequelize.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS event."encounter_temp_home_captain_idx"`
+    );
+    await queryInterface.sequelize.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS event."encounter_temp_away_captain_idx"`
+    );
+    await queryInterface.sequelize.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS public."teams_captain_idx"`
+    );
+  },
+};

--- a/docs/player-encounters-integration-test-plan.md
+++ b/docs/player-encounters-integration-test-plan.md
@@ -1,0 +1,146 @@
+# Integration test plan — `playerEncounterCompetitions` query
+
+Version: 1.0 (2026-06-12)
+
+## Why
+
+The `playerEncounterCompetitions` resolver
+([`encounter.resolver.ts`](../packages/backend-graphql/src/resolvers/event/competition/encounter.resolver.ts))
+runs a hand-written raw SQL query. The existing unit suite
+([`encounter.resolver.spec.ts`](../packages/backend-graphql/src/resolvers/event/competition/encounter.resolver.spec.ts))
+fully mocks `sequelize.query`, so it verifies **resolver glue** (id extraction,
+pagination, error fallback) and **query shape** (CTE + `UNION`, no correlated
+subquery) — but it **cannot** prove the SQL is correct against a real schema, nor
+that the rewrite returns the same rows as the pre-N+1-fix version, nor that the
+new indexes are actually used.
+
+This plan adds a Postgres integration test that closes that gap.
+
+## What the integration test must prove
+
+1. **Correctness** — each of the 6 player-involvement paths returns the encounter:
+   1. game leader
+   2. temp home captain / temp away captain
+   3. home team captain
+   4. away team captain
+   5. active home/away team membership (respecting `start`/`end` vs `ec.date`)
+   6. game player (via `GamePlayerMemberships`)
+2. **The 8-completed-games gate** — an encounter with ≠ 8 completed games
+   (`winner IS NOT NULL AND winner != 0`) is excluded even when the player is
+   involved; exactly 8 is included.
+3. **Dedup** — a player involved via multiple paths on the same encounter yields
+   one row (the `UNION` contract).
+4. **Membership window** — a membership whose `[start, end]` does not span
+   `ec.date` is excluded.
+5. **Equivalence (regression guard)** — for the same seed, the new CTE+UNION query
+   returns the identical id set as the legacy multi-join + correlated-subquery
+   query. Embed the legacy SQL as a constant in the test so it stays runnable.
+
+## Blocker to fix first — jest ignores integration specs in backend-graphql
+
+[`packages/backend-graphql/jest.config.ts`](../packages/backend-graphql/jest.config.ts:8)
+sets:
+
+```ts
+testPathIgnorePatterns: ["/node_modules/", "\\.integration\\.spec\\.ts$"],
+```
+
+So `*.integration.spec.ts` files in this package are **never** picked up — the
+command documented in `AGENTS.md` (`RUN_INTEGRATION_TESTS=1 pnpm exec jest
+--testPathPattern <feature>.integration`) silently finds nothing here. Two
+options:
+
+- **Option A (recommended): dedicated integration jest config.** Add
+  `packages/backend-graphql/jest.integration.config.ts` that extends the base
+  preset but sets `testMatch: ["**/*.integration.spec.ts"]` and drops the ignore
+  pattern. Run via `pnpm exec jest -c jest.integration.config.ts`. Keeps the CI
+  gate fast (default config still ignores integration) and makes the opt-in
+  explicit. Add a `test:integration` script to the package `package.json`.
+- **Option B: override at invocation.** Run with
+  `--testPathIgnorePatterns /node_modules/` to wipe the integration ignore. One
+  less file, but the documented command differs from every other package and is
+  easy to get wrong.
+
+Pick A. Update `AGENTS.md` Common Commands + the integration-test convention
+block to show the backend-graphql-specific command.
+
+## Test mechanics (follow the `AGENTS.md` integration convention)
+
+- **File** — `packages/backend-graphql/src/resolvers/event/competition/player-encounters.integration.spec.ts`.
+- **Opt-in gate** — `const describeOrSkip = process.env["RUN_INTEGRATION_TESTS"] === "1" ? describe : describe.skip;`
+  Also skip (warn, don't fail) when `process.env["DB_DIALECT"] !== "postgres"`.
+- **Connection** — `dotenv.config()` from monorepo root, then a fresh
+  `new Sequelize({ dialect: "postgres", host: DB_IP, port, database, username,
+password, models: [<all models from @badman/backend-database>], logging: false })`.
+  Pass the **full** model set from the barrel — cross-model associations
+  (Team ↔ TeamPlayerMembership, Game ↔ GamePlayerMembership) need the whole graph.
+- **Construct the resolver directly** — `new EncounterCompetitionResolver(sequelize, ...stubs)`.
+  Only `_sequelize` and the static model methods matter for this query; loader
+  services / queue / ranking deps can be `{}`/`null` stubs since
+  `playerEncounterCompetitions` doesn't touch them.
+- **Sentinel scope** — season `9999`, an ad-hoc club + draw created in
+  `beforeAll`; never collide with seed/dev rows.
+- **Self-clean** — `beforeEach` wipes the sentinel scope (encounters, games,
+  memberships, teams, players keyed to the test club); `afterAll` deletes the
+  club + draw and `sequelize.close()`. Use `Op.in` keyed on the created ids.
+
+## Fixture builder
+
+Helper `seedEncounter({ completedGames, involve })` that creates:
+
+- a `DrawCompetition` under the sentinel scope (once, shared),
+- home + away `Team`s under the sentinel club,
+- an `EncounterCompetition` with `date` inside the membership window,
+- `completedGames` rows in `event."Games"` (`linkType='competition'`, `winner=1`),
+  plus optional unfinished games (`winner NULL`/`0`) to test the gate boundary,
+- the player linkage requested by `involve` (one of: `gameLeader`,
+  `tempHomeCaptain`, `tempAwayCaptain`, `homeCaptain`, `awayCaptain`,
+  `homeMember`, `awayMember`, `gamePlayer`), with membership `start`/`end`
+  controllable to test the window.
+
+Return the encounter id so assertions can match against the resolver output.
+
+## Test cases
+
+| #   | Setup                                                                                     | Expect                    |
+| --- | ----------------------------------------------------------------------------------------- | ------------------------- |
+| 1   | 8 completed games, player = gameLeader                                                    | encounter returned        |
+| 2   | 8 completed, player = tempHomeCaptain                                                     | returned                  |
+| 3   | 8 completed, player = tempAwayCaptain                                                     | returned                  |
+| 4   | 8 completed, player = home team captain                                                   | returned                  |
+| 5   | 8 completed, player = away team captain                                                   | returned                  |
+| 6   | 8 completed, active home membership spanning date                                         | returned                  |
+| 7   | 8 completed, active away membership spanning date                                         | returned                  |
+| 8   | 8 completed, player = game player                                                         | returned                  |
+| 9   | 7 completed games, player = gameLeader                                                    | **excluded** (gate)       |
+| 10  | 9 completed games, player = gameLeader                                                    | **excluded** (gate)       |
+| 11  | 8 completed, membership ends before `ec.date`                                             | **excluded** (window)     |
+| 12  | 8 completed, membership starts after `ec.date`                                            | **excluded** (window)     |
+| 13  | 8 completed, player is BOTH gameLeader AND game player                                    | returned **once** (dedup) |
+| 14  | player uninvolved in an 8-game encounter                                                  | **excluded**              |
+| 15  | equivalence: 3–4 mixed encounters seeded; assert new query id-set === legacy query id-set | sets equal                |
+
+## CI
+
+Stays **out of the PR gate** (gate runs `lint test --affected`; the dedicated
+integration config + opt-in env var keep it excluded). Document the manual run:
+
+```bash
+npm run docker:up
+cd packages/backend-graphql
+RUN_INTEGRATION_TESTS=1 pnpm exec jest -c jest.integration.config.ts \
+  --testPathPattern player-encounters.integration
+```
+
+Optionally add a separate, manually-dispatched workflow later that spins up the
+`docker-compose.dev.yml` postgres and runs the integration project — not part of
+this plan.
+
+## Deliverables checklist
+
+- [ ] `jest.integration.config.ts` in backend-graphql (Option A)
+- [ ] `test:integration` script in `packages/backend-graphql/package.json`
+- [ ] `player-encounters.integration.spec.ts` with the fixture builder + cases above
+- [ ] Legacy SQL embedded as a constant for the equivalence case
+- [ ] `AGENTS.md`: correct the backend-graphql integration command
+- [ ] Verify the new indexes are hit (`EXPLAIN` spot-check in one test, log-only — not an assertion, since plan choice is data-dependent)

--- a/packages/backend-graphql/src/resolvers/event/competition/encounter.resolver.spec.ts
+++ b/packages/backend-graphql/src/resolvers/event/competition/encounter.resolver.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { DrawCompetition, EncounterCompetition, Team } from "@badman/backend-database";
+import { DrawCompetition, EncounterCompetition, Player, Team } from "@badman/backend-database";
 import { getQueueToken } from "@nestjs/bull";
+import { Op, QueryTypes } from "sequelize";
 import { Sequelize } from "sequelize-typescript";
 import { EncounterCompetitionResolver } from "./encounter.resolver";
 import { DrawCompetitionLoaderService } from "../../../loaders/draw-competition-loader.service";
@@ -9,6 +10,35 @@ import { EncounterValidationService } from "@badman/backend-change-encounter";
 import { EncounterGamesGenerationService } from "@badman/backend-encounter-games";
 import { PointsService, RankingSystemService } from "@badman/backend-ranking";
 import { SyncQueue } from "@badman/backend-queue";
+
+const makeModule = async (sequelizeMock: Partial<Sequelize>) => {
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      EncounterCompetitionResolver,
+      {
+        provide: getQueueToken(SyncQueue),
+        useValue: { add: jest.fn() },
+      },
+      {
+        provide: Sequelize,
+        useValue: { transaction: jest.fn(), ...sequelizeMock },
+      },
+      { provide: PointsService, useValue: {} },
+      { provide: EncounterValidationService, useValue: {} },
+      { provide: EncounterGamesGenerationService, useValue: {} },
+      { provide: RankingSystemService, useValue: {} },
+      { provide: TeamLoaderService, useValue: { load: jest.fn() } },
+      { provide: DrawCompetitionLoaderService, useValue: { load: jest.fn() } },
+    ],
+  }).compile();
+  return module;
+};
+
+const makePlayer = (id: string | undefined) =>
+  ({ id, hasAnyPermission: jest.fn().mockReturnValue(false) }) as unknown as Player;
+
+const makeEncounterModel = (id: string) =>
+  ({ id, date: new Date("2025-01-01") }) as unknown as EncounterCompetition;
 
 describe("EncounterCompetitionResolver — DataLoader field resolvers", () => {
   let resolver: EncounterCompetitionResolver;
@@ -25,44 +55,7 @@ describe("EncounterCompetitionResolver — DataLoader field resolvers", () => {
     }) as unknown as EncounterCompetition;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        EncounterCompetitionResolver,
-        {
-          provide: getQueueToken(SyncQueue),
-          useValue: { add: jest.fn() },
-        },
-        {
-          provide: Sequelize,
-          useValue: { transaction: jest.fn() },
-        },
-        {
-          provide: PointsService,
-          useValue: {},
-        },
-        {
-          provide: EncounterValidationService,
-          useValue: {},
-        },
-        {
-          provide: EncounterGamesGenerationService,
-          useValue: {},
-        },
-        {
-          provide: RankingSystemService,
-          useValue: {},
-        },
-        {
-          provide: TeamLoaderService,
-          useValue: { load: jest.fn() },
-        },
-        {
-          provide: DrawCompetitionLoaderService,
-          useValue: { load: jest.fn() },
-        },
-      ],
-    }).compile();
-
+    const module = await makeModule({});
     resolver = module.get<EncounterCompetitionResolver>(EncounterCompetitionResolver);
     teamLoaderService = module.get<TeamLoaderService>(TeamLoaderService);
     drawLoaderService = module.get<DrawCompetitionLoaderService>(DrawCompetitionLoaderService);
@@ -188,5 +181,109 @@ describe("EncounterCompetitionResolver — DataLoader field resolvers", () => {
       expect(homeResult).toBe(teamA);
       expect(awayResult).toBe(teamB);
     });
+  });
+});
+
+describe("EncounterCompetitionResolver — playerEncounterCompetitions", () => {
+  let resolver: EncounterCompetitionResolver;
+  let sequelizeQuerySpy: jest.SpyInstance;
+  const queryMock = jest.fn();
+
+  beforeEach(async () => {
+    const module = await makeModule({ query: queryMock });
+    resolver = module.get<EncounterCompetitionResolver>(EncounterCompetitionResolver);
+    sequelizeQuerySpy = queryMock;
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it("returns [] when user has no id", async () => {
+    const result = await resolver.playerEncounterCompetitions(makePlayer(undefined), {});
+    expect(result).toEqual([]);
+    expect(sequelizeQuerySpy).not.toHaveBeenCalled();
+  });
+
+  it("returns [] when raw query finds no matching encounters", async () => {
+    sequelizeQuerySpy.mockResolvedValue([]);
+    jest.spyOn(EncounterCompetition, "findAll").mockResolvedValue([]);
+
+    const result = await resolver.playerEncounterCompetitions(makePlayer("player-1"), {});
+    expect(result).toEqual([]);
+    expect(EncounterCompetition.findAll).not.toHaveBeenCalled();
+  });
+
+  it("returns [] when raw query result is not an array (defensive guard)", async () => {
+    sequelizeQuerySpy.mockResolvedValue(null as never);
+
+    const result = await resolver.playerEncounterCompetitions(makePlayer("player-1"), {});
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] and does not throw when raw query rejects", async () => {
+    sequelizeQuerySpy.mockRejectedValue(new Error("DB exploded"));
+
+    const result = await resolver.playerEncounterCompetitions(makePlayer("player-1"), {});
+    expect(result).toEqual([]);
+  });
+
+  it("fetches encounters by IDs returned from raw query", async () => {
+    const enc1 = makeEncounterModel("enc-1");
+    const enc2 = makeEncounterModel("enc-2");
+
+    sequelizeQuerySpy.mockResolvedValue([
+      { id: "enc-1", date: new Date() },
+      { id: "enc-2", date: new Date() },
+    ]);
+    jest.spyOn(EncounterCompetition, "findAll").mockResolvedValue([enc1, enc2]);
+
+    const result = await resolver.playerEncounterCompetitions(makePlayer("player-1"), {
+      take: 3,
+      skip: 0,
+    });
+
+    expect(result).toEqual([enc1, enc2]);
+    expect(EncounterCompetition.findAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: { [Op.in]: ["enc-1", "enc-2"] } },
+      })
+    );
+  });
+
+  it("passes playerId as replacement to raw query", async () => {
+    sequelizeQuerySpy.mockResolvedValue([]);
+
+    await resolver.playerEncounterCompetitions(makePlayer("player-abc"), {});
+
+    expect(sequelizeQuerySpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        replacements: { playerId: "player-abc" },
+        type: QueryTypes.SELECT,
+      })
+    );
+  });
+
+  it("skips rows with non-string id in raw query result", async () => {
+    sequelizeQuerySpy.mockResolvedValue([{ id: 42 }, { id: "valid-enc" }, null, {}]);
+    const enc = makeEncounterModel("valid-enc");
+    jest.spyOn(EncounterCompetition, "findAll").mockResolvedValue([enc]);
+
+    const result = await resolver.playerEncounterCompetitions(makePlayer("player-1"), {});
+    expect(result).toEqual([enc]);
+  });
+
+  it("uses CTE + UNION query shape, not correlated subquery", async () => {
+    sequelizeQuerySpy.mockResolvedValue([]);
+
+    await resolver.playerEncounterCompetitions(makePlayer("player-1"), {});
+
+    const sql: string = sequelizeQuerySpy.mock.calls[0][0];
+
+    // CTE must pre-compute completed encounters once
+    expect(sql).toMatch(/WITH\s+completed\s+AS/i);
+    // UNION branches replace the multi-join
+    expect(sql).toMatch(/\bUNION\b/i);
+    // Must NOT use a correlated subquery for the 8-game check
+    expect(sql).not.toMatch(/SELECT\s+COUNT\s*\(\s*\*\s*\)\s*FROM\s+event\."Games"/i);
   });
 });

--- a/packages/backend-graphql/src/resolvers/event/competition/encounter.resolver.ts
+++ b/packages/backend-graphql/src/resolvers/event/competition/encounter.resolver.ts
@@ -104,53 +104,72 @@ export class EncounterCompetitionResolver {
         return [];
       }
 
-      // Execute the raw query with proper error handling
+      // CTE pre-computes completed encounters once (avoids per-row correlated subquery).
+      // UNION branches let each player-involvement path hit its own index independently;
+      // UNION (not UNION ALL) deduplicates, so no outer DISTINCT needed.
       const queryResult = await this._sequelize.query(
         `
-        SELECT DISTINCT ec.id, ec."date"
+        WITH completed AS (
+          SELECT "linkId" AS id
+          FROM event."Games"
+          WHERE "linkType" = 'competition'
+            AND "winner" IS NOT NULL
+            AND "winner" != 0
+          GROUP BY "linkId"
+          HAVING COUNT(*) = 8
+        )
+        -- 1. Game leader / temp captains
+        SELECT ec.id, ec."date"
         FROM event."EncounterCompetitions" ec
-        LEFT JOIN "Teams" t_home ON ec."homeTeamId" = t_home.id
-        LEFT JOIN "Teams" t_away ON ec."awayTeamId" = t_away.id
-        LEFT JOIN "TeamPlayerMemberships" tpm_home ON t_home.id = tpm_home."teamId" AND tpm_home."playerId" = :playerId
-        LEFT JOIN "TeamPlayerMemberships" tpm_away ON t_away.id = tpm_away."teamId" AND tpm_away."playerId" = :playerId
-        LEFT JOIN event."Games" g ON g."linkId" = ec.id AND g."linkType" = 'competition'
-        LEFT JOIN event."GamePlayerMemberships" gpm ON g.id = gpm."gameId" AND gpm."playerId" = :playerId
+        INNER JOIN completed c ON c.id = ec.id
         WHERE ec."date" IS NOT NULL
           AND (
-            -- 1. Game Leader
             ec."gameLeaderId" = :playerId
-            OR
-            -- 2. Temp Captains
-            ec."tempHomeCaptainId" = :playerId
-            OR
-            ec."tempAwayCaptainId" = :playerId
-            OR
-            -- 3. Team Captains
-            t_home."captainId" = :playerId
-            OR
-            t_away."captainId" = :playerId
-            OR
-            -- 4. Team Members (active memberships)
-            (tpm_home."playerId" = :playerId 
-             AND tpm_home."start" <= ec."date"
-             AND (tpm_home."end" IS NULL OR tpm_home."end" >= ec."date"))
-            OR
-            (tpm_away."playerId" = :playerId
-             AND tpm_away."start" <= ec."date"
-             AND (tpm_away."end" IS NULL OR tpm_away."end" >= ec."date"))
-            OR
-            -- 5. Game Players
-            gpm."playerId" = :playerId
+            OR ec."tempHomeCaptainId" = :playerId
+            OR ec."tempAwayCaptainId" = :playerId
           )
-          AND (
-            -- Must have exactly 8 completed games
-            SELECT COUNT(*)
-            FROM event."Games" g_count
-            WHERE g_count."linkId" = ec.id 
-              AND g_count."linkType" = 'competition'
-              AND g_count."winner" IS NOT NULL 
-              AND g_count."winner" != 0
-          ) = 8
+        UNION
+        -- 2. Home team captain
+        SELECT ec.id, ec."date"
+        FROM event."EncounterCompetitions" ec
+        INNER JOIN completed c ON c.id = ec.id
+        JOIN "Teams" t ON t.id = ec."homeTeamId" AND t."captainId" = :playerId
+        WHERE ec."date" IS NOT NULL
+        UNION
+        -- 3. Away team captain
+        SELECT ec.id, ec."date"
+        FROM event."EncounterCompetitions" ec
+        INNER JOIN completed c ON c.id = ec.id
+        JOIN "Teams" t ON t.id = ec."awayTeamId" AND t."captainId" = :playerId
+        WHERE ec."date" IS NOT NULL
+        UNION
+        -- 4. Home team member (active membership)
+        SELECT ec.id, ec."date"
+        FROM event."EncounterCompetitions" ec
+        INNER JOIN completed c ON c.id = ec.id
+        JOIN "TeamPlayerMemberships" tpm ON tpm."teamId" = ec."homeTeamId"
+          AND tpm."playerId" = :playerId
+          AND tpm."start" <= ec."date"
+          AND (tpm."end" IS NULL OR tpm."end" >= ec."date")
+        WHERE ec."date" IS NOT NULL
+        UNION
+        -- 5. Away team member (active membership)
+        SELECT ec.id, ec."date"
+        FROM event."EncounterCompetitions" ec
+        INNER JOIN completed c ON c.id = ec.id
+        JOIN "TeamPlayerMemberships" tpm ON tpm."teamId" = ec."awayTeamId"
+          AND tpm."playerId" = :playerId
+          AND tpm."start" <= ec."date"
+          AND (tpm."end" IS NULL OR tpm."end" >= ec."date")
+        WHERE ec."date" IS NOT NULL
+        UNION
+        -- 6. Game player
+        SELECT ec.id, ec."date"
+        FROM event."EncounterCompetitions" ec
+        INNER JOIN completed c ON c.id = ec.id
+        JOIN event."Games" g ON g."linkId" = ec.id AND g."linkType" = 'competition'
+        JOIN event."GamePlayerMemberships" gpm ON gpm."gameId" = g.id AND gpm."playerId" = :playerId
+        WHERE ec."date" IS NOT NULL
       `,
         {
           replacements: { playerId: targetPlayerId },


### PR DESCRIPTION
## Summary

- Rewrites `playerEncounterCompetitions` raw SQL from a correlated subquery + multi-LEFT-JOIN + `DISTINCT` (6.3s, 98% of transaction) to a CTE + `UNION` pattern that runs the 8-completed-games check once and hits each player-involvement path via its own index
- Adds 5 partial `CONCURRENTLY` indexes covering the new query shape (gameLeaderId, tempHomeCaptainId, tempAwayCaptainId on EncounterCompetitions; captainId on Teams; completed competition games on Games)
- Adds 8 unit tests for resolver behaviour + a SQL-shape regression guard that verifies the rewrite is in place (confirmed fails on old code, passes on new)
- Adds integration test plan ([`docs/player-encounters-integration-test-plan.md`](docs/player-encounters-integration-test-plan.md)) — 15 test cases with fixture builder design, blocker note (jest ignores `*.integration.spec.ts` in backend-graphql), and equivalence guard spec

## Root cause

The old query contained a correlated subquery in the `WHERE` clause:
```sql
AND (SELECT COUNT(*) FROM event."Games" g_count WHERE g_count."linkId" = ec.id ...) = 8
```
This executed once per row in `EncounterCompetitions`. Combined with 4 LEFT JOINs across large tables and a `DISTINCT` pass, the query took 6.29s on production (Sentry issue 121422588).

## Test plan

- [x] Unit tests: `pnpm turbo run test --filter=@badman/backend-graphql -- --testPathPattern encounter.resolver` → 18/18 pass
- [x] SQL shape regression guard: confirmed fails on old query, passes on new
- [ ] Integration tests: follow `docs/player-encounters-integration-test-plan.md` (requires docker postgres + `RUN_INTEGRATION_TESTS=1`)
- [ ] Migration: `npx sequelize-cli db:migrate` — all 5 indexes created `CONCURRENTLY` (no table lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)