### PR TITLE
fix(i18n): add triggerButton translation for admin change date feature

### DIFF
--- a/packages/backend-translate/assets/i18n/en/all.json
+++ b/packages/backend-translate/assets/i18n/en/all.json
@@ -2707,7 +2707,8 @@
           "buttons": {
             "cancel": "Cancel",
             "confirm": "Confirm"
-          }
+          },
+          "triggerButton": "Change date directly (admin)"
         },
         "table": {
           "headers": {

--- a/packages/backend-translate/assets/i18n/fr_BE/all.json
+++ b/packages/backend-translate/assets/i18n/fr_BE/all.json
@@ -2212,7 +2212,8 @@
           "buttons": {
             "cancel": "Annuler",
             "confirm": "Confirmer"
-          }
+          },
+          "triggerButton": "Modifier la date directement (admin)"
         },
         "table": {
           "headers": {

--- a/packages/backend-translate/assets/i18n/nl_BE/all.json
+++ b/packages/backend-translate/assets/i18n/nl_BE/all.json
@@ -2425,7 +2425,8 @@
           "buttons": {
             "cancel": "Annuleren",
             "confirm": "Bevestigen"
-          }
+          },
+          "triggerButton": "Datum direct wijzigen (admin)"
         },
         "table": {
           "headers": {

--- a/packages/utils/src/lib/i18n.generated.ts
+++ b/packages/utils/src/lib/i18n.generated.ts
@@ -2726,6 +2726,7 @@ export type I18nTranslations = {
                             "cancel": string;
                             "confirm": string;
                         };
+                        "triggerButton": string;
                     };
                     "table": {
                         "headers": {


### PR DESCRIPTION
## Summary
- Added `triggerButton` translation key for the admin change date dialog in all 3 locales (EN, NL, FR)

## Test plan
- [ ] Verify the "Change date directly (admin)" button label renders correctly in all locales on staging