### PR TITLE
fix(notifications): send encounter-change notifications without team …

### DIFF
--- a/packages/backend-notifications/src/services/notification/notification.service.spec.ts
+++ b/packages/backend-notifications/src/services/notification/notification.service.spec.ts
@@ -187,23 +187,29 @@ describe("NotificationService", () => {
       expect(notifySpy).not.toHaveBeenCalled();
     });
 
-    it("skips notification when opposing team has no email", async () => {
+    it("still notifies (in-platform) when opposing team has no email", async () => {
       const homeTeam = buildTeam("home", "club-h", buildPlayer("home@club.be"));
+      const awayCaptain = buildPlayer("away@club.be");
       const awayTeam = {
-        ...buildTeam("away", "club-a", buildPlayer("away@club.be")),
+        ...buildTeam("away", "club-a", awayCaptain),
         email: undefined,
       } as unknown as Team;
 
       jest.spyOn(Team, "findByPk").mockResolvedValueOnce(homeTeam).mockResolvedValueOnce(awayTeam);
 
-      const notifySpy = jest.spyOn(
-        CompetitionEncounterChangeConfirmationRequestNotifier.prototype,
-        "notify"
-      );
+      const notifySpy = jest
+        .spyOn(CompetitionEncounterChangeConfirmationRequestNotifier.prototype, "notify")
+        .mockResolvedValue(undefined);
 
       await service.notifyEncounterChange(buildEncounter("h", "a"), true);
 
-      expect(notifySpy).not.toHaveBeenCalled();
+      expect(notifySpy).toHaveBeenCalledTimes(1);
+      expect(notifySpy).toHaveBeenCalledWith(
+        awayCaptain,
+        "enc-1",
+        expect.objectContaining({ isHome: false }),
+        { email: "" }
+      );
     });
 
     it("builds a CLIENT_URL-based URL for the opposing team", async () => {
@@ -297,6 +303,31 @@ describe("NotificationService", () => {
       await service.notifyEncounterChangeMessage(buildEncounter("h", "a"), true);
 
       expect(notifySpy).not.toHaveBeenCalled();
+    });
+
+    it("still notifies (in-platform) when opposing team has no email", async () => {
+      const homeTeam = buildTeam("home", "club-h", buildPlayer("home@club.be"));
+      const awayCaptain = buildPlayer("away@club.be");
+      const awayTeam = {
+        ...buildTeam("away", "club-a", awayCaptain),
+        email: undefined,
+      } as unknown as Team;
+
+      jest.spyOn(Team, "findByPk").mockResolvedValueOnce(homeTeam).mockResolvedValueOnce(awayTeam);
+
+      const notifySpy = jest
+        .spyOn(CompetitionEncounterHasCommentNotifier.prototype, "notify")
+        .mockResolvedValue(undefined);
+
+      await service.notifyEncounterChangeMessage(buildEncounter("h", "a"), true);
+
+      expect(notifySpy).toHaveBeenCalledTimes(1);
+      expect(notifySpy).toHaveBeenCalledWith(
+        awayCaptain,
+        "enc-1",
+        expect.objectContaining({ encounter: expect.anything() }),
+        expect.objectContaining({ email: "" })
+      );
     });
 
     it("builds a CLIENT_URL-based URL for the opposing team", async () => {

--- a/packages/backend-notifications/src/services/notification/notification.service.ts
+++ b/packages/backend-notifications/src/services/notification/notification.service.ts
@@ -119,7 +119,7 @@ export class NotificationService {
 
     const notifier = new CompetitionEncounterHasCommentNotifier(this.mailing, this.push);
 
-    if (opposingTeam.captain && opposingTeam.email) {
+    if (opposingTeam.captain) {
       this._logger.log(
         `[notifyEncounterChangeMessage] Notifying opposing captain ${opposingTeam.captain.email}`
       );
@@ -127,11 +127,10 @@ export class NotificationService {
         opposingTeam.captain,
         encounter.id,
         { encounter },
-        { email: opposingTeam.email, url }
+        { email: opposingTeam.email ?? "", url }
       );
     } else {
-      const reason = !opposingTeam.captain ? "no captain" : "no email";
-      this._logger.warn(`[notifyEncounterChangeMessage] Skipping — ${reason}`);
+      this._logger.warn(`[notifyEncounterChangeMessage] Skipping — no captain`);
     }
   }
 


### PR DESCRIPTION
…email

notifyEncounterChange already fired without a team email (in-platform notifications still reach the captain). notifyEncounterChangeMessage was inconsistent — it skipped when the opposing team had no email. Drop the email guard so both fire whenever a captain exists; email falls back to "".

Update the notifyEncounterChange spec to assert it fires with an empty email, and add the matching case for notifyEncounterChangeMessage.