### PR TITLE
feat(encounter): admin force-reschedule mutation

### DIFF
--- a/packages/backend-graphql/src/resolvers/event/competition/encounter.resolver.ts
+++ b/packages/backend-graphql/src/resolvers/event/competition/encounter.resolver.ts
@@ -13,6 +13,7 @@ import {
   EncounterCompetition,
   Game,
   Location,
+  Logging,
   Player,
   RankingSystem,
   Team,
@@ -23,8 +24,10 @@ import {
   ChangeEncounterDateStatus,
   ChangeEncounterParty,
   EncounterChangeViewState,
+  LoggingAction,
 } from "@badman/utils";
 import { EncounterGamesGenerationService } from "@badman/backend-encounter-games";
+import { NotificationService } from "@badman/backend-notifications";
 import { getSyncJobOptions, Sync, SyncQueue } from "@badman/backend-queue";
 import { PointsService, RankingSystemService } from "@badman/backend-ranking";
 import { InjectQueue } from "@nestjs/bull";
@@ -77,7 +80,8 @@ export class EncounterCompetitionResolver {
     private encounterGamesService: EncounterGamesGenerationService,
     private readonly rankingSystemService: RankingSystemService,
     private readonly teamLoader: TeamLoaderService,
-    private readonly drawLoader: DrawCompetitionLoaderService
+    private readonly drawLoader: DrawCompetitionLoaderService,
+    private readonly notificationService: NotificationService
   ) {}
 
   @Query(() => EncounterCompetition)
@@ -555,11 +559,11 @@ export class EncounterCompetitionResolver {
   }
 
   @Mutation(() => Boolean)
-  async changeDate(
+  async adminChangeEncounterDate(
     @User() user: Player,
     @Args("id", { type: () => ID }) id: string,
     @Args("date") date: Date,
-
+    @Args("locationId", { type: () => ID, nullable: true }) locationId: string | undefined,
     @Args("updateBadman") updateBadman: boolean,
     @Args("updateVisual") updateVisual: boolean
   ) {
@@ -574,19 +578,45 @@ export class EncounterCompetitionResolver {
     }
 
     if (updateBadman) {
-      await encounter.update({ date: date });
+      const locationChanged = !!locationId && locationId !== encounter.locationId;
+      this.logger.log(
+        `[adminChangeEncounterDate] encounterId=${encounter.id} date=${date.toISOString()} locationId=${locationId ?? "unchanged"} actor=${user.id}`
+      );
+      const transaction = await this._sequelize.transaction();
+      try {
+        const updates: { date: Date; locationId?: string } = { date };
+        if (locationChanged) {
+          updates.locationId = locationId;
+        }
+        await encounter.update(updates, { transaction });
+        await Logging.create(
+          {
+            action: LoggingAction.EncounterChanged,
+            playerId: user.id,
+            meta: {
+              encounterId: encounter.id,
+              date,
+              originalDate: encounter.originalDate,
+            },
+          },
+          { transaction }
+        );
+        await transaction.commit();
+        this.logger.log(`[adminChangeEncounterDate] committed encounterId=${encounter.id}`);
+      } catch (e) {
+        await transaction.rollback();
+        this.logger.error(`[adminChangeEncounterDate] rollback encounterId=${encounter.id}`, e);
+        throw e;
+      }
+
+      this.notificationService.notifyEncounterChangeFinished(encounter, locationChanged);
     }
 
     if (updateVisual) {
       await this.syncQueue.add(
         Sync.ChangeDate,
-        {
-          encounterId: encounter.id,
-        },
-        {
-          removeOnComplete: true,
-          removeOnFail: false,
-        }
+        { encounterId: encounter.id },
+        { removeOnComplete: true, removeOnFail: false }
       );
     }
 

--- a/packages/backend-translate/assets/i18n/en/all.json
+++ b/packages/backend-translate/assets/i18n/en/all.json
@@ -2695,6 +2695,20 @@
           "changedDate": "Changed date",
           "homeGames": "Home games"
         },
+        "adminChangeDateDialog": {
+          "title": "Change encounter date",
+          "dateLabel": "Date & time",
+          "locationLabel": "Location",
+          "locationNone": "No location",
+          "messages": {
+            "success": "Date changed successfully",
+            "error": "Failed to change date"
+          },
+          "buttons": {
+            "cancel": "Cancel",
+            "confirm": "Confirm"
+          }
+        },
         "table": {
           "headers": {
             "team": "Team",

--- a/packages/backend-translate/assets/i18n/en/all.json
+++ b/packages/backend-translate/assets/i18n/en/all.json
@@ -3876,7 +3876,8 @@
           "originalDate": "Original date",
           "proposal": "Proposal",
           "buttons": {
-            "courtsAvailable": "court(s) available"
+            "spaceForEncounters": "Space for {count} more encounters",
+            "courtsAvailableTooltip": "{courts} courts available"
           },
           "eventWarning": "Competition is not allowed",
           "drawer": {

--- a/packages/backend-translate/assets/i18n/fr_BE/all.json
+++ b/packages/backend-translate/assets/i18n/fr_BE/all.json
@@ -2199,12 +2199,42 @@
     "clubPage": {
       "noClubFound": "Aucun club trouvé",
       "encounters": {
+        "adminChangeDateDialog": {
+          "title": "Modifier la date de la rencontre",
+          "dateLabel": "Date et heure",
+          "locationLabel": "Emplacement",
+          "locationNone": "Aucun emplacement",
+          "messages": {
+            "success": "Date modifiée avec succès",
+            "error": "Échec de la modification de la date"
+          },
+          "buttons": {
+            "cancel": "Annuler",
+            "confirm": "Confirmer"
+          }
+        },
         "table": {
+          "headers": {
+            "team": "Équipe",
+            "opponent": "Adversaire",
+            "homeAway": "Domicile/Extérieur",
+            "date": "Date",
+            "location": "Emplacement",
+            "status": "Statut",
+            "validation": "Validation",
+            "changeEncounterDate": "Modifier la date de la rencontre",
+            "view": "Afficher"
+          },
           "status": {
             "proposal_sent": "Proposition envoyée",
             "action_required": "Action requise",
             "rejected_waiting": "Attente de réponse",
             "moved": "Déplacée"
+          },
+          "validation": {
+            "valid": "Date et heure dans les créneaux de jeu, lieu disponible",
+            "warnings": "Date et heure en dehors des créneaux de jeu standard",
+            "invalid": "Lieu indisponible ou déjà complet à cette heure"
           }
         }
       },
@@ -2228,29 +2258,6 @@
         "encounterNotEntered": "Résultat de la rencontre non saisi",
         "clubEnrollment": "Mise à jour de l'inscription au club",
         "default": "Notification"
-      }
-    },
-    "clubPage": {
-      "noClubFound": "Aucun club trouvé",
-      "encounters": {
-        "table": {
-          "headers": {
-            "team": "Équipe",
-            "opponent": "Adversaire",
-            "homeAway": "Domicile/Extérieur",
-            "date": "Date",
-            "location": "Emplacement",
-            "status": "Statut",
-            "validation": "Validation",
-            "changeEncounterDate": "Modifier la date de la rencontre",
-            "view": "Afficher"
-          },
-          "validation": {
-            "valid": "Date et heure dans les créneaux de jeu, lieu disponible",
-            "warnings": "Date et heure en dehors des créneaux de jeu standard",
-            "invalid": "Lieu indisponible ou déjà complet à cette heure"
-          }
-        }
       }
     }
   }

--- a/packages/backend-translate/assets/i18n/fr_BE/all.json
+++ b/packages/backend-translate/assets/i18n/fr_BE/all.json
@@ -2169,7 +2169,8 @@
           "originalDate": "Date originale",
           "proposal": "Proposition",
           "buttons": {
-            "courtsAvailable": "terrain(s) disponible(s)"
+            "spaceForEncounters": "Place pour {count} rencontres supplémentaires",
+            "courtsAvailableTooltip": "{courts} terrains disponibles"
           },
           "eventWarning": "La compétition n'est pas autorisée",
           "drawer": {

--- a/packages/backend-translate/assets/i18n/nl_BE/all.json
+++ b/packages/backend-translate/assets/i18n/nl_BE/all.json
@@ -3654,7 +3654,8 @@
           "originalDate": "Oorspronkelijke datum",
           "proposal": "Voorstel",
           "buttons": {
-            "courtsAvailable": "veld(en) beschikbaar"
+            "spaceForEncounters": "Ruimte voor nog {count} ontmoetingen",
+            "courtsAvailableTooltip": "{courts} velden beschikbaar"
           },
           "eventWarning": "Competitie is niet toegestaan",
           "drawer": {

--- a/packages/backend-translate/assets/i18n/nl_BE/all.json
+++ b/packages/backend-translate/assets/i18n/nl_BE/all.json
@@ -2413,6 +2413,20 @@
           "changedDate": "Gewijzigde datum",
           "homeGames": "Thuiswedstrijden"
         },
+        "adminChangeDateDialog": {
+          "title": "Wijzig wedstrijddatum",
+          "dateLabel": "Datum & tijd",
+          "locationLabel": "Locatie",
+          "locationNone": "Geen locatie",
+          "messages": {
+            "success": "Datum succesvol gewijzigd",
+            "error": "Datum wijzigen mislukt"
+          },
+          "buttons": {
+            "cancel": "Annuleren",
+            "confirm": "Bevestigen"
+          }
+        },
         "table": {
           "headers": {
             "team": "Team",

--- a/packages/utils/src/lib/i18n.generated.ts
+++ b/packages/utils/src/lib/i18n.generated.ts
@@ -2713,6 +2713,20 @@ export type I18nTranslations = {
                         "changedDate": string;
                         "homeGames": string;
                     };
+                    "adminChangeDateDialog": {
+                        "title": string;
+                        "dateLabel": string;
+                        "locationLabel": string;
+                        "locationNone": string;
+                        "messages": {
+                            "success": string;
+                            "error": string;
+                        };
+                        "buttons": {
+                            "cancel": string;
+                            "confirm": string;
+                        };
+                    };
                     "table": {
                         "headers": {
                             "team": string;

--- a/packages/utils/src/lib/i18n.generated.ts
+++ b/packages/utils/src/lib/i18n.generated.ts
@@ -3959,7 +3959,8 @@ export type I18nTranslations = {
                         "originalDate": string;
                         "proposal": string;
                         "buttons": {
-                            "courtsAvailable": string;
+                            "spaceForEncounters": string;
+                            "courtsAvailableTooltip": string;
                         };
                         "eventWarning": string;
                         "drawer": {


### PR DESCRIPTION
## Summary

- Renames `changeDate` → `adminChangeEncounterDate` to match the frontend document name
- Adds optional `locationId` arg so admin can also change the encounter location in one call
- Wraps the Badman DB update in a transaction with an audit log entry (`Logging` / `LoggingAction.EncounterChanged`)
- Notifies both club captains via `notifyEncounterChangeFinished` after a successful change
- Structured logger calls for observability (`[adminChangeEncounterDate]` prefix)

## Test plan

- [ ] Admin with `change-any:encounter` permission can call the mutation and the encounter date updates
- [ ] Passing `locationId` updates the location; omitting it leaves it unchanged
- [ ] A `Logging` row is created for each admin change
- [ ] Both club captains receive a notification email after the change
- [ ] Non-admin user receives `UnauthorizedException`
- [ ] Frontend codegen picks up `locationId` after schema regeneration