### PR TITLE
fix(change-date): fix three bugs in SyncDateProcessor and add missing…

### DIFF
--- a/apps/worker/sync/src/app/processors/change-date/__tests__/change-date.spec.ts
+++ b/apps/worker/sync/src/app/processors/change-date/__tests__/change-date.spec.ts
@@ -1,0 +1,156 @@
+import { EncounterCompetition } from "@badman/backend-database";
+import axios from "axios";
+import { SyncDateProcessor } from "../change-date";
+
+jest.mock("@badman/backend-database", () => ({
+  EncounterCompetition: { findByPk: jest.fn() },
+}));
+
+jest.mock("axios");
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeEncounter(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "enc-uuid",
+    visualCode: "42",
+    date: new Date("2025-11-15T13:00:00Z"),
+    originalDate: new Date("2025-10-05T12:00:00Z"),
+    dateSyncedAt: undefined as Date | undefined,
+    save: jest.fn().mockResolvedValue(undefined),
+    getDrawCompetition: jest.fn().mockResolvedValue({
+      getSubEventCompetition: jest.fn().mockResolvedValue({
+        getEventCompetition: jest.fn().mockResolvedValue({
+          visualCode: "TOURN-1",
+          name: "Test Event",
+        }),
+      }),
+    }),
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Record<string, unknown> = {}) {
+  const defaults: Record<string, unknown> = {
+    VR_CHANGE_DATES: true,
+    NODE_ENV: "production",
+    VR_API: "https://vr.api",
+    VR_API_USER: "user",
+    VR_API_PASS: "pass",
+  };
+  const map = { ...defaults, ...overrides };
+  return { get: jest.fn((key: string) => map[key]) } as never;
+}
+
+function makeProcessor(configOverrides: Record<string, unknown> = {}) {
+  return new SyncDateProcessor(makeConfig(configOverrides));
+}
+
+function makeJob(encounterId = "enc-uuid") {
+  return { data: { encounterId } } as never;
+}
+
+// ─── tests ──────────────────────────────────────────────────────────────────
+
+describe("SyncDateProcessor.acceptDate", () => {
+  beforeEach(() => jest.clearAllMocks());
+  afterEach(() => jest.restoreAllMocks());
+
+  it("returns early without touching DB when VR_CHANGE_DATES is not true", async () => {
+    const processor = makeProcessor({ VR_CHANGE_DATES: false });
+    await processor.acceptDate(makeJob());
+    expect(EncounterCompetition.findByPk).not.toHaveBeenCalled();
+  });
+
+  it("returns early when encounter is not found", async () => {
+    (EncounterCompetition.findByPk as jest.Mock).mockResolvedValue(null);
+    const processor = makeProcessor();
+    await processor.acceptDate(makeJob("missing-enc"));
+    expect(axios).not.toHaveBeenCalled();
+  });
+
+  it("returns early when event has no visualCode — does not call axios", async () => {
+    const enc = makeEncounter();
+    enc.getDrawCompetition.mockResolvedValue({
+      getSubEventCompetition: jest.fn().mockResolvedValue({
+        getEventCompetition: jest.fn().mockResolvedValue({ visualCode: null, name: "No Code" }),
+      }),
+    });
+    (EncounterCompetition.findByPk as jest.Mock).mockResolvedValue(enc);
+    const processor = makeProcessor();
+    await processor.acceptDate(makeJob());
+    expect(axios).not.toHaveBeenCalled();
+    // finally block still runs even on early return inside try
+    expect(enc.save).toHaveBeenCalled();
+  });
+
+  it("returns early when encounter has no visualCode — does not call axios", async () => {
+    const enc = makeEncounter({ visualCode: null });
+    (EncounterCompetition.findByPk as jest.Mock).mockResolvedValue(enc);
+    const processor = makeProcessor();
+    await processor.acceptDate(makeJob());
+    expect(axios).not.toHaveBeenCalled();
+    // finally block still runs even on early return inside try
+    expect(enc.save).toHaveBeenCalled();
+  });
+
+  it("in non-production: does NOT call axios and does NOT set dateSyncedAt", async () => {
+    const enc = makeEncounter();
+    (EncounterCompetition.findByPk as jest.Mock).mockResolvedValue(enc);
+    const processor = makeProcessor({ NODE_ENV: "staging" });
+
+    await processor.acceptDate(makeJob());
+
+    expect(axios).not.toHaveBeenCalled();
+    expect(enc.dateSyncedAt).toBeUndefined();
+    expect(enc.save).toHaveBeenCalled();
+  });
+
+  it("in production: calls PUT with correct XML body and sets dateSyncedAt on success", async () => {
+    const enc = makeEncounter();
+    (EncounterCompetition.findByPk as jest.Mock).mockResolvedValue(enc);
+    (axios as unknown as jest.Mock).mockResolvedValue({
+      data: `<?xml version="1.0"?><Result><Error><Code>0</Code><Message>Success.</Message></Error></Result>`,
+    });
+
+    const processor = makeProcessor();
+    await processor.acceptDate(makeJob());
+
+    expect(axios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "PUT",
+        url: "https://vr.api/Tournament/TOURN-1/Match/42/Date",
+        headers: { "Content-Type": "application/xml" },
+        data: expect.stringContaining("<MatchDate>2025-11-15T14:00:00</MatchDate>"), // UTC+1 (CET)
+      })
+    );
+    expect(enc.dateSyncedAt).toBeInstanceOf(Date);
+    expect(enc.save).toHaveBeenCalled();
+  });
+
+  it("in production: clears dateSyncedAt and saves when VR API returns an error code", async () => {
+    const enc = makeEncounter();
+    (EncounterCompetition.findByPk as jest.Mock).mockResolvedValue(enc);
+    (axios as unknown as jest.Mock).mockResolvedValue({
+      data: `<?xml version="1.0"?><Result><Error><Code>1</Code><Message>Not found.</Message></Error></Result>`,
+    });
+
+    const processor = makeProcessor();
+    await processor.acceptDate(makeJob());
+
+    expect(enc.dateSyncedAt).toBeUndefined();
+    expect(enc.save).toHaveBeenCalled();
+  });
+
+  it("in production: clears dateSyncedAt and saves when axios throws", async () => {
+    const enc = makeEncounter();
+    (EncounterCompetition.findByPk as jest.Mock).mockResolvedValue(enc);
+    (axios as unknown as jest.Mock).mockRejectedValue(new Error("network error"));
+
+    const processor = makeProcessor();
+    await processor.acceptDate(makeJob());
+
+    expect(enc.dateSyncedAt).toBeUndefined();
+    expect(enc.save).toHaveBeenCalled();
+  });
+});

--- a/apps/worker/sync/src/app/processors/change-date/change-date.ts
+++ b/apps/worker/sync/src/app/processors/change-date/change-date.ts
@@ -14,7 +14,6 @@ import { ConfigType } from "@badman/utils";
 })
 export class SyncDateProcessor {
   private readonly logger = new Logger(SyncDateProcessor.name);
-  private visualFormat = "YYYY-MM-DDTHH:mm:ss";
 
   constructor(private configService: ConfigService<ConfigType>) {
     this.logger.debug("SyncDateConsumer");
@@ -47,6 +46,11 @@ export class SyncDateProcessor {
         return;
       }
 
+      if (!encounter.visualCode) {
+        this.logger.error(`No visual code found for encounter ${encounter.id} — cannot sync date`);
+        return;
+      }
+
       const url = `${this.configService.get("VR_API")}/Tournament/${event.visualCode}/Match/${
         encounter.visualCode
       }/Date`;
@@ -61,7 +65,7 @@ export class SyncDateProcessor {
     <TournamentMatch>
         <TournamentID>${event.visualCode}</TournamentID>
         <MatchID>${encounter.visualCode}</MatchID>
-        <MatchDate>${formatEncounterDateForApi(encounter.date as Date, "Europe/Brussels", this.visualFormat)}</MatchDate>
+        <MatchDate>${formatEncounterDateForApi(encounter.date as Date, "Europe/Brussels")}</MatchDate>
     </TournamentMatch>
   `;
 
@@ -99,10 +103,14 @@ export class SyncDateProcessor {
           this.logger.error(options);
           throw new Error(bodyPut.Error?.Message);
         }
+
+        encounter.dateSyncedAt = new Date();
       } else {
         this.logger.debug(options);
+        this.logger.log(
+          `[SyncDateProcessor] Skipping VR API call in non-production — dateSyncedAt NOT updated`
+        );
       }
-      encounter.dateSyncedAt = new Date();
     } catch (error) {
       this.logger.error(error);
       encounter.dateSyncedAt = undefined;

--- a/packages/backend-graphql/src/resolvers/event/competition/encounter.resolver.spec.ts
+++ b/packages/backend-graphql/src/resolvers/event/competition/encounter.resolver.spec.ts
@@ -4,6 +4,7 @@ import {
   EncounterChange,
   EncounterChangeDate,
   EncounterCompetition,
+  Logging,
   Player,
   Team,
 } from "@badman/backend-database";
@@ -15,17 +16,21 @@ import { TeamLoaderService } from "../../../loaders/team-loader.service";
 import { EncounterValidationService } from "@badman/backend-change-encounter";
 import { EncounterGamesGenerationService } from "@badman/backend-encounter-games";
 import { PointsService, RankingSystemService } from "@badman/backend-ranking";
-import { SyncQueue } from "@badman/backend-queue";
+import { NotificationService } from "@badman/backend-notifications";
+import { Sync, SyncQueue } from "@badman/backend-queue";
 import {
   ChangeEncounterDateStatus,
   ChangeEncounterParty,
   EncounterChangeViewState,
 } from "@badman/utils";
+import { NotFoundException, UnauthorizedException } from "@nestjs/common";
 
 describe("EncounterCompetitionResolver — DataLoader field resolvers", () => {
   let resolver: EncounterCompetitionResolver;
   let teamLoaderService: TeamLoaderService;
   let drawLoaderService: DrawCompetitionLoaderService;
+  let syncQueue: { add: jest.Mock };
+  let notificationService: { notifyEncounterChangeFinished: jest.Mock };
 
   const makeEncounter = (overrides: Partial<EncounterCompetition> = {}) =>
     ({
@@ -37,16 +42,24 @@ describe("EncounterCompetitionResolver — DataLoader field resolvers", () => {
     }) as unknown as EncounterCompetition;
 
   beforeEach(async () => {
+    syncQueue = { add: jest.fn() };
+    notificationService = { notifyEncounterChangeFinished: jest.fn() };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EncounterCompetitionResolver,
         {
           provide: getQueueToken(SyncQueue),
-          useValue: { add: jest.fn() },
+          useValue: syncQueue,
         },
         {
           provide: Sequelize,
-          useValue: { transaction: jest.fn() },
+          useValue: {
+            transaction: jest.fn().mockResolvedValue({
+              commit: jest.fn().mockResolvedValue(undefined),
+              rollback: jest.fn().mockResolvedValue(undefined),
+            }),
+          },
         },
         {
           provide: PointsService,
@@ -71,6 +84,10 @@ describe("EncounterCompetitionResolver — DataLoader field resolvers", () => {
         {
           provide: DrawCompetitionLoaderService,
           useValue: { load: jest.fn() },
+        },
+        {
+          provide: NotificationService,
+          useValue: notificationService,
         },
       ],
     }).compile();
@@ -202,12 +219,13 @@ describe("EncounterCompetitionResolver — DataLoader field resolvers", () => {
     const makeDate = (status: ChangeEncounterDateStatus | null) =>
       ({ status }) as unknown as EncounterChangeDate;
 
-    const makeEncounterWithChange = (change: EncounterChange | null) =>
-      ({
+    const makeEncounterWithChange = (change: EncounterChange | null) => {
+      jest.spyOn(EncounterChange, "findOne").mockResolvedValue(change);
+      return {
         id: "enc-uuid",
         homeTeamId: "home-team-uuid",
-        getEncounterChange: jest.fn().mockResolvedValue(change),
-      }) as unknown as EncounterCompetition;
+      } as unknown as EncounterCompetition;
+    };
 
     beforeEach(() => {
       jest.spyOn(teamLoaderService, "load").mockResolvedValue(homeTeam);
@@ -312,6 +330,182 @@ describe("EncounterCompetitionResolver — DataLoader field resolvers", () => {
       expect(loadSpy).toHaveBeenCalledWith("team-2");
       expect(homeResult).toBe(teamA);
       expect(awayResult).toBe(teamB);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // adminChangeEncounterDate mutation
+  // ---------------------------------------------------------------------------
+  describe("adminChangeEncounterDate", () => {
+    const adminUser = {
+      id: "admin-uuid",
+      hasAnyPermission: jest.fn().mockResolvedValue(true),
+    } as unknown as Player;
+
+    const unauthorizedUser = {
+      id: "user-uuid",
+      hasAnyPermission: jest.fn().mockResolvedValue(false),
+    } as unknown as Player;
+
+    const newDate = new Date("2025-11-15T13:00:00Z");
+
+    function makeDbEncounter(overrides: Partial<EncounterCompetition> = {}) {
+      return {
+        id: "enc-uuid",
+        locationId: "loc-uuid",
+        originalDate: new Date("2025-10-05T12:00:00Z"),
+        update: jest.fn().mockResolvedValue(undefined),
+        ...overrides,
+      } as unknown as EncounterCompetition;
+    }
+
+    it("throws NotFoundException when encounter does not exist", async () => {
+      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(null);
+
+      await expect(
+        resolver.adminChangeEncounterDate(adminUser, "missing-id", newDate, undefined, true, false)
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("throws UnauthorizedException when user lacks change-any:encounter", async () => {
+      const encounter = makeDbEncounter();
+      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(encounter);
+
+      await expect(
+        resolver.adminChangeEncounterDate(
+          unauthorizedUser,
+          "enc-uuid",
+          newDate,
+          undefined,
+          true,
+          false
+        )
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it("updateBadman=true: updates date, creates Logging entry, commits, notifies", async () => {
+      const encounter = makeDbEncounter();
+      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(encounter);
+      const loggingCreate = jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
+
+      const result = await resolver.adminChangeEncounterDate(
+        adminUser,
+        "enc-uuid",
+        newDate,
+        undefined,
+        true,
+        false
+      );
+
+      expect(result).toBe(true);
+      expect(encounter.update).toHaveBeenCalledWith({ date: newDate }, expect.any(Object));
+      expect(loggingCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ meta: expect.objectContaining({ date: newDate }) }),
+        expect.any(Object)
+      );
+      expect(notificationService.notifyEncounterChangeFinished).toHaveBeenCalledWith(
+        encounter,
+        false // location not changed
+      );
+    });
+
+    it("updateBadman=true with new locationId: updates location and flags locationChanged=true", async () => {
+      const encounter = makeDbEncounter({ locationId: "old-loc" });
+      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(encounter);
+      jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
+
+      await resolver.adminChangeEncounterDate(
+        adminUser,
+        "enc-uuid",
+        newDate,
+        "new-loc",
+        true,
+        false
+      );
+
+      expect(encounter.update).toHaveBeenCalledWith(
+        { date: newDate, locationId: "new-loc" },
+        expect.any(Object)
+      );
+      expect(notificationService.notifyEncounterChangeFinished).toHaveBeenCalledWith(
+        encounter,
+        true // location changed
+      );
+    });
+
+    it("updateBadman=false: skips DB update and notifications", async () => {
+      const encounter = makeDbEncounter();
+      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(encounter);
+      const loggingCreate = jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
+
+      await resolver.adminChangeEncounterDate(
+        adminUser,
+        "enc-uuid",
+        newDate,
+        undefined,
+        false,
+        false
+      );
+
+      expect(encounter.update).not.toHaveBeenCalled();
+      expect(loggingCreate).not.toHaveBeenCalled();
+      expect(notificationService.notifyEncounterChangeFinished).not.toHaveBeenCalled();
+    });
+
+    it("updateVisual=true: queues Sync.ChangeDate job", async () => {
+      const encounter = makeDbEncounter();
+      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(encounter);
+
+      await resolver.adminChangeEncounterDate(
+        adminUser,
+        "enc-uuid",
+        newDate,
+        undefined,
+        false,
+        true
+      );
+
+      expect(syncQueue.add).toHaveBeenCalledWith(
+        Sync.ChangeDate,
+        { encounterId: "enc-uuid" },
+        expect.any(Object)
+      );
+    });
+
+    it("updateVisual=false: does not queue any sync job", async () => {
+      const encounter = makeDbEncounter();
+      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(encounter);
+      jest.spyOn(Logging, "create").mockResolvedValue(undefined as never);
+
+      await resolver.adminChangeEncounterDate(
+        adminUser,
+        "enc-uuid",
+        newDate,
+        undefined,
+        true,
+        false
+      );
+
+      expect(syncQueue.add).not.toHaveBeenCalled();
+    });
+
+    it("rolls back transaction on DB error", async () => {
+      const encounter = makeDbEncounter();
+      encounter.update = jest.fn().mockRejectedValue(new Error("DB failure"));
+      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(encounter);
+
+      const sequelize = resolver["_sequelize"] as unknown as {
+        transaction: jest.Mock;
+      };
+      const tx = { commit: jest.fn(), rollback: jest.fn() };
+      sequelize.transaction.mockResolvedValue(tx);
+
+      await expect(
+        resolver.adminChangeEncounterDate(adminUser, "enc-uuid", newDate, undefined, true, false)
+      ).rejects.toThrow("DB failure");
+
+      expect(tx.rollback).toHaveBeenCalled();
+      expect(tx.commit).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
… tests

- Remove broken visualFormat ("YYYY-MM-DDTHH:mm:ss" uses Moment.js tokens that throw RangeError in date-fns v4); use formatEncounterDateForApi default ("yyyy-MM-dd'T'HH:mm:ss") which matches the VR API schema
- Guard encounter.visualCode before building the PUT URL to avoid sending ".../Match/null/Date" to toornoi.nl
- Only set dateSyncedAt after a successful production API call; previously always stamped in finally, making staging look synced when nothing was sent

Add SyncDateProcessor unit tests covering all guard branches, non-production skip path, production success, API error response, and network failure.

Fix encounter.resolver.spec.ts: add missing NotificationService provider (module failed to compile since adminChangeEncounterDate was added), fix changeStatus tests to spy on EncounterChange.findOne instead of instance method, and add full coverage for adminChangeEncounterDate mutation.