### PR TITLE
fix(encounter-change): remove deprecated updateEncounterChange mutation and stale tests

### DIFF
--- a/packages/backend-graphql/src/resolvers/event/competition/encounter-change.resolver.spec.ts
+++ b/packages/backend-graphql/src/resolvers/event/competition/encounter-change.resolver.spec.ts
@@ -1,8 +1,8 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { NotFoundException } from "@nestjs/common";
 import { Sequelize } from "sequelize-typescript";
 import { getQueueToken } from "@nestjs/bull";
-import { EncounterChange, EncounterCompetition, Player } from "@badman/backend-database";
+import { EncounterChange, Player } from "@badman/backend-database";
 import { SyncQueue } from "@badman/backend-queue";
 import { EncounterValidationService } from "@badman/backend-change-encounter";
 import { NotificationService } from "@badman/backend-notifications";
@@ -83,61 +83,6 @@ describe("EncounterChangeCompetitionResolver", () => {
       const result = { count: 1, rows: [{ id: "ec1" }] } as any;
       jest.spyOn(EncounterChange, "findAndCountAll").mockResolvedValue(result);
       expect(await resolver.encounterChanges({} as any)).toBe(result);
-    });
-  });
-
-  describe("updateEncounterChange (mutation)", () => {
-    it("throws NotFoundException when encounter change not found", async () => {
-      jest.spyOn(EncounterChange, "findByPk").mockResolvedValue(null);
-      await expect(
-        resolver.updateEncounterChange(buildUser(true), { id: "missing" } as any)
-      ).rejects.toThrow(NotFoundException);
-    });
-
-    it("throws NotFoundException when encounter not found", async () => {
-      const fakeChange = { id: "ec-uuid", encounterId: "enc-uuid" } as unknown as EncounterChange;
-      jest.spyOn(EncounterChange, "findByPk").mockResolvedValue(fakeChange);
-      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(null);
-      await expect(
-        resolver.updateEncounterChange(buildUser(true), { id: "ec-uuid" } as any)
-      ).rejects.toThrow(NotFoundException);
-    });
-
-    it("throws UnauthorizedException when user lacks change:encounter for both clubs", async () => {
-      const fakeChange = { id: "ec-uuid", encounterId: "enc-uuid" } as unknown as EncounterChange;
-      const fakeHome = { clubId: "home-club" };
-      const fakeAway = { clubId: "away-club" };
-      const fakeEncounter = {
-        getHome: jest.fn().mockResolvedValue(fakeHome),
-        getAway: jest.fn().mockResolvedValue(fakeAway),
-      } as unknown as EncounterCompetition;
-      jest.spyOn(EncounterChange, "findByPk").mockResolvedValue(fakeChange);
-      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(fakeEncounter);
-      await expect(
-        resolver.updateEncounterChange(buildUser(false), { id: "ec-uuid" } as any)
-      ).rejects.toThrow(UnauthorizedException);
-    });
-
-    it("updates encounter change and returns result when user has permission", async () => {
-      const updated = { id: "ec-uuid", status: "accepted" };
-      const fakeChange = {
-        id: "ec-uuid",
-        encounterId: "enc-uuid",
-        update: jest.fn().mockResolvedValue(updated),
-      } as unknown as EncounterChange;
-      const fakeHome = { clubId: "home-club" };
-      const fakeAway = { clubId: "away-club" };
-      const fakeEncounter = {
-        getHome: jest.fn().mockResolvedValue(fakeHome),
-        getAway: jest.fn().mockResolvedValue(fakeAway),
-      } as unknown as EncounterCompetition;
-      jest.spyOn(EncounterChange, "findByPk").mockResolvedValue(fakeChange);
-      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(fakeEncounter);
-      const result = await resolver.updateEncounterChange(buildUser(true), {
-        id: "ec-uuid",
-      } as any);
-      expect(fakeChange.update).toHaveBeenCalled();
-      expect(result).toBe(updated);
     });
   });
 
