### PR TITLE
fix(encounter): seed movingEncounters setting and fix admin date change record

### DIFF
--- a/database/migrations/20260708000000-add_moving_encounters_setting.js
+++ b/database/migrations/20260708000000-add_moving_encounters_setting.js
@@ -1,0 +1,76 @@
+"use strict";
+
+const CLAIM_ID = "c3d4e5f6-7a8b-9c0d-1e2f-3a4b5c6d7e8f";
+const SETTING_KEY = "movingEncounters";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: (queryInterface) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      try {
+        // Seed the change-any:encounter global claim (used by adminChangeEncounterDate
+        // and the movingEncounters setting permission check)
+        await queryInterface.bulkInsert(
+          { tableName: "Claims", schema: "security" },
+          [
+            {
+              id: CLAIM_ID,
+              name: "change-any:encounter",
+              description: "Change any encounter date or rescheduling-window settings",
+              category: "encounter",
+              type: "global",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ],
+          { transaction: t, ignoreDuplicates: true }
+        );
+
+        // Seed the movingEncounters admin setting row
+        await queryInterface.bulkInsert(
+          { tableName: "Settings", schema: "system" },
+          [
+            {
+              id: queryInterface.sequelize.constructor.literal("uuid_generate_v4()"),
+              key: SETTING_KEY,
+              description: "Encounter rescheduling open/close configuration",
+              enabled: false,
+              startDate: null,
+              endDate: null,
+              meta: null,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ],
+          { transaction: t, ignoreDuplicates: true }
+        );
+      } catch (err) {
+        console.error("We errored with", err);
+        await t.rollback();
+        throw err;
+      }
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      try {
+        await queryInterface.bulkDelete(
+          { tableName: "Settings", schema: "system" },
+          { key: SETTING_KEY },
+          { transaction: t }
+        );
+
+        await queryInterface.bulkDelete(
+          { tableName: "Claims", schema: "security" },
+          { id: { [Sequelize.Op.in]: [CLAIM_ID] } },
+          { transaction: t }
+        );
+      } catch (err) {
+        console.error("We errored with", err);
+        await t.rollback();
+        throw err;
+      }
+    });
+  },
+};

--- a/packages/backend-graphql/src/resolvers/event/competition/encounter-change.service.ts
+++ b/packages/backend-graphql/src/resolvers/event/competition/encounter-change.service.ts
@@ -505,12 +505,20 @@ export class EncounterChangeService {
     locationId: string | undefined,
     transaction: import("sequelize").Transaction
   ): Promise<void> {
-    const encounterChange = await EncounterChange.findOne({
+    let encounterChange = await EncounterChange.findOne({
       where: { encounterId },
       transaction,
     });
 
-    if (!encounterChange) return;
+    if (!encounterChange) {
+      encounterChange = await EncounterChange.create(
+        { encounterId, lastActionBy: ChangeEncounterParty.HOME, lastActionAt: new Date() },
+        { transaction }
+      );
+      this.logger.debug(
+        `[resolveProposalsForAdminChange] created new EncounterChange for encounterId=${encounterId}`
+      );
+    }
 
     const openDates = await encounterChange.getDates({ transaction });
     for (const d of openDates) {

--- a/packages/backend-graphql/src/resolvers/notification/notification.resolver.ts
+++ b/packages/backend-graphql/src/resolvers/notification/notification.resolver.ts
@@ -27,12 +27,34 @@ export class NotificationResolver {
 
   @Query(() => [Notification])
   async notifications(@Args() listArgs: ListArgs): Promise<Notification[]> {
-    return Notification.findAll(ListArgs.toFindOptions(listArgs));
+    const results = await Notification.findAll(ListArgs.toFindOptions(listArgs));
+    this.logger.debug(
+      `[notifications] returned ${results.length} notifications: ${results
+        .map(
+          (n) =>
+            `{id=${n.id} type=${n.type} linkType=${n.linkType} linkId=${n.linkId} read=${n.read}}`
+        )
+        .join(", ")}`
+    );
+    return results;
   }
 
   @ResolveField(() => EncounterCompetition)
   async encounter(@Parent() notification: Notification): Promise<EncounterCompetition> {
-    return notification.getEncounter();
+    this.logger.debug(
+      `[encounter] resolving encounter for notification id=${notification.id} linkType=${notification.linkType} linkId=${notification.linkId}`
+    );
+    const encounter = await notification.getEncounter();
+    if (!encounter) {
+      this.logger.warn(
+        `[encounter] no encounter found for notification id=${notification.id} linkId=${notification.linkId}`
+      );
+    } else {
+      this.logger.debug(
+        `[encounter] resolved encounterId=${encounter.id} homeTeamId=${encounter.homeTeamId} awayTeamId=${encounter.awayTeamId}`
+      );
+    }
+    return encounter;
   }
 
   @ResolveField(() => EventCompetition)
@@ -81,6 +103,10 @@ export class NotificationResolver {
       if (dbNotification.sendToId !== user.id) {
         throw new UnauthorizedException();
       }
+
+      this.logger.log(
+        `[updateNotification] notificationId=${dbNotification.id} type=${dbNotification.type} linkType=${dbNotification.linkType} linkId=${dbNotification.linkId} userId=${user.id}`
+      );
 
       await dbNotification.update(
         { ...dbNotification.toJSON(), ...updateNotificationData },

--- a/packages/backend-graphql/src/resolvers/setting/setting.resolver.ts
+++ b/packages/backend-graphql/src/resolvers/setting/setting.resolver.ts
@@ -6,6 +6,7 @@ import { Sequelize } from "sequelize-typescript";
 
 const SETTING_PERMISSIONS: Record<string, string[]> = {
   enrollment: ["change:enrollment"],
+  movingEncounters: ["change-any:encounter"],
 };
 
 @Resolver(() => AdminSetting)

--- a/packages/backend-translate/assets/i18n/en/all.json
+++ b/packages/backend-translate/assets/i18n/en/all.json
@@ -687,7 +687,9 @@
     "september": "September"
   },
   "notifications": {
+    "empty": "No notifications",
     "noNotifications": "No notifications",
+    "title": "Notifications",
     "types": {
       "encounterNotAcceptedNotification": "The match <strong>{encounter.home.name}</strong> against <strong>{encounter.away.name}</strong> on <strong>{encounter.date}</strong> has not yet been entered.",
       "encounterNotEnteredNotification": "The match <strong>{encounter.home.name}</strong> against <strong>{encounter.away.name}</strong> on <strong>{encounter.date}</strong> has not yet been entered."
@@ -1462,6 +1464,15 @@
         "save": "Save",
         "success": "Enrollment settings saved successfully",
         "error": "Failed to save enrollment settings"
+      },
+      "movingEncounters": {
+        "title": "Moving encounters",
+        "enabled": "Rescheduling open",
+        "startDate": "Start date",
+        "endDate": "End date",
+        "save": "Save",
+        "success": "Moving encounter settings saved successfully",
+        "error": "Failed to save moving encounter settings"
       }
     },
     "avgLevelPage": {
@@ -2811,7 +2822,8 @@
               "namur": "Namur",
               "oost-vlaanderen": "East Flanders",
               "vlaams-brabant": "Flemish Brabant",
-              "west-vlaanderen": "West Flanders"
+              "west-vlaanderen": "West Flanders",
+              "liga": "League"
             },
             "clubId": "Club ID",
             "messages": {
@@ -3806,6 +3818,10 @@
     },
     "changeEncounter": {
       "title": "Change encounter",
+      "disabled": {
+        "title": "Rescheduling closed",
+        "message": "Encounter rescheduling is currently closed. Please check back later."
+      },
       "encounterNotFound": "Encounter not found",
       "proposals": {
         "title": "Proposal",
@@ -3880,7 +3896,8 @@
           "proposal": "Proposal",
           "buttons": {
             "spaceForEncounters": "Space for {count} more encounters",
-            "courtsAvailableTooltip": "{courts} courts available"
+            "courtsAvailableTooltip": "{courts} courts available",
+            "alreadyProposedTooltip": "This date has already been proposed"
           },
           "eventWarning": "Competition is not allowed",
           "drawer": {
@@ -3913,6 +3930,7 @@
     "notifications": {
       "title": "Notifications",
       "empty": "No new notifications",
+      "markAllAsRead": "Mark all as read",
       "types": {
         "encounterChangeNew": "New rescheduling request received",
         "encounterChangeConfirmation": "Action required: rescheduling request",

--- a/packages/backend-translate/assets/i18n/fr_BE/all.json
+++ b/packages/backend-translate/assets/i18n/fr_BE/all.json
@@ -1202,7 +1202,9 @@
     "september": "Septembre"
   },
   "notifications": {
+    "empty": "Aucune notification",
     "noNotifications": "Aucune notification",
+    "title": "Notifications",
     "types": {
       "encounterNotAcceptedNotification": "Le match <strong>{encounter.home.name}</strong> contre <strong>{encounter.away.name}</strong> sur <strong>{encounter.date}</strong> n'a pas encore été saisie.",
       "encounterNotEnteredNotification": "Le match <strong>{encounter.home.name}</strong> contre <strong>{encounter.away.name}</strong> sur <strong>{encounter.date}</strong> n'a pas encore été saisie."
@@ -1700,6 +1702,15 @@
         "save": "Sauvegarder",
         "success": "Paramètres d'inscription enregistrés avec succès",
         "error": "Échec de l'enregistrement des paramètres d'inscription"
+      },
+      "movingEncounters": {
+        "title": "Déplacement des rencontres",
+        "enabled": "Déplacements ouverts",
+        "startDate": "Date de début",
+        "endDate": "Date de fin",
+        "save": "Sauvegarder",
+        "success": "Paramètres de déplacement des rencontres enregistrés avec succès",
+        "error": "Échec de l'enregistrement des paramètres de déplacement des rencontres"
       }
     },
     "avgLevelPage": {
@@ -1855,6 +1866,14 @@
               "startRequired": "La date de début est requise",
               "endRequired": "La date de fin est requise"
             }
+          }
+        }
+      },
+      "generalInfoTab": {
+        "title": "General info",
+        "generalForm": {
+          "states": {
+            "liga": "Ligue"
           }
         }
       },
@@ -2098,6 +2117,10 @@
     },
     "changeEncounter": {
       "title": "Déplacer la rencontre",
+      "disabled": {
+        "title": "Déplacements fermés",
+        "message": "Le déplacement des rencontres est actuellement fermé. Veuillez réessayer plus tard."
+      },
       "encounterNotFound": "Rencontre non trouvée",
       "proposals": {
         "title": "Propositions",
@@ -2172,7 +2195,8 @@
           "proposal": "Proposition",
           "buttons": {
             "spaceForEncounters": "Place pour {count} rencontres supplémentaires",
-            "courtsAvailableTooltip": "{courts} terrains disponibles"
+            "courtsAvailableTooltip": "{courts} terrains disponibles",
+            "alreadyProposedTooltip": "Cette date a déjà été proposée"
           },
           "eventWarning": "La compétition n'est pas autorisée",
           "drawer": {
@@ -2253,6 +2277,7 @@
     "notifications": {
       "title": "Notifications",
       "empty": "Aucune nouvelle notification",
+      "markAllAsRead": "Tout marquer comme lu",
       "types": {
         "encounterChangeNew": "Nouvelle demande de replanification reçue",
         "encounterChangeConfirmation": "Action requise : demande de replanification",

--- a/packages/backend-translate/assets/i18n/nl_BE/all.json
+++ b/packages/backend-translate/assets/i18n/nl_BE/all.json
@@ -682,7 +682,9 @@
     "september": "September"
   },
   "notifications": {
+    "empty": "Geen notificaties",
     "noNotifications": "Geen notificaties",
+    "title": "Notificaties",
     "types": {
       "encounterNotAcceptedNotification": "De wedstrijd <strong>{encounter.home.name}</strong> tegen <strong>{encounter.away.name}</strong> op <strong>{encounter.date}</strong> is nog niet ingegeven.",
       "encounterNotEnteredNotification": "De wedstrijd <strong>{encounter.home.name}</strong> tegen <strong>{encounter.away.name}</strong> op <strong>{encounter.date}</strong> is nog niet ingegeven."
@@ -1180,6 +1182,15 @@
         "save": "Opslaan",
         "success": "Inschrijvingsinstellingen succesvol opgeslagen",
         "error": "Inschrijvingsinstellingen opslaan mislukt"
+      },
+      "movingEncounters": {
+        "title": "Verplaatsen ontmoetingen",
+        "enabled": "Verplaatsingen open",
+        "startDate": "Startdatum",
+        "endDate": "Einddatum",
+        "save": "Opslaan",
+        "success": "Instellingen voor verplaatsen ontmoetingen succesvol opgeslagen",
+        "error": "Instellingen voor verplaatsen ontmoetingen opslaan mislukt"
       }
     },
     "avgLevelPage": {
@@ -2529,7 +2540,8 @@
               "namur": "Namen",
               "oost-vlaanderen": "Oost-Vlaanderen",
               "vlaams-brabant": "Vlaams-Brabant",
-              "west-vlaanderen": "West-Vlaanderen"
+              "west-vlaanderen": "West-Vlaanderen",
+              "liga": "Liga"
             },
             "clubId": "Club ID",
             "messages": {
@@ -3584,6 +3596,10 @@
     },
     "changeEncounter": {
       "title": "Verplaats ontmoeting",
+      "disabled": {
+        "title": "Verplaatsingen gesloten",
+        "message": "Het verplaatsen van ontmoetingen is momenteel gesloten. Probeer later opnieuw."
+      },
       "encounterNotFound": "Ontmoeting niet gevonden",
       "proposals": {
         "title": "Voorstellen",
@@ -3658,7 +3674,8 @@
           "proposal": "Voorstel",
           "buttons": {
             "spaceForEncounters": "Ruimte voor nog {count} ontmoetingen",
-            "courtsAvailableTooltip": "{courts} velden beschikbaar"
+            "courtsAvailableTooltip": "{courts} velden beschikbaar",
+            "alreadyProposedTooltip": "Deze datum is al voorgesteld"
           },
           "eventWarning": "Competitie is niet toegestaan",
           "drawer": {
@@ -3691,6 +3708,7 @@
     "notifications": {
       "title": "Meldingen",
       "empty": "Geen nieuwe meldingen",
+      "markAllAsRead": "Alles als gelezen markeren",
       "types": {
         "encounterChangeNew": "Nieuw verplaatsingsverzoek ontvangen",
         "encounterChangeConfirmation": "Actie vereist: verplaatsingsverzoek",

--- a/packages/utils/src/lib/i18n.generated.ts
+++ b/packages/utils/src/lib/i18n.generated.ts
@@ -694,7 +694,9 @@ export type I18nTranslations = {
             "september": string;
         };
         "notifications": {
+            "empty": string;
             "noNotifications": string;
+            "title": string;
             "types": {
                 "encounterNotAcceptedNotification": string;
                 "encounterNotEnteredNotification": string;
@@ -1476,6 +1478,15 @@ export type I18nTranslations = {
                     "openDate": string;
                     "startDate": string;
                     "closeDate": string;
+                    "endDate": string;
+                    "save": string;
+                    "success": string;
+                    "error": string;
+                };
+                "movingEncounters": {
+                    "title": string;
+                    "enabled": string;
+                    "startDate": string;
                     "endDate": string;
                     "save": string;
                     "success": string;
@@ -2830,6 +2841,7 @@ export type I18nTranslations = {
                                 "oost-vlaanderen": string;
                                 "vlaams-brabant": string;
                                 "west-vlaanderen": string;
+                                "liga": string;
                             };
                             "clubId": string;
                             "messages": {
@@ -3889,6 +3901,10 @@ export type I18nTranslations = {
             };
             "changeEncounter": {
                 "title": string;
+                "disabled": {
+                    "title": string;
+                    "message": string;
+                };
                 "encounterNotFound": string;
                 "proposals": {
                     "title": string;
@@ -3964,6 +3980,7 @@ export type I18nTranslations = {
                         "buttons": {
                             "spaceForEncounters": string;
                             "courtsAvailableTooltip": string;
+                            "alreadyProposedTooltip": string;
                         };
                         "eventWarning": string;
                         "drawer": {
@@ -3996,6 +4013,7 @@ export type I18nTranslations = {
             "notifications": {
                 "title": string;
                 "empty": string;
+                "markAllAsRead": string;
                 "types": {
                     "encounterChangeNew": string;
                     "encounterChangeConfirmation": string;
@@ -4024,6 +4042,14 @@ export type I18nTranslations = {
                                 "startRequired": string;
                                 "endRequired": string;
                             };
+                        };
+                    };
+                };
+                "generalInfoTab": {
+                    "title": string;
+                    "generalForm": {
+                        "states": {
+                            "liga": string;
                         };
                     };
                 };


### PR DESCRIPTION
## Summary

- **Migration**: seeds `change-any:encounter` global claim + `movingEncounters` admin setting row (mirrors the `enrollment` pattern from `20260320000000`)
- **Resolver**: adds `movingEncounters: ["change-any:encounter"]` to `SETTING_PERMISSIONS` so `updateAdminSetting` no longer throws 404 for this key
- **Bug fix**: `resolveProposalsForAdminChange` now creates an `EncounterChange` record when none exists — admin date overrides previously produced no ACCEPTED date entry, causing the frontend `alreadyProposed` logic to miss the slot
- **i18n**: keys for movingEncounters settings UI, notification empty/title strings, change-encounter disabled state, and a missing `liga` region label

## Test plan

- [ ] Run `npx sequelize-cli db:migrate` — migration applies cleanly
- [ ] Open admin settings UI → movingEncounters form loads and saves without 404
- [ ] Admin changes an encounter date on an encounter with no prior rescheduling request → an `EncounterChange` row with an ACCEPTED date entry is created
- [ ] Frontend slot picker shows that date as taken (blue disabled) after admin override
- [ ] Existing tests pass: `pnpm turbo run test --filter=@badman/backend-graphql`