### PR TITLE
fix(export): query enrollment entries by subEventId instead of drawId

### DIFF
--- a/apps/api/src/app/services/export/enrollment.service.spec.ts
+++ b/apps/api/src/app/services/export/enrollment.service.spec.ts
@@ -54,10 +54,12 @@ function makeEntry(overrides: {
   team?: Team | null;
   players?: { id: string; single?: number; double?: number; mix?: number }[];
   teamIndex?: number;
+  drawCompetition?: Partial<DrawCompetition> | null;
 }): EventEntry {
   return {
     id: "entry-1",
     team: overrides.team !== undefined ? overrides.team : makeTeam(),
+    drawCompetition: overrides.drawCompetition !== undefined ? overrides.drawCompetition : null,
     meta: {
       competition: {
         teamIndex: overrides.teamIndex ?? 1,
@@ -67,18 +69,11 @@ function makeEntry(overrides: {
   } as unknown as EventEntry;
 }
 
-function makeDrawWithEntries(entries: EventEntry[]): DrawCompetition {
-  return {
-    name: "Heren - Groep 1",
-    getEventEntries: jest.fn().mockResolvedValue(entries),
-  } as unknown as DrawCompetition;
-}
-
-function makeSubEvent(eventType: string, draws: DrawCompetition[]): SubEventCompetition {
+function makeSubEvent(eventType: string, entries: EventEntry[]): SubEventCompetition {
   return {
     name: "Heren",
     eventType,
-    getDrawCompetitions: jest.fn().mockResolvedValue(draws),
+    getEventEntries: jest.fn().mockResolvedValue(entries),
   } as unknown as SubEventCompetition;
 }
 
@@ -113,10 +108,8 @@ describe("EnrollmentService", () => {
 
   it("returns exactly 1 row for a single player entry", async () => {
     const player = makePlayer();
-    const draw = makeDrawWithEntries([
-      makeEntry({ players: [{ id: PLAYER_ID, single: 5, double: 4, mix: 3 }] }),
-    ]);
-    const subEvent = makeSubEvent(SubEventTypeEnum.M, [draw]);
+    const entry = makeEntry({ players: [{ id: PLAYER_ID, single: 5, double: 4, mix: 3 }] });
+    const subEvent = makeSubEvent(SubEventTypeEnum.M, [entry]);
 
     jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(makeEvent("Test", [subEvent]));
     jest.spyOn(Player, "findAll").mockResolvedValue([player]);
@@ -130,8 +123,7 @@ describe("EnrollmentService", () => {
 
   it("skips entry with no team and logs a warning", async () => {
     const warnSpy = jest.spyOn(service["logger"], "warn");
-    const draw = makeDrawWithEntries([makeEntry({ team: null })]);
-    const subEvent = makeSubEvent(SubEventTypeEnum.M, [draw]);
+    const subEvent = makeSubEvent(SubEventTypeEnum.M, [makeEntry({ team: null })]);
 
     jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(makeEvent("Test", [subEvent]));
     jest.spyOn(Player, "findAll").mockResolvedValue([]);
@@ -143,8 +135,9 @@ describe("EnrollmentService", () => {
   });
 
   it("skips player row when player ID not found in map", async () => {
-    const draw = makeDrawWithEntries([makeEntry({ players: [{ id: "unknown-id" }] })]);
-    const subEvent = makeSubEvent(SubEventTypeEnum.M, [draw]);
+    const subEvent = makeSubEvent(SubEventTypeEnum.M, [
+      makeEntry({ players: [{ id: "unknown-id" }] }),
+    ]);
 
     jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(makeEvent("Test", [subEvent]));
     jest.spyOn(Player, "findAll").mockResolvedValue([]);
@@ -156,10 +149,8 @@ describe("EnrollmentService", () => {
 
   it("MX sub-event: col 10 = single+double+mix, col 11 is empty", async () => {
     const player = makePlayer();
-    const draw = makeDrawWithEntries([
-      makeEntry({ players: [{ id: PLAYER_ID, single: 5, double: 4, mix: 3 }] }),
-    ]);
-    const subEvent = makeSubEvent(SubEventTypeEnum.MX, [draw]);
+    const entry = makeEntry({ players: [{ id: PLAYER_ID, single: 5, double: 4, mix: 3 }] });
+    const subEvent = makeSubEvent(SubEventTypeEnum.MX, [entry]);
 
     jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(makeEvent("Test", [subEvent]));
     jest.spyOn(Player, "findAll").mockResolvedValue([player]);
@@ -172,10 +163,8 @@ describe("EnrollmentService", () => {
 
   it("non-MX sub-event: col 10 is empty, col 11 = single+double", async () => {
     const player = makePlayer();
-    const draw = makeDrawWithEntries([
-      makeEntry({ players: [{ id: PLAYER_ID, single: 5, double: 4, mix: 3 }] }),
-    ]);
-    const subEvent = makeSubEvent(SubEventTypeEnum.M, [draw]);
+    const entry = makeEntry({ players: [{ id: PLAYER_ID, single: 5, double: 4, mix: 3 }] });
+    const subEvent = makeSubEvent(SubEventTypeEnum.M, [entry]);
 
     jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(makeEvent("Test", [subEvent]));
     jest.spyOn(Player, "findAll").mockResolvedValue([player]);
@@ -188,19 +177,11 @@ describe("EnrollmentService", () => {
 
   it("strips sub-event name prefix from draw name in Reeks column", async () => {
     const player = makePlayer();
-    const draw = {
-      name: "Heren - Groep 1",
-      getEventEntries: jest
-        .fn()
-        .mockResolvedValue([
-          makeEntry({ players: [{ id: PLAYER_ID, single: 5, double: 4, mix: 0 }] }),
-        ]),
-    } as unknown as DrawCompetition;
-    const subEvent = {
-      name: "Heren",
-      eventType: SubEventTypeEnum.M,
-      getDrawCompetitions: jest.fn().mockResolvedValue([draw]),
-    } as unknown as SubEventCompetition;
+    const entry = makeEntry({
+      players: [{ id: PLAYER_ID, single: 5, double: 4, mix: 0 }],
+      drawCompetition: { name: "Heren - Groep 1" } as DrawCompetition,
+    });
+    const subEvent = makeSubEvent(SubEventTypeEnum.M, [entry]);
 
     jest.spyOn(EventCompetition, "findByPk").mockResolvedValue(makeEvent("Test", [subEvent]));
     jest.spyOn(Player, "findAll").mockResolvedValue([player]);

--- a/apps/api/src/app/services/export/enrollment.service.ts
+++ b/apps/api/src/app/services/export/enrollment.service.ts
@@ -47,27 +47,26 @@ export class EnrollmentService {
       ],
     });
 
-    // Collect all player IDs across all entries for bulk resolution
+    // Collect all player IDs across all entries for bulk resolution.
+    // Entries are fetched via subEventId (always set at enrollment time).
+    // drawCompetition is included to populate the Reeks column when the entry
+    // has been assigned to a draw; entries not yet assigned get an empty Reeks.
     const allPlayerIds: string[] = [];
     const allEntries: {
       subEvent: SubEventCompetition;
-      draw: DrawCompetition;
       entry: EventEntry;
     }[] = [];
 
     for (const subEvent of subEvents) {
-      const draws = await subEvent.getDrawCompetitions();
-      for (const draw of draws) {
-        const entries = await draw.getEventEntries({
-          include: [{ model: Team }],
-          order: [["team", "name", "ASC"]],
-        });
-        for (const entry of entries) {
-          for (const meta of entry.meta?.competition?.players ?? []) {
-            if (meta.id) allPlayerIds.push(meta.id);
-          }
-          allEntries.push({ subEvent, draw, entry });
+      const entries = await subEvent.getEventEntries({
+        include: [{ model: Team }, { model: DrawCompetition }],
+        order: [["team", "name", "ASC"]],
+      });
+      for (const entry of entries) {
+        for (const meta of entry.meta?.competition?.players ?? []) {
+          if (meta.id) allPlayerIds.push(meta.id);
         }
+        allEntries.push({ subEvent, entry });
       }
     }
 
@@ -77,11 +76,13 @@ export class EnrollmentService {
 
     const rows: (string | number | undefined | null)[][] = [];
 
-    for (const { subEvent, draw, entry } of allEntries) {
+    for (const { subEvent, entry } of allEntries) {
       if (!entry.team) {
         this.logger.warn(`Entry ${entry.id} has no team — skipping`);
         continue;
       }
+
+      const drawName = entry.drawCompetition?.name ?? "";
 
       for (const meta of (entry.meta?.competition?.players ?? []).sort(sortPlayers)) {
         if (!meta.id) continue;
@@ -97,7 +98,7 @@ export class EnrollmentService {
             meta.double ?? 0,
             meta.mix ?? 0,
             subEvent.name,
-            draw.name,
+            drawName,
             isMixed,
             entry.meta?.competition?.teamIndex
           )


### PR DESCRIPTION
Enrollment sets subEventId on EventEntry; drawId is only populated after VR sync assigns teams to draws. The old code iterated draws and called getEventEntries() (filtered by drawId), which returned nothing for teams enrolled before draws were created. Switch to subEvent.getEventEntries() so all enrolled teams appear in the export regardless of draw assignment. Include DrawCompetition in the eager load to still populate the Reeks column when a draw has been assigned.

Update enrollment.service.spec.ts to match the new subEvent-based shape.