@@ -326,35 +271,6 @@ describe("EncounterChangeCompetitionResolver", () => {
 
       const result = await resolver.dates(fakeChange);
       expect(result).toHaveLength(0);
-    });
-  });
-
-  describe("addChangeEncounter (mutation)", () => {
-    it("throws NotFoundException when encounter not found", async () => {
-      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(null);
-      await expect(
-        resolver.addChangeEncounter(buildUser(true), { encounterId: "missing", home: true } as any)
-      ).rejects.toThrow(NotFoundException);
-    });
-
-    it("throws NotFoundException when team not found in encounter", async () => {
-      const fakeEncounter = { home: null, away: null } as unknown as EncounterCompetition;
-      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(fakeEncounter);
-      await expect(
-        resolver.addChangeEncounter(buildUser(true), { encounterId: "enc-uuid", home: true } as any)
-      ).rejects.toThrow(NotFoundException);
-    });
-
-    it("throws UnauthorizedException when user lacks change:encounter permission", async () => {
-      const fakeTeam = { clubId: "club-uuid" };
-      const fakeEncounter = { home: fakeTeam, away: null } as unknown as EncounterCompetition;
-      jest.spyOn(EncounterCompetition, "findByPk").mockResolvedValue(fakeEncounter);
-      await expect(
-        resolver.addChangeEncounter(buildUser(false), {
-          encounterId: "enc-uuid",
-          home: true,
-        } as any)
-      ).rejects.toThrow(UnauthorizedException);
     });
   });
 });

--- a/packages/backend-graphql/src/resolvers/event/competition/encounter-change.resolver.ts
+++ b/packages/backend-graphql/src/resolvers/event/competition/encounter-change.resolver.ts
@@ -1,12 +1,5 @@
-import {
-  EncounterChange,
-  EncounterChangeDate,
-  EncounterChangeUpdateInput,
-  EncounterCompetition,
-  Location,
-  Player,
-} from "@badman/backend-database";
-import { NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { EncounterChange, EncounterChangeDate, Location, Player } from "@badman/backend-database";
+import { NotFoundException } from "@nestjs/common";
 import {
   Args,
   Field,
@@ -89,37 +82,6 @@ export class EncounterChangeCompetitionResolver {
     @Args("input") input: FinalizeEncounterChangeInput
   ): Promise<FinalizeEncounterChangeResult> {
     return this.encounterChangeService.finalize(user, input);
-  }
-
-  @Mutation(() => EncounterChange)
-  async updateEncounterChange(
-    @User() user: Player,
-    @Args("data") updateChangeEncounter: EncounterChangeUpdateInput
-  ): Promise<EncounterChange> {
-    const encounterChange = await EncounterChange.findByPk(updateChangeEncounter.id);
-    if (!encounterChange) {
-      throw new NotFoundException(updateChangeEncounter.id);
-    }
-
-    const encounter = await EncounterCompetition.findByPk(encounterChange.encounterId);
-    if (!encounter) {
-      throw new NotFoundException(`${EncounterCompetition.name}: ${encounterChange.encounterId}`);
-    }
-
-    const homeTeam = await encounter.getHome();
-    const awayTeam = await encounter.getAway();
-
-    if (
-      !(await user.hasAnyPermission([
-        `${homeTeam.clubId}_change:encounter`,
-        `${awayTeam.clubId}_change:encounter`,
-        "change-any:encounter",
-      ]))
-    ) {
-      throw new UnauthorizedException(`You do not have permission to edit this encounter`);
-    }
-
-    return encounterChange.update(updateChangeEncounter);
   }
 }
 


### PR DESCRIPTION
## Summary

- Drop `updateEncounterChange` resolver method — the frontend defines the mutation in `mutations.gql` but never calls it; replaced by the `propose` / `triage` / `finalize` flow
- Remove the corresponding `updateEncounterChange` test block from the spec
- Remove stale `addChangeEncounter` test block (method was already removed from the resolver)
- Clean up now-unused imports in resolver and spec

## Why

Fixes the 3 failing tests breaking CI on the `develop → staging` PR (#1061).