### PR TITLE
chore(seed): fix encounter setup for local dev testing

### DIFF
--- a/database/seeders/20250101000000-seed-test-data.js
+++ b/database/seeders/20250101000000-seed-test-data.js
@@ -300,7 +300,7 @@ module.exports = {
         const ctx = new SeederContext(sequelize, QueryTypes, transaction);
 
         const now = new Date();
-        const season = now.getMonth() >= 8 ? now.getFullYear() : now.getFullYear() - 1;
+        const season = now.getMonth() >= 4 ? now.getFullYear() : now.getFullYear() - 1;
         const previousSeason = season - 1;
         console.log(`📅 Using season: ${season}\n`);
         console.log(`📅 Using previous season for historical teams: ${previousSeason}\n`);
@@ -351,9 +351,11 @@ module.exports = {
           }
         );
 
+        await ensureClubAdminPermission(ctx, opponent.clubId, opponentUser.id);
+
         await seedLocationsForClub(ctx, opponent.clubId, season, OPPONENT_LOCATIONS(season));
 
-        await createEncounters(ctx, drawId, home.teamId, opponent.teamId, ENCOUNTER_COUNT);
+        await createEncounters(ctx, drawId, home.teamId, opponent.teamId, ENCOUNTER_COUNT, season);
 
         console.log("📊 Summary:");
         console.log(`   • Club: TEAM AWESOME (${home.clubId})`);

--- a/database/seeders/utils/dist/entity-builders.js
+++ b/database/seeders/utils/dist/entity-builders.js
@@ -1,317 +1,464 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.createAvailability = exports.createLocation = exports.createEncounters = exports.createOpponentTeam = exports.createDrawCompetition = exports.createSubEventCompetition = exports.createEventCompetition = exports.addPlayerToTeam = exports.createTeam = exports.addPlayerToClub = exports.createClub = exports.findOrCreatePlayer = void 0;
+exports.createAvailability =
+  exports.createLocation =
+  exports.createEncounters =
+  exports.createOpponentTeam =
+  exports.createDrawCompetition =
+  exports.createSubEventCompetition =
+  exports.createEventCompetition =
+  exports.addPlayerToTeam =
+  exports.createTeam =
+  exports.addPlayerToClub =
+  exports.createClub =
+  exports.findOrCreatePlayer =
+    void 0;
 const error_handler_1 = require("./error-handler");
 const club_team_naming_1 = require("./club-team-naming");
 const membership_helpers_1 = require("./membership-helpers");
 /**
  * Find or create a player
  */
-async function findOrCreatePlayer(ctx, userEmail, firstName, lastName, memberId, gender, competitionPlayer, sub) {
-    // Check if user already exists
-    // Note: QueryTypes.SELECT returns the array directly, not [results, metadata]
-    const existingUsers = await ctx.query(`SELECT id, email, "firstName", "lastName" FROM "Players" WHERE email = :email LIMIT 1`, { email: userEmail });
-    if (existingUsers && existingUsers.length > 0) {
-        const user = existingUsers[0];
-        console.log(`✅ Found existing user: ${user.firstName} ${user.lastName} (${user.email})\n`);
-        return user;
-    }
-    // Create new player
-    console.log("👤 Creating new player...");
-    const user = await ctx.insert(`INSERT INTO "Players" (email, "firstName", "lastName", "memberId", gender, "createdAt", "updatedAt", "competitionPlayer", "sub")
-     VALUES (:email, :firstName, :lastName, :memberId, :gender, NOW(), NOW(),:competitionPlayer, :sub)
-     RETURNING id, email, "firstName", "lastName"`, {
-        email: userEmail,
-        firstName,
-        lastName,
-        memberId,
-        gender,
-        competitionPlayer,
-        sub,
-    });
-    console.log(`✅ Created new player: ${user.firstName} ${user.lastName} (${user.email})\n`);
+async function findOrCreatePlayer(
+  ctx,
+  userEmail,
+  firstName,
+  lastName,
+  memberId,
+  gender,
+  competitionPlayer,
+  sub
+) {
+  // Check if user already exists
+  // Note: QueryTypes.SELECT returns the array directly, not [results, metadata]
+  const slug = `${firstName}-${lastName}`.toLowerCase().replace(/\s+/g, "-");
+  const existingUsers = await ctx.query(
+    `SELECT id, email, "firstName", "lastName" FROM "Players" WHERE email = :email OR slug = :slug LIMIT 1`,
+    { email: userEmail, slug }
+  );
+  if (existingUsers && existingUsers.length > 0) {
+    const user = existingUsers[0];
+    console.log(`✅ Found existing user: ${user.firstName} ${user.lastName} (${user.email})\n`);
     return user;
+  }
+  // Create new player
+  console.log("👤 Creating new player...");
+  const user = await ctx.insert(
+    `INSERT INTO "Players" (email, "firstName", "lastName", "memberId", gender, slug, "createdAt", "updatedAt", "competitionPlayer", "sub")
+     VALUES (:email, :firstName, :lastName, :memberId, :gender, :slug, NOW(), NOW(),:competitionPlayer, :sub)
+     RETURNING id, email, "firstName", "lastName"`,
+    {
+      email: userEmail,
+      firstName,
+      lastName,
+      memberId,
+      gender,
+      slug,
+      competitionPlayer,
+      sub,
+    }
+  );
+  console.log(`✅ Created new player: ${user.firstName} ${user.lastName} (${user.email})\n`);
+  return user;
 }
 /**
  * Create a club
  */
 async function createClub(ctx, clubName) {
-    console.log(`🏢 Creating Club: ${clubName}...`);
-    // Generate abbreviation from club name (first 3 letters, uppercase)
-    const abbreviation = clubName.substring(0, 3).toUpperCase();
-    const club = await ctx.insert(`INSERT INTO "Clubs" (name, "teamName", "fullName", abbreviation, "useForTeamName", "createdAt", "updatedAt")
+  console.log(`🏢 Creating Club: ${clubName}...`);
+  // Generate abbreviation from club name (first 3 letters, uppercase)
+  const abbreviation = clubName.substring(0, 3).toUpperCase();
+  const club = await ctx.insert(
+    `INSERT INTO "Clubs" (name, "teamName", "fullName", abbreviation, "useForTeamName", "createdAt", "updatedAt")
      VALUES (:name, :teamName, :fullName, :abbreviation, :useForTeamName, NOW(), NOW())
-     RETURNING id, name`, {
-        name: clubName,
-        teamName: clubName,
-        fullName: `${clubName} Full Name`,
-        abbreviation,
-        useForTeamName: "teamName",
-    });
-    const clubId = club.id;
-    console.log(`✅ Created Club: ${clubName} (${clubId})\n`);
-    return clubId;
+     RETURNING id, name`,
+    {
+      name: clubName,
+      teamName: clubName,
+      fullName: `${clubName} Full Name`,
+      abbreviation,
+      useForTeamName: "teamName",
+    }
+  );
+  const clubId = club.id;
+  console.log(`✅ Created Club: ${clubName} (${clubId})\n`);
+  return clubId;
 }
 /**
  * Add player to club membership
  */
 async function addPlayerToClub(ctx, clubId, playerId) {
-    const existing = await (0, membership_helpers_1.hasActiveMembership)(ctx, "ClubPlayerMemberships", `"clubId" = :clubId AND "playerId" = :playerId`, { clubId, playerId });
-    if (existing) {
-        console.log(`ℹ️  Player already has an active membership with this club\n`);
-        return;
-    }
-    const row = await ctx.insert(`INSERT INTO "ClubPlayerMemberships" ("clubId", "playerId", "start", "confirmed", "membershipType", "createdAt", "updatedAt")
+  const existing = await (0, membership_helpers_1.hasActiveMembership)(
+    ctx,
+    "ClubPlayerMemberships",
+    `"clubId" = :clubId AND "playerId" = :playerId`,
+    { clubId, playerId }
+  );
+  if (existing) {
+    console.log(`ℹ️  Player already has an active membership with this club\n`);
+    return;
+  }
+  const row = await ctx.insert(
+    `INSERT INTO "ClubPlayerMemberships" ("clubId", "playerId", "start", "confirmed", "membershipType", "createdAt", "updatedAt")
      VALUES (:clubId, :playerId, NOW(), true, 'NORMAL', NOW(), NOW())
-     RETURNING id`, { clubId, playerId });
-    console.log(`✅ Added user to club (membership ID: ${row.id})\n`);
+     RETURNING id`,
+    { clubId, playerId }
+  );
+  console.log(`✅ Added user to club (membership ID: ${row.id})\n`);
 }
 /**
  * Internal: insert a team row (used by createTeam and createOpponentTeam).
  */
 async function insertTeam(ctx, clubId, teamNumber, season, captainId, teamType) {
-    const club = await (0, club_team_naming_1.getClubById)(ctx, clubId);
-    const { name: teamName, abbreviation } = (0, club_team_naming_1.generateTeamName)(club, teamNumber, teamType);
-    const team = await ctx.insert(`INSERT INTO "Teams" ("clubId", type, season, "teamNumber", "captainId", "link", name, abbreviation, "createdAt", "updatedAt")
+  const club = await (0, club_team_naming_1.getClubById)(ctx, clubId);
+  const { name: teamName, abbreviation } = (0, club_team_naming_1.generateTeamName)(
+    club,
+    teamNumber,
+    teamType
+  );
+  const team = await ctx.insert(
+    `INSERT INTO "Teams" ("clubId", type, season, "teamNumber", "captainId", "link", name, abbreviation, "createdAt", "updatedAt")
      VALUES (:clubId, :type, :season, :teamNumber, :captainId, gen_random_uuid(), :name, :abbreviation, NOW(), NOW())
-     RETURNING id`, {
-        clubId,
-        type: teamType,
-        season,
-        teamNumber,
-        captainId,
-        name: teamName,
-        abbreviation,
-    });
-    return team.id;
+     RETURNING id`,
+    {
+      clubId,
+      type: teamType,
+      season,
+      teamNumber,
+      captainId,
+      name: teamName,
+      abbreviation,
+    }
+  );
+  return team.id;
 }
 /**
  * Create a team (idempotent: returns existing team if same club/season/type/teamNumber).
  */
 async function createTeam(ctx, clubId, season, captainId, teamType = "M", teamNumber = 1) {
-    console.log("👥 Creating Team...");
-    const existing = await ctx.query(`SELECT id FROM "Teams" 
+  console.log("👥 Creating Team...");
+  const existing = await ctx.query(
+    `SELECT id FROM "Teams" 
      WHERE "clubId" = :clubId AND season = :season AND type = :type AND "teamNumber" = :teamNumber
-     LIMIT 1`, { clubId, season, type: teamType, teamNumber });
-    if (existing && existing.length > 0 && existing[0]) {
-        console.log(`ℹ️  Team already exists for this club/season (ID: ${existing[0].id})\n`);
-        return existing[0].id;
-    }
-    const teamId = await insertTeam(ctx, clubId, teamNumber, season, captainId, teamType);
-    console.log(`✅ Created Team (${teamId})\n`);
-    return teamId;
+     LIMIT 1`,
+    { clubId, season, type: teamType, teamNumber }
+  );
+  if (existing && existing.length > 0 && existing[0]) {
+    console.log(`ℹ️  Team already exists for this club/season (ID: ${existing[0].id})\n`);
+    return existing[0].id;
+  }
+  const teamId = await insertTeam(ctx, clubId, teamNumber, season, captainId, teamType);
+  console.log(`✅ Created Team (${teamId})\n`);
+  return teamId;
 }
 /**
  * Add player to team membership
  */
 async function addPlayerToTeam(ctx, teamId, playerId, membershipStart) {
-    // Check if membership already exists
-    const existing = await (0, membership_helpers_1.hasActiveMembership)(ctx, "TeamPlayerMemberships", `"teamId" = :teamId AND "playerId" = :playerId`, { teamId, playerId });
-    if (existing) {
-        console.log(`ℹ️  Player already has an active membership with this team\n`);
-        return;
-    }
-    const start = membershipStart ?? new Date();
-    await ctx.rawQuery(`INSERT INTO "TeamPlayerMemberships" ("teamId", "playerId", "start", "membershipType", "createdAt", "updatedAt")
-     VALUES (:teamId, :playerId, :start, 'REGULAR', NOW(), NOW())`, { teamId, playerId, start });
-    console.log(`✅ Added user to team\n`);
+  // Check if membership already exists
+  const existing = await (0, membership_helpers_1.hasActiveMembership)(
+    ctx,
+    "TeamPlayerMemberships",
+    `"teamId" = :teamId AND "playerId" = :playerId`,
+    { teamId, playerId }
+  );
+  if (existing) {
+    console.log(`ℹ️  Player already has an active membership with this team\n`);
+    return;
+  }
+  const start = membershipStart ?? new Date();
+  await ctx.rawQuery(
+    `INSERT INTO "TeamPlayerMemberships" ("teamId", "playerId", "start", "membershipType", "createdAt", "updatedAt")
+     VALUES (:teamId, :playerId, :start, 'REGULAR', NOW(), NOW())`,
+    { teamId, playerId, start }
+  );
+  console.log(`✅ Added user to team\n`);
 }
 /**
  * Create event competition (idempotent: returns existing if visualCode already exists).
  */
 async function createEventCompetition(ctx, season) {
-    console.log("🏆 Creating EventCompetition...");
-    const visualCode = `TEST-${season}`;
-    const existing = await ctx.query(`SELECT id FROM event."EventCompetitions" WHERE "visualCode" = :visualCode LIMIT 1`, { visualCode });
-    if (existing && existing.length > 0 && existing[0]) {
-        console.log(`ℹ️  EventCompetition already exists (${existing[0].id})\n`);
-        return existing[0].id;
+  console.log("🏆 Creating EventCompetition...");
+  const visualCode = `TEST-${season}`;
+  const existing = await ctx.query(
+    `SELECT id FROM event."EventCompetitions" WHERE "visualCode" = :visualCode LIMIT 1`,
+    { visualCode }
+  );
+  if (existing && existing.length > 0 && existing[0]) {
+    console.log(`ℹ️  EventCompetition already exists (${existing[0].id})\n`);
+    return existing[0].id;
+  }
+  const sixMonthsFromNow = new Date(Date.now() + 6 * 30 * 24 * 60 * 60 * 1000);
+  const oneMonthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const event = await ctx.insert(
+    `INSERT INTO event."EventCompetitions" (name, type, season, official, "visualCode", "changeOpenDate", "changeCloseDatePeriod1", "changeCloseDatePeriod2", "changeCloseRequestDatePeriod1", "changeCloseRequestDatePeriod2", "createdAt", "updatedAt")
+     VALUES (:name, :type, :season, true, :visualCode, :changeOpenDate, :closePeriod1, :closePeriod2, :requestPeriod1, :requestPeriod2, NOW(), NOW())
+     RETURNING id`,
+    {
+      name: `Test Event ${season}`,
+      type: "PROV",
+      season,
+      visualCode,
+      changeOpenDate: oneMonthAgo,
+      closePeriod1: sixMonthsFromNow,
+      closePeriod2: sixMonthsFromNow,
+      requestPeriod1: sixMonthsFromNow,
+      requestPeriod2: sixMonthsFromNow,
     }
-    const event = await ctx.insert(`INSERT INTO event."EventCompetitions" (name, type, season, official, "visualCode", "createdAt", "updatedAt")
-     VALUES (:name, :type, :season, true, :visualCode, NOW(), NOW())
-     RETURNING id`, {
-        name: `Test Event ${season}`,
-        type: "PROV",
-        season,
-        visualCode,
-    });
-    const eventId = event.id;
-    console.log(`✅ Created EventCompetition (${eventId})\n`);
-    return eventId;
+  );
+  const eventId = event.id;
+  console.log(`✅ Created EventCompetition (${eventId})\n`);
+  return eventId;
 }
 /**
  * Create sub event competition (idempotent: returns existing if same eventId + name exists).
  */
 async function createSubEventCompetition(ctx, eventId) {
-    console.log("📋 Creating SubEventCompetition...");
-    const existing = await ctx.query(`SELECT id FROM event."SubEventCompetitions" WHERE "eventId" = :eventId AND name = 'Test SubEvent M' LIMIT 1`, { eventId });
-    if (existing && existing.length > 0 && existing[0]) {
-        console.log(`ℹ️  SubEventCompetition already exists (${existing[0].id})\n`);
-        return existing[0].id;
-    }
-    const subEvent = await ctx.insert(`INSERT INTO event."SubEventCompetitions" ("eventId", name, "eventType", level, "maxLevel", "minBaseIndex", "maxBaseIndex", "createdAt", "updatedAt")
+  console.log("📋 Creating SubEventCompetition...");
+  const existing = await ctx.query(
+    `SELECT id FROM event."SubEventCompetitions" WHERE "eventId" = :eventId AND name = 'Test SubEvent M' LIMIT 1`,
+    { eventId }
+  );
+  if (existing && existing.length > 0 && existing[0]) {
+    console.log(`ℹ️  SubEventCompetition already exists (${existing[0].id})\n`);
+    return existing[0].id;
+  }
+  const subEvent = await ctx.insert(
+    `INSERT INTO event."SubEventCompetitions" ("eventId", name, "eventType", level, "maxLevel", "minBaseIndex", "maxBaseIndex", "createdAt", "updatedAt")
      VALUES (:eventId, :name, :eventType, 1, 6, 50, 70, NOW(), NOW())
-     RETURNING id`, {
-        eventId,
-        name: "Test SubEvent M",
-        eventType: "M",
-    });
-    const subEventId = subEvent.id;
-    console.log(`✅ Created SubEventCompetition (${subEventId})\n`);
-    return subEventId;
+     RETURNING id`,
+    {
+      eventId,
+      name: "Test SubEvent M",
+      eventType: "M",
+    }
+  );
+  const subEventId = subEvent.id;
+  console.log(`✅ Created SubEventCompetition (${subEventId})\n`);
+  return subEventId;
 }
 /**
  * Create draw competition (idempotent: returns existing if visualCode already exists).
  */
 async function createDrawCompetition(ctx, subEventId, season) {
-    console.log("🎲 Creating DrawCompetition...");
-    const visualCode = `TEST-DRAW-${season}`;
-    const existing = await ctx.query(`SELECT id FROM event."DrawCompetitions" WHERE "subeventId" = :subeventId AND "visualCode" = :visualCode LIMIT 1`, { subeventId: subEventId, visualCode });
-    if (existing && existing.length > 0 && existing[0]) {
-        console.log(`ℹ️  DrawCompetition already exists (${existing[0].id})\n`);
-        return existing[0].id;
-    }
-    const draw = await ctx.insert(`INSERT INTO event."DrawCompetitions" ("subeventId", name, type, "visualCode", "createdAt", "updatedAt")
+  console.log("🎲 Creating DrawCompetition...");
+  const visualCode = `TEST-DRAW-${season}`;
+  const existing = await ctx.query(
+    `SELECT id FROM event."DrawCompetitions" WHERE "subeventId" = :subeventId AND "visualCode" = :visualCode LIMIT 1`,
+    { subeventId: subEventId, visualCode }
+  );
+  if (existing && existing.length > 0 && existing[0]) {
+    console.log(`ℹ️  DrawCompetition already exists (${existing[0].id})\n`);
+    return existing[0].id;
+  }
+  const draw = await ctx.insert(
+    `INSERT INTO event."DrawCompetitions" ("subeventId", name, type, "visualCode", "createdAt", "updatedAt")
      VALUES (:subeventId, :name, :type, :visualCode, NOW(), NOW())
-     RETURNING id`, {
-        subeventId: subEventId,
-        name: "Test Draw",
-        type: "POULE",
-        visualCode,
-    });
-    const drawId = draw.id;
-    console.log(`✅ Created DrawCompetition (${drawId})\n`);
-    return drawId;
+     RETURNING id`,
+    {
+      subeventId: subEventId,
+      name: "Test Draw",
+      type: "POULE",
+      visualCode,
+    }
+  );
+  const drawId = draw.id;
+  console.log(`✅ Created DrawCompetition (${drawId})\n`);
+  return drawId;
 }
 /**
  * Create opponent team (always inserts; no idempotency check).
  * Same parameter order as createTeam: (ctx, clubId, season, captainId, teamType?, teamNumber?).
  */
 async function createOpponentTeam(ctx, clubId, season, captainId, teamType = "M", teamNumber = 1) {
-    console.log("👥 Creating opponent Team...");
-    const opponentTeamId = await insertTeam(ctx, clubId, teamNumber, season, captainId, teamType);
-    console.log(`✅ Created opponent Team (${opponentTeamId})\n`);
-    return opponentTeamId;
+  console.log("👥 Creating opponent Team...");
+  const opponentTeamId = await insertTeam(ctx, clubId, teamNumber, season, captainId, teamType);
+  console.log(`✅ Created opponent Team (${opponentTeamId})\n`);
+  return opponentTeamId;
 }
 /**
  * Create encounters
  */
-async function createEncounters(ctx, drawId, teamId, opponentTeamId, encounterCount = 10) {
-    console.log("⚔️ Creating Encounters...");
-    const now = new Date();
-    const halfCount = Math.floor(encounterCount / 2);
-    for (let i = 0; i < encounterCount; i++) {
-        let encounterDate;
-        if (i < halfCount) {
-            // First half: dates before current date
-            // Generate dates going backwards from current date with varying intervals
-            // Use base interval of 5-6 days plus variation to avoid same weekday
-            const baseDays = (halfCount - i) * 5;
-            const variation = (i % 7) - 3; // Vary by -3 to +3 days
-            const daysBefore = baseDays + variation;
-            encounterDate = new Date(now);
-            encounterDate.setDate(encounterDate.getDate() - daysBefore);
-        }
-        else {
-            // Second half: dates after current date
-            // Generate dates going forwards from current date with varying intervals
-            // Use base interval of 5-6 days plus variation to avoid same weekday
-            const baseDays = (i - halfCount + 1) * 5;
-            const variation = (i % 7) - 3; // Vary by -3 to +3 days
-            const daysAfter = baseDays + variation;
-            encounterDate = new Date(now);
-            encounterDate.setDate(encounterDate.getDate() + daysAfter);
-        }
-        // Validate the date
-        if (isNaN(encounterDate.getTime())) {
-            throw new Error(`Invalid date created: ${encounterDate}`);
-        }
-        await ctx.rawQuery(`INSERT INTO event."EncounterCompetitions" 
+async function createEncounters(ctx, drawId, teamId, opponentTeamId, encounterCount = 10, season) {
+  console.log("⚔️ Creating Encounters...");
+  const now = new Date();
+  const currentMonth = now.getMonth(); // 0-indexed
+  // Competition season runs Sep 1 (month 8) → Apr 30 (month 3) of the following year.
+  // If we're in the off-season (May–Aug, month 4–7), anchor dates to the season window
+  // instead of now so encounters don't land in off-season months.
+  const inOffSeason = currentMonth >= 4 && currentMonth < 8;
+  const effectiveSeason = season ?? (currentMonth >= 4 ? now.getFullYear() : now.getFullYear() - 1);
+  const seasonStart = new Date(`${effectiveSeason}-09-01`);
+  const seasonEnd = new Date(`${effectiveSeason + 1}-04-30`);
+  const anchor = inOffSeason ? seasonStart : now;
+  const halfCount = Math.floor(encounterCount / 2);
+  // Spread encounters evenly across the season window
+  const totalDays = Math.floor(
+    (seasonEnd.getTime() - seasonStart.getTime()) / (24 * 60 * 60 * 1000)
+  );
+  const step = Math.floor(totalDays / encounterCount);
+  for (let i = 0; i < encounterCount; i++) {
+    let encounterDate;
+    if (inOffSeason) {
+      // All encounters spread across the upcoming season
+      encounterDate = new Date(seasonStart);
+      encounterDate.setDate(seasonStart.getDate() + i * step + (i % 7));
+    } else if (i < halfCount) {
+      // First half: dates before current date
+      const baseDays = (halfCount - i) * 5;
+      const variation = (i % 7) - 3;
+      const daysBefore = baseDays + variation;
+      encounterDate = new Date(anchor);
+      encounterDate.setDate(anchor.getDate() - daysBefore);
+    } else {
+      // Second half: dates after current date
+      const baseDays = (i - halfCount + 1) * 5;
+      const variation = (i % 7) - 3;
+      const daysAfter = baseDays + variation;
+      encounterDate = new Date(anchor);
+      encounterDate.setDate(anchor.getDate() + daysAfter);
+    }
+    // Validate the date
+    if (isNaN(encounterDate.getTime())) {
+      throw new Error(`Invalid date created: ${encounterDate}`);
+    }
+    await ctx.rawQuery(
+      `INSERT INTO event."EncounterCompetitions" 
        ("drawId", "homeTeamId", "awayTeamId", date, "originalDate", "homeScore", "awayScore", 
         finished, accepted, "homeCaptainPresent", "awayCaptainPresent", "gameLeaderPresent",
         "homeCaptainAccepted", "awayCaptainAccepted", "gameLeaderAccepted", "createdAt", "updatedAt")
        VALUES (:drawId, :homeTeamId, :awayTeamId, :date, :originalDate, :homeScore, :awayScore,
                :finished, :accepted, :homeCaptainPresent, :awayCaptainPresent, false,
-               :homeCaptainAccepted, :awayCaptainAccepted, false, NOW(), NOW())`, {
-            drawId,
-            homeTeamId: i % 2 === 0 ? teamId : opponentTeamId,
-            awayTeamId: i % 2 === 0 ? opponentTeamId : teamId,
-            date: encounterDate,
-            originalDate: encounterDate,
-            homeScore: i % 3 === 0 ? 4 : 0,
-            awayScore: i % 3 === 0 ? 2 : 0,
-            finished: i % 3 === 0,
-            accepted: i % 2 === 0,
-            homeCaptainPresent: i % 2 === 0,
-            awayCaptainPresent: i % 2 === 0,
-            homeCaptainAccepted: i % 2 === 0,
-            awayCaptainAccepted: i % 2 === 0,
-        });
-    }
-    console.log(`✅ Created ${encounterCount} Encounters\n`);
+               :homeCaptainAccepted, :awayCaptainAccepted, false, NOW(), NOW())`,
+      {
+        drawId,
+        homeTeamId: i % 2 === 0 ? teamId : opponentTeamId,
+        awayTeamId: i % 2 === 0 ? opponentTeamId : teamId,
+        date: encounterDate,
+        originalDate: encounterDate,
+        homeScore: i % 3 === 0 ? 4 : 0,
+        awayScore: i % 3 === 0 ? 2 : 0,
+        finished: i % 3 === 0,
+        accepted: i % 2 === 0,
+        homeCaptainPresent: i % 2 === 0,
+        awayCaptainPresent: i % 2 === 0,
+        homeCaptainAccepted: i % 2 === 0,
+        awayCaptainAccepted: i % 2 === 0,
+      }
+    );
+  }
+  console.log(`✅ Created ${encounterCount} Encounters\n`);
 }
 /**
  * Create a location for a club (idempotent: check by name + clubId)
  */
 async function createLocation(ctx, clubId, locationData) {
-    const existing = await ctx.query(`SELECT id, name FROM event."Locations" WHERE name = :name AND "clubId" = :clubId LIMIT 1`, { name: locationData.name, clubId });
-    if (existing && existing.length > 0) {
-        console.log(`ℹ️  Location already exists: ${existing[0].name} (${existing[0].id})\n`);
-        return existing[0];
-    }
-    const hasCoordinates = locationData.latitude != null && locationData.longitude != null;
-    const coordinatesColumn = hasCoordinates ? ', coordinates' : '';
-    const coordinatesValue = hasCoordinates
-        ? `, ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)`
-        : '';
-    const location = await ctx.insert(`INSERT INTO event."Locations" (name, address, street, "streetNumber", postalcode, city, state, phone, "clubId", "createdAt", "updatedAt"${coordinatesColumn})
+  const existing = await ctx.query(
+    `SELECT id, name FROM event."Locations" WHERE name = :name AND "clubId" = :clubId LIMIT 1`,
+    { name: locationData.name, clubId }
+  );
+  if (existing && existing.length > 0) {
+    console.log(`ℹ️  Location already exists: ${existing[0].name} (${existing[0].id})\n`);
+    return existing[0];
+  }
+  const hasCoordinates = locationData.latitude != null && locationData.longitude != null;
+  const coordinatesColumn = hasCoordinates ? ", coordinates" : "";
+  const coordinatesValue = hasCoordinates
+    ? `, ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)`
+    : "";
+  const location = await ctx.insert(
+    `INSERT INTO event."Locations" (name, address, street, "streetNumber", postalcode, city, state, phone, "clubId", "createdAt", "updatedAt"${coordinatesColumn})
      VALUES (:name, :address, :street, :streetNumber, :postalcode, :city, :state, :phone, :clubId, NOW(), NOW()${coordinatesValue})
-     RETURNING id, name`, { ...locationData, clubId });
-    console.log(`✅ Created Location: ${location.name} (${location.id})\n`);
-    return location;
+     RETURNING id, name`,
+    { ...locationData, clubId }
+  );
+  console.log(`✅ Created Location: ${location.name} (${location.id})\n`);
+  return location;
 }
 /**
  * Create availability for a location (idempotent: check by locationId + season)
  */
 async function createAvailability(ctx, locationId, season, days, exceptions = []) {
-    const existing = await ctx.query(`SELECT id FROM event."Availabilities" WHERE "locationId" = :locationId AND season = :season LIMIT 1`, { locationId, season });
-    if (existing && existing.length > 0) {
-        console.log(`ℹ️  Availability already exists for this location/season (${existing[0].id})\n`);
-        return existing[0];
-    }
-    const availability = await ctx.insert(`INSERT INTO event."Availabilities" ("locationId", season, days, exceptions, "createdAt", "updatedAt")
+  const existing = await ctx.query(
+    `SELECT id FROM event."Availabilities" WHERE "locationId" = :locationId AND season = :season LIMIT 1`,
+    { locationId, season }
+  );
+  if (existing && existing.length > 0) {
+    console.log(`ℹ️  Availability already exists for this location/season (${existing[0].id})\n`);
+    return existing[0];
+  }
+  const availability = await ctx.insert(
+    `INSERT INTO event."Availabilities" ("locationId", season, days, exceptions, "createdAt", "updatedAt")
      VALUES (:locationId, :season, :days, :exceptions, NOW(), NOW())
-     RETURNING id`, {
-        locationId,
-        season,
-        days: JSON.stringify(days),
-        exceptions: JSON.stringify(exceptions),
-    });
-    console.log(`✅ Created Availability (${availability.id}) for season ${season}\n`);
-    return availability;
+     RETURNING id`,
+    {
+      locationId,
+      season,
+      days: JSON.stringify(days),
+      exceptions: JSON.stringify(exceptions),
+    }
+  );
+  console.log(`✅ Created Availability (${availability.id}) for season ${season}\n`);
+  return availability;
 }
 // Wrap all functions with error handling
-const findOrCreatePlayerWithErrorHandling = (0, error_handler_1.withErrorHandling)(findOrCreatePlayer, "finding/creating player");
+const findOrCreatePlayerWithErrorHandling = (0, error_handler_1.withErrorHandling)(
+  findOrCreatePlayer,
+  "finding/creating player"
+);
 exports.findOrCreatePlayer = findOrCreatePlayerWithErrorHandling;
-const createClubWithErrorHandling = (0, error_handler_1.withErrorHandling)(createClub, "creating club");
+const createClubWithErrorHandling = (0, error_handler_1.withErrorHandling)(
+  createClub,
+  "creating club"
+);
 exports.createClub = createClubWithErrorHandling;
-const addPlayerToClubWithErrorHandling = (0, error_handler_1.withErrorHandling)(addPlayerToClub, "inserting ClubPlayerMembership");
+const addPlayerToClubWithErrorHandling = (0, error_handler_1.withErrorHandling)(
+  addPlayerToClub,
+  "inserting ClubPlayerMembership"
+);
 exports.addPlayerToClub = addPlayerToClubWithErrorHandling;
-const createTeamWithErrorHandling = (0, error_handler_1.withErrorHandling)(createTeam, "creating team");
+const createTeamWithErrorHandling = (0, error_handler_1.withErrorHandling)(
+  createTeam,
+  "creating team"
+);
 exports.createTeam = createTeamWithErrorHandling;
-const addPlayerToTeamWithErrorHandling = (0, error_handler_1.withErrorHandling)(addPlayerToTeam, "inserting TeamPlayerMembership");
+const addPlayerToTeamWithErrorHandling = (0, error_handler_1.withErrorHandling)(
+  addPlayerToTeam,
+  "inserting TeamPlayerMembership"
+);
 exports.addPlayerToTeam = addPlayerToTeamWithErrorHandling;
-const createEventCompetitionWithErrorHandling = (0, error_handler_1.withErrorHandling)(createEventCompetition, "creating EventCompetition");
+const createEventCompetitionWithErrorHandling = (0, error_handler_1.withErrorHandling)(
+  createEventCompetition,
+  "creating EventCompetition"
+);
 exports.createEventCompetition = createEventCompetitionWithErrorHandling;
-const createSubEventCompetitionWithErrorHandling = (0, error_handler_1.withErrorHandling)(createSubEventCompetition, "creating SubEventCompetition");
+const createSubEventCompetitionWithErrorHandling = (0, error_handler_1.withErrorHandling)(
+  createSubEventCompetition,
+  "creating SubEventCompetition"
+);
 exports.createSubEventCompetition = createSubEventCompetitionWithErrorHandling;
-const createDrawCompetitionWithErrorHandling = (0, error_handler_1.withErrorHandling)(createDrawCompetition, "creating DrawCompetition");
+const createDrawCompetitionWithErrorHandling = (0, error_handler_1.withErrorHandling)(
+  createDrawCompetition,
+  "creating DrawCompetition"
+);
 exports.createDrawCompetition = createDrawCompetitionWithErrorHandling;
-const createOpponentTeamWithErrorHandling = (0, error_handler_1.withErrorHandling)(createOpponentTeam, "creating opponent team");
+const createOpponentTeamWithErrorHandling = (0, error_handler_1.withErrorHandling)(
+  createOpponentTeam,
+  "creating opponent team"
+);
 exports.createOpponentTeam = createOpponentTeamWithErrorHandling;
-const createEncountersWithErrorHandling = (0, error_handler_1.withErrorHandling)(createEncounters, "creating encounters");
+const createEncountersWithErrorHandling = (0, error_handler_1.withErrorHandling)(
+  createEncounters,
+  "creating encounters"
+);
 exports.createEncounters = createEncountersWithErrorHandling;
-const createLocationWithErrorHandling = (0, error_handler_1.withErrorHandling)(createLocation, "creating location");
+const createLocationWithErrorHandling = (0, error_handler_1.withErrorHandling)(
+  createLocation,
+  "creating location"
+);
 exports.createLocation = createLocationWithErrorHandling;
-const createAvailabilityWithErrorHandling = (0, error_handler_1.withErrorHandling)(createAvailability, "creating availability");
+const createAvailabilityWithErrorHandling = (0, error_handler_1.withErrorHandling)(
+  createAvailability,
+  "creating availability"
+);
 exports.createAvailability = createAvailabilityWithErrorHandling;

--- a/database/seeders/utils/dist/permissions.js
+++ b/database/seeders/utils/dist/permissions.js
@@ -7,153 +7,179 @@ exports.ensurePlayerRole = ensurePlayerRole;
 exports.ensureClubAdminPermission = ensureClubAdminPermission;
 const crypto_1 = require("crypto");
 async function getRoleSchemaInfo(ctx) {
-    const columns = await ctx.query(`SELECT column_name
+  const columns = await ctx.query(`SELECT column_name
      FROM information_schema.columns
      WHERE table_schema = 'security'
        AND table_name = 'Roles'
        AND column_name IN ('locked', 'linkId', 'linkType', 'clubId', 'type')`);
-    const columnSet = new Set(columns.map((c) => c.column_name));
-    const [idColumn] = await ctx.query(`SELECT column_default
+  const columnSet = new Set(columns.map((c) => c.column_name));
+  const [idColumn] = await ctx.query(`SELECT column_default
      FROM information_schema.columns
      WHERE table_schema = 'security'
        AND table_name = 'Roles'
        AND column_name = 'id'
      LIMIT 1`);
-    return {
-        hasLocked: columnSet.has("locked"),
-        hasLinkColumns: columnSet.has("linkId") && columnSet.has("linkType"),
-        hasIdDefault: !!idColumn?.column_default,
-    };
+  return {
+    hasLocked: columnSet.has("locked"),
+    hasLinkColumns: columnSet.has("linkId") && columnSet.has("linkType"),
+    hasIdDefault: !!idColumn?.column_default,
+  };
 }
-async function ensureRole(ctx, { name, description, linkId, linkType, locked = true, }) {
-    const { hasLocked, hasLinkColumns, hasIdDefault } = await getRoleSchemaInfo(ctx);
-    const roleId = hasIdDefault ? undefined : (0, crypto_1.randomUUID)();
-    const [role] = await ctx.query(hasLinkColumns
-        ? `SELECT id FROM "security"."Roles"
+async function ensureRole(ctx, { name, description, linkId, linkType, locked = true }) {
+  const { hasLocked, hasLinkColumns, hasIdDefault } = await getRoleSchemaInfo(ctx);
+  const roleId = hasIdDefault ? undefined : (0, crypto_1.randomUUID)();
+  const [role] = await ctx.query(
+    hasLinkColumns
+      ? `SELECT id FROM "security"."Roles"
          WHERE name = :name AND "linkId" = :linkId AND "linkType" = :linkType
          LIMIT 1`
-        : `SELECT id FROM "security"."Roles"
+      : `SELECT id FROM "security"."Roles"
          WHERE name = :name AND "clubId" = :linkId AND type = :legacyType
-         LIMIT 1`, {
-        name,
-        linkId,
-        linkType,
-        legacyType: linkType?.toUpperCase?.() ?? linkType,
-    });
-    if (role?.id) {
-        return role.id;
+         LIMIT 1`,
+    {
+      name,
+      linkId,
+      linkType,
+      legacyType: linkType?.toUpperCase?.() ?? linkType,
     }
-    const createdRole = await ctx.insert(hasLinkColumns
-        ? hasLocked
-            ? hasIdDefault
-                ? `INSERT INTO "security"."Roles" (name, description, locked, "linkId", "linkType", "createdAt", "updatedAt")
+  );
+  if (role?.id) {
+    return role.id;
+  }
+  const createdRole = await ctx.insert(
+    hasLinkColumns
+      ? hasLocked
+        ? hasIdDefault
+          ? `INSERT INTO "security"."Roles" (name, description, locked, "linkId", "linkType", "createdAt", "updatedAt")
              VALUES (:name, :description, :locked, :linkId, :linkType, NOW(), NOW())
              RETURNING id`
-                : `INSERT INTO "security"."Roles" (id, name, description, locked, "linkId", "linkType", "createdAt", "updatedAt")
+          : `INSERT INTO "security"."Roles" (id, name, description, locked, "linkId", "linkType", "createdAt", "updatedAt")
              VALUES (:roleId, :name, :description, :locked, :linkId, :linkType, NOW(), NOW())
              RETURNING id`
-            : hasIdDefault
-                ? `INSERT INTO "security"."Roles" (name, description, "linkId", "linkType", "createdAt", "updatedAt")
+        : hasIdDefault
+          ? `INSERT INTO "security"."Roles" (name, description, "linkId", "linkType", "createdAt", "updatedAt")
              VALUES (:name, :description, :linkId, :linkType, NOW(), NOW())
              RETURNING id`
-                : `INSERT INTO "security"."Roles" (id, name, description, "linkId", "linkType", "createdAt", "updatedAt")
+          : `INSERT INTO "security"."Roles" (id, name, description, "linkId", "linkType", "createdAt", "updatedAt")
              VALUES (:roleId, :name, :description, :linkId, :linkType, NOW(), NOW())
              RETURNING id`
-        : hasIdDefault
-            ? `INSERT INTO "security"."Roles" (name, description, "clubId", type, "createdAt", "updatedAt")
+      : hasIdDefault
+        ? `INSERT INTO "security"."Roles" (name, description, "clubId", type, "createdAt", "updatedAt")
            VALUES (:name, :description, :linkId, :legacyType, NOW(), NOW())
            RETURNING id`
-            : `INSERT INTO "security"."Roles" (id, name, description, "clubId", type, "createdAt", "updatedAt")
+        : `INSERT INTO "security"."Roles" (id, name, description, "clubId", type, "createdAt", "updatedAt")
            VALUES (:roleId, :name, :description, :linkId, :legacyType, NOW(), NOW())
-           RETURNING id`, {
-        roleId,
-        name,
-        description,
-        locked,
-        linkId,
-        linkType,
-        legacyType: linkType?.toUpperCase?.() ?? linkType,
-    });
-    return createdRole.id;
+           RETURNING id`,
+    {
+      roleId,
+      name,
+      description,
+      locked,
+      linkId,
+      linkType,
+      legacyType: linkType?.toUpperCase?.() ?? linkType,
+    }
+  );
+  return createdRole.id;
 }
 async function ensureClaimId(ctx, name) {
-    const [claim] = await ctx.query(`SELECT id FROM "security"."Claims" WHERE name = :name LIMIT 1`, { name });
-    if (!claim?.id) {
-        throw new Error(`Claim "${name}" not found`);
-    }
-    return claim.id;
+  const [claim] = await ctx.query(`SELECT id FROM "security"."Claims" WHERE name = :name LIMIT 1`, {
+    name,
+  });
+  if (!claim?.id) {
+    throw new Error(`Claim "${name}" not found`);
+  }
+  return claim.id;
 }
 async function ensureRoleClaim(ctx, roleId, claimId) {
-    try {
-        const existingRoleClaim = await ctx.query(`SELECT 1 AS id FROM "security"."RoleClaimMemberships"
+  try {
+    const existingRoleClaim = await ctx.query(
+      `SELECT 1 AS id FROM "security"."RoleClaimMemberships"
        WHERE "roleId" = :roleId AND "claimId" = :claimId
-       LIMIT 1`, { roleId, claimId });
-        if (!existingRoleClaim.length) {
-            await ctx.rawQuery(`INSERT INTO "security"."RoleClaimMemberships" ("roleId", "claimId", "createdAt", "updatedAt")
-         VALUES (:roleId, :claimId, NOW(), NOW())`, { roleId, claimId });
-        }
+       LIMIT 1`,
+      { roleId, claimId }
+    );
+    if (!existingRoleClaim.length) {
+      await ctx.rawQuery(
+        `INSERT INTO "security"."RoleClaimMemberships" ("roleId", "claimId", "createdAt", "updatedAt")
+         VALUES (:roleId, :claimId, NOW(), NOW())`,
+        { roleId, claimId }
+      );
     }
-    catch (error) {
-        console.error("❌ Failed to ensure RoleClaimMembership");
-        console.error(`   roleId: ${roleId}`);
-        console.error(`   claimId: ${claimId}`);
-        if (error instanceof Error) {
-            console.error(`   message: ${error.message}`);
-        }
-        else {
-            console.error(`   message: ${String(error)}`);
-        }
-        if (error && typeof error === "object" && "sql" in error) {
-            console.error(`   sql: ${String(error.sql)}`);
-        }
-        throw error;
+  } catch (error) {
+    console.error("❌ Failed to ensure RoleClaimMembership");
+    console.error(`   roleId: ${roleId}`);
+    console.error(`   claimId: ${claimId}`);
+    if (error instanceof Error) {
+      console.error(`   message: ${error.message}`);
+    } else {
+      console.error(`   message: ${String(error)}`);
     }
+    if (error && typeof error === "object" && "sql" in error) {
+      console.error(`   sql: ${String(error.sql)}`);
+    }
+    throw error;
+  }
 }
 async function ensurePlayerRole(ctx, playerId, roleId) {
-    try {
-        const existingPlayerRole = await ctx.query(`SELECT 1 AS id FROM "security"."PlayerRoleMemberships"
+  try {
+    const existingPlayerRole = await ctx.query(
+      `SELECT 1 AS id FROM "security"."PlayerRoleMemberships"
        WHERE "playerId" = :playerId AND "roleId" = :roleId
-       LIMIT 1`, { playerId, roleId });
-        console.log(`✅ Checking if player ${playerId} has role ${roleId} (existingPlayerRole: ${existingPlayerRole.length})\n`);
-        if (!existingPlayerRole.length) {
-            console.log(`✅ Adding player ${playerId} to role ${roleId}\n`);
-            await ctx.rawQuery(`INSERT INTO "security"."PlayerRoleMemberships" ("playerId", "roleId", "createdAt", "updatedAt")
-         VALUES (:playerId, :roleId, NOW(), NOW())`, { playerId, roleId });
-        }
+       LIMIT 1`,
+      { playerId, roleId }
+    );
+    console.log(
+      `✅ Checking if player ${playerId} has role ${roleId} (existingPlayerRole: ${existingPlayerRole.length})\n`
+    );
+    if (!existingPlayerRole.length) {
+      console.log(`✅ Adding player ${playerId} to role ${roleId}\n`);
+      await ctx.rawQuery(
+        `INSERT INTO "security"."PlayerRoleMemberships" ("playerId", "roleId", "createdAt", "updatedAt")
+         VALUES (:playerId, :roleId, NOW(), NOW())`,
+        { playerId, roleId }
+      );
     }
-    catch (error) {
-        console.error("❌ Failed to ensure PlayerRoleMembership");
-        console.error(`   playerId: ${playerId}`);
-        console.error(`   roleId: ${roleId}`);
-        if (error instanceof Error) {
-            console.error(`   message: ${error.message}`);
-        }
-        else {
-            console.error(`   message: ${String(error)}`);
-        }
-        if (error && typeof error === "object" && "sql" in error) {
-            console.error(`   sql: ${String(error.sql)}`);
-        }
-        throw error;
+  } catch (error) {
+    console.error("❌ Failed to ensure PlayerRoleMembership");
+    console.error(`   playerId: ${playerId}`);
+    console.error(`   roleId: ${roleId}`);
+    if (error instanceof Error) {
+      console.error(`   message: ${error.message}`);
+    } else {
+      console.error(`   message: ${String(error)}`);
     }
+    if (error && typeof error === "object" && "sql" in error) {
+      console.error(`   sql: ${String(error.sql)}`);
+    }
+    throw error;
+  }
 }
 async function ensureClubAdminPermission(ctx, clubId, playerId) {
-    const roleId = await ensureRole(ctx, {
-        name: "Admin",
-        description: "Club admin",
-        linkId: clubId,
-        linkType: "club",
-        locked: true,
-    });
-    console.log(`✅ Created Admin role for club ${clubId} (role ID: ${roleId})\n`);
-    const clubClaimId = await ensureClaimId(ctx, "edit:club");
-    console.log(`✅ Created edit:club claim (claim ID: ${clubClaimId})\n`);
-    await ensureRoleClaim(ctx, roleId, clubClaimId);
-    console.log(`✅ Added edit:club claim to Admin role (role ID: ${roleId})\n`);
-    const locationClaimId = await ensureClaimId(ctx, "edit:location");
-    console.log(`✅ Created edit:location claim (claim ID: ${locationClaimId})\n`);
-    await ensureRoleClaim(ctx, roleId, locationClaimId);
-    console.log(`✅ Added edit:location claim to Admin role (role ID: ${roleId})\n`);
-    await ensurePlayerRole(ctx, playerId, roleId);
-    console.log(`✅ Added Admin role to player (player ID: ${playerId})\n`);
+  const roleId = await ensureRole(ctx, {
+    name: "Admin",
+    description: "Club admin",
+    linkId: clubId,
+    linkType: "club",
+    locked: true,
+  });
+  console.log(`✅ Created Admin role for club ${clubId} (role ID: ${roleId})\n`);
+  const clubClaimId = await ensureClaimId(ctx, "edit:club");
+  console.log(`✅ Created edit:club claim (claim ID: ${clubClaimId})\n`);
+  await ensureRoleClaim(ctx, roleId, clubClaimId);
+  console.log(`✅ Added edit:club claim to Admin role (role ID: ${roleId})\n`);
+  const locationClaimId = await ensureClaimId(ctx, "edit:location");
+  console.log(`✅ Created edit:location claim (claim ID: ${locationClaimId})\n`);
+  await ensureRoleClaim(ctx, roleId, locationClaimId);
+  console.log(`✅ Added edit:location claim to Admin role (role ID: ${roleId})\n`);
+  const changeEncounterClaimId = await ensureClaimId(ctx, "change:encounter");
+  console.log(`✅ Created change:encounter claim (claim ID: ${changeEncounterClaimId})\n`);
+  await ensureRoleClaim(ctx, roleId, changeEncounterClaimId);
+  console.log(`✅ Added change:encounter claim to Admin role (role ID: ${roleId})\n`);
+  const enterResultsClaimId = await ensureClaimId(ctx, "enter:results");
+  console.log(`✅ Created enter:results claim (claim ID: ${enterResultsClaimId})\n`);
+  await ensureRoleClaim(ctx, roleId, enterResultsClaimId);
+  console.log(`✅ Added enter:results claim to Admin role (role ID: ${roleId})\n`);
+  await ensurePlayerRole(ctx, playerId, roleId);
+  console.log(`✅ Added Admin role to player (player ID: ${playerId})\n`);
 }

--- a/database/seeders/utils/dist/player-factory.js
+++ b/database/seeders/utils/dist/player-factory.js
@@ -8,71 +8,98 @@ const data_factory_1 = require("./data-factory");
  * PlayerFactory provides utilities for creating players in seeders and tests
  */
 class PlayerFactory {
-    /**
-     * Create a single player with optional overrides
-     */
-    static async create(ctx, options = {}) {
-        const { email, firstName, lastName, memberId, gender = "M", domain = "example.com", prefix = "test", sub = "", ranking, skipRanking = false, } = options;
-        // Generate defaults if not provided
-        const finalEmail = email || data_factory_1.DataFactory.generateEmail(prefix, domain);
-        const name = firstName && lastName ? { firstName, lastName } : data_factory_1.DataFactory.generateName();
-        const finalMemberId = memberId || data_factory_1.DataFactory.generateMemberId(prefix.toUpperCase());
-        const player = await (0, entity_builders_1.findOrCreatePlayer)(ctx, finalEmail, name.firstName, name.lastName, finalMemberId, gender, true, // competitionPlayer
-        sub);
-        // Add ranking if not skipped
-        if (!skipRanking) {
-            await (0, ranking_builders_1.addRankingToPlayer)(ctx, player.id, {
-                single: ranking?.single,
-                double: ranking?.double,
-                mix: ranking?.mix,
-            });
-        }
-        return player;
+  /**
+   * Create a single player with optional overrides
+   */
+  static async create(ctx, options = {}) {
+    const {
+      email,
+      firstName,
+      lastName,
+      memberId,
+      gender = "M",
+      domain = "example.com",
+      prefix = "test",
+      sub = "",
+      ranking,
+      skipRanking = false,
+    } = options;
+    // Generate defaults if not provided
+    const finalEmail = email || data_factory_1.DataFactory.generateEmail(prefix, domain);
+    const name =
+      firstName && lastName ? { firstName, lastName } : data_factory_1.DataFactory.generateName();
+    const finalMemberId =
+      memberId || data_factory_1.DataFactory.generateMemberId(prefix.toUpperCase());
+    const player = await (0, entity_builders_1.findOrCreatePlayer)(
+      ctx,
+      finalEmail,
+      name.firstName,
+      name.lastName,
+      finalMemberId,
+      gender,
+      true, // competitionPlayer
+      sub
+    );
+    // Add ranking if not skipped
+    if (!skipRanking) {
+      await (0, ranking_builders_1.addRankingToPlayer)(ctx, player.id, {
+        single: ranking?.single,
+        double: ranking?.double,
+        mix: ranking?.mix,
+      });
     }
-    /**
-     * Create multiple players at once
-     */
-    static async createMany(ctx, options) {
-        const { count, gender = "mixed", domain = "example.com", prefix = "test", baseIndex = 0, skipRanking = false, } = options;
-        const players = [];
-        for (let i = 0; i < count; i++) {
-            const index = baseIndex + i;
-            // Determine gender for this player
-            let playerGender;
-            if (gender === "mixed") {
-                // Alternate between M and F
-                playerGender = index % 2 === 0 ? "M" : "F";
-            }
-            else {
-                playerGender = gender;
-            }
-            const name = data_factory_1.DataFactory.generateNameAtIndex(index, playerGender);
-            const player = await this.create(ctx, {
-                email: `${name.firstName.toLowerCase()}.${name.lastName.toLowerCase()}@${domain}`,
-                firstName: name.firstName,
-                lastName: name.lastName,
-                memberId: `${prefix.toUpperCase()}-${index}-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
-                gender: playerGender,
-                domain,
-                prefix,
-                skipRanking,
-            });
-            players.push(player);
-        }
-        return players;
+    return player;
+  }
+  /**
+   * Create multiple players at once
+   */
+  static async createMany(ctx, options) {
+    const {
+      count,
+      gender = "mixed",
+      domain = "example.com",
+      prefix = "test",
+      baseIndex = 0,
+      skipRanking = false,
+    } = options;
+    const players = [];
+    for (let i = 0; i < count; i++) {
+      const index = baseIndex + i;
+      // Determine gender for this player
+      let playerGender;
+      if (gender === "mixed") {
+        // Alternate between M and F
+        playerGender = index % 2 === 0 ? "M" : "F";
+      } else {
+        playerGender = gender;
+      }
+      const name = data_factory_1.DataFactory.generateNameAtIndex(index, playerGender);
+      const player = await this.create(ctx, {
+        email: `${name.firstName.toLowerCase()}.${name.lastName.toLowerCase().replace(/\s+/g, "")}@${domain}`,
+        firstName: name.firstName,
+        lastName: name.lastName,
+        memberId: `${prefix.toUpperCase()}-${index}-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+        gender: playerGender,
+        domain,
+        prefix,
+        skipRanking,
+      });
+      players.push(player);
     }
-    /**
-     * Create players for a specific team/club
-     */
-    static async createForTeam(ctx, teamName, count, options = {}) {
-        const domain = options.domain || `${teamName.toLowerCase().replace(/\s+/g, "")}.com`;
-        const prefix = options.prefix || teamName.toUpperCase().replace(/\s+/g, "-");
-        return this.createMany(ctx, {
-            count,
-            domain,
-            prefix,
-            ...options,
-        });
-    }
+    return players;
+  }
+  /**
+   * Create players for a specific team/club
+   */
+  static async createForTeam(ctx, teamName, count, options = {}) {
+    const domain = options.domain || `${teamName.toLowerCase().replace(/\s+/g, "")}.com`;
+    const prefix = options.prefix || teamName.toUpperCase().replace(/\s+/g, "-");
+    return this.createMany(ctx, {
+      count,
+      domain,
+      prefix,
+      ...options,
+    });
+  }
 }
 exports.PlayerFactory = PlayerFactory;

--- a/database/seeders/utils/entity-builders.ts
+++ b/database/seeders/utils/entity-builders.ts
@@ -28,9 +28,10 @@ async function findOrCreatePlayer(
 ): Promise<Player> {
   // Check if user already exists
   // Note: QueryTypes.SELECT returns the array directly, not [results, metadata]
+  const slug = `${firstName}-${lastName}`.toLowerCase().replace(/\s+/g, "-");
   const existingUsers = await ctx.query<Player>(
-    `SELECT id, email, "firstName", "lastName" FROM "Players" WHERE email = :email LIMIT 1`,
-    { email: userEmail }
+    `SELECT id, email, "firstName", "lastName" FROM "Players" WHERE email = :email OR slug = :slug LIMIT 1`,
+    { email: userEmail, slug }
   );
 
   if (existingUsers && existingUsers.length > 0) {
@@ -41,7 +42,6 @@ async function findOrCreatePlayer(
 
   // Create new player
   console.log("👤 Creating new player...");
-  const slug = `${firstName}-${lastName}`.toLowerCase().replace(/\s+/g, "-");
   const user = await ctx.insert<Player>(
     `INSERT INTO "Players" (email, "firstName", "lastName", "memberId", gender, slug, "createdAt", "updatedAt", "competitionPlayer", "sub")
      VALUES (:email, :firstName, :lastName, :memberId, :gender, :slug, NOW(), NOW(),:competitionPlayer, :sub)
@@ -221,15 +221,22 @@ async function createEventCompetition(ctx: SeederContext, season: number): Promi
     console.log(`ℹ️  EventCompetition already exists (${existing[0].id})\n`);
     return existing[0].id;
   }
+  const sixMonthsFromNow = new Date(Date.now() + 6 * 30 * 24 * 60 * 60 * 1000);
+  const oneMonthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
   const event = await ctx.insert<EventCompetition>(
-    `INSERT INTO event."EventCompetitions" (name, type, season, official, "visualCode", "createdAt", "updatedAt")
-     VALUES (:name, :type, :season, true, :visualCode, NOW(), NOW())
+    `INSERT INTO event."EventCompetitions" (name, type, season, official, "visualCode", "changeOpenDate", "changeCloseDatePeriod1", "changeCloseDatePeriod2", "changeCloseRequestDatePeriod1", "changeCloseRequestDatePeriod2", "createdAt", "updatedAt")
+     VALUES (:name, :type, :season, true, :visualCode, :changeOpenDate, :closePeriod1, :closePeriod2, :requestPeriod1, :requestPeriod2, NOW(), NOW())
      RETURNING id`,
     {
       name: `Test Event ${season}`,
       type: "PROV",
       season,
       visualCode,
+      changeOpenDate: oneMonthAgo,
+      closePeriod1: sixMonthsFromNow,
+      closePeriod2: sixMonthsFromNow,
+      requestPeriod1: sixMonthsFromNow,
+      requestPeriod2: sixMonthsFromNow,
     }
   );
   const eventId = event.id;
@@ -325,33 +332,49 @@ async function createEncounters(
   drawId: string,
   teamId: string,
   opponentTeamId: string,
-  encounterCount = 10
+  encounterCount = 10,
+  season?: number
 ): Promise<void> {
   console.log("⚔️ Creating Encounters...");
   const now = new Date();
+  const currentMonth = now.getMonth(); // 0-indexed
+
+  // Competition season runs Sep 1 (month 8) → Apr 30 (month 3) of the following year.
+  // If we're in the off-season (May–Aug, month 4–7), anchor dates to the season window
+  // instead of now so encounters don't land in off-season months.
+  const inOffSeason = currentMonth >= 4 && currentMonth < 8;
+  const effectiveSeason = season ?? (currentMonth >= 4 ? now.getFullYear() : now.getFullYear() - 1);
+  const seasonStart = new Date(`${effectiveSeason}-09-01`);
+  const seasonEnd = new Date(`${effectiveSeason + 1}-04-30`);
+  const anchor = inOffSeason ? seasonStart : now;
   const halfCount = Math.floor(encounterCount / 2);
+  // Spread encounters evenly across the season window
+  const totalDays = Math.floor(
+    (seasonEnd.getTime() - seasonStart.getTime()) / (24 * 60 * 60 * 1000)
+  );
+  const step = Math.floor(totalDays / encounterCount);
 
   for (let i = 0; i < encounterCount; i++) {
     let encounterDate: Date;
 
-    if (i < halfCount) {
+    if (inOffSeason) {
+      // All encounters spread across the upcoming season
+      encounterDate = new Date(seasonStart);
+      encounterDate.setDate(seasonStart.getDate() + i * step + (i % 7));
+    } else if (i < halfCount) {
       // First half: dates before current date
-      // Generate dates going backwards from current date with varying intervals
-      // Use base interval of 5-6 days plus variation to avoid same weekday
       const baseDays = (halfCount - i) * 5;
-      const variation = (i % 7) - 3; // Vary by -3 to +3 days
+      const variation = (i % 7) - 3;
       const daysBefore = baseDays + variation;
-      encounterDate = new Date(now);
-      encounterDate.setDate(encounterDate.getDate() - daysBefore);
+      encounterDate = new Date(anchor);
+      encounterDate.setDate(anchor.getDate() - daysBefore);
     } else {
       // Second half: dates after current date
-      // Generate dates going forwards from current date with varying intervals
-      // Use base interval of 5-6 days plus variation to avoid same weekday
       const baseDays = (i - halfCount + 1) * 5;
-      const variation = (i % 7) - 3; // Vary by -3 to +3 days
+      const variation = (i % 7) - 3;
       const daysAfter = baseDays + variation;
-      encounterDate = new Date(now);
-      encounterDate.setDate(encounterDate.getDate() + daysAfter);
+      encounterDate = new Date(anchor);
+      encounterDate.setDate(anchor.getDate() + daysAfter);
     }
 
     // Validate the date
@@ -417,10 +440,10 @@ async function createLocation(
   }
 
   const hasCoordinates = locationData.latitude != null && locationData.longitude != null;
-  const coordinatesColumn = hasCoordinates ? ', coordinates' : '';
+  const coordinatesColumn = hasCoordinates ? ", coordinates" : "";
   const coordinatesValue = hasCoordinates
     ? `, ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)`
-    : '';
+    : "";
 
   const location = await ctx.insert<Location>(
     `INSERT INTO event."Locations" (name, address, street, "streetNumber", postalcode, city, state, phone, "clubId", "createdAt", "updatedAt"${coordinatesColumn})
@@ -502,10 +525,7 @@ const createEncountersWithErrorHandling = withErrorHandling(
   createEncounters,
   "creating encounters"
 );
-const createLocationWithErrorHandling = withErrorHandling(
-  createLocation,
-  "creating location"
-);
+const createLocationWithErrorHandling = withErrorHandling(createLocation, "creating location");
 const createAvailabilityWithErrorHandling = withErrorHandling(
   createAvailability,
   "creating availability"

--- a/database/seeders/utils/permissions.ts
+++ b/database/seeders/utils/permissions.ts
@@ -32,7 +32,6 @@ async function getRoleSchemaInfo(ctx: SeederContext): Promise<RoleSchemaInfo> {
   };
 }
 
-
 export async function ensureRole(
   ctx: SeederContext,
   {
@@ -221,6 +220,17 @@ export async function ensureClubAdminPermission(
   console.log(`✅ Created edit:location claim (claim ID: ${locationClaimId})\n`);
   await ensureRoleClaim(ctx, roleId, locationClaimId);
   console.log(`✅ Added edit:location claim to Admin role (role ID: ${roleId})\n`);
+
+  const changeEncounterClaimId = await ensureClaimId(ctx, "change:encounter");
+  console.log(`✅ Created change:encounter claim (claim ID: ${changeEncounterClaimId})\n`);
+  await ensureRoleClaim(ctx, roleId, changeEncounterClaimId);
+  console.log(`✅ Added change:encounter claim to Admin role (role ID: ${roleId})\n`);
+
+  const enterResultsClaimId = await ensureClaimId(ctx, "enter:results");
+  console.log(`✅ Created enter:results claim (claim ID: ${enterResultsClaimId})\n`);
+  await ensureRoleClaim(ctx, roleId, enterResultsClaimId);
+  console.log(`✅ Added enter:results claim to Admin role (role ID: ${roleId})\n`);
+
   await ensurePlayerRole(ctx, playerId, roleId);
   console.log(`✅ Added Admin role to player (player ID: ${playerId})\n`);
 }

--- a/database/seeders/utils/player-factory.ts
+++ b/database/seeders/utils/player-factory.ts
@@ -115,7 +115,7 @@ export class PlayerFactory {
       const name = DataFactory.generateNameAtIndex(index, playerGender);
 
       const player = await this.create(ctx, {
-        email: `${name.firstName.toLowerCase()}.${name.lastName.toLowerCase()}@${domain}`,
+        email: `${name.firstName.toLowerCase()}.${name.lastName.toLowerCase().replace(/\s+/g, "")}@${domain}`,
         firstName: name.firstName,
         lastName: name.lastName,
         memberId: `${prefix.toUpperCase()}-${index}-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,


### PR DESCRIPTION
Seed:
- Fix season calculation to use month >= 4 (matching getSeason() in utils)
- Fix email generation stripping spaces from last names
- Fix findOrCreatePlayer to check by both email and slug
- Add changeOpenDate, changeCloseDatePeriod1/2, changeCloseRequestDatePeriod1/2 to EventCompetition insert with dynamic dates relative to now
- Add change:encounter and enter:results claims to club Admin role
- Add opponent club admin permissions for jad+dev@dashdot.be
- Generate encounter dates within the competition season window (Sep–Apr) instead of anchoring to current date (which may be off-season)
- Pass season to createEncounters so dates land in correct year