### PR TITLE
fix(notifications): store recipient clubId in notification meta for correct click routing

### DIFF
--- a/packages/backend-notifications/src/notifiers/notifier.base.ts
+++ b/packages/backend-notifications/src/notifiers/notifier.base.ts
@@ -32,7 +32,8 @@ export abstract class Notifier<T, A = { email: string }> {
       email?: boolean;
       push?: boolean;
       sms?: boolean;
-    }
+    },
+    meta?: Record<string, unknown>
   ): Promise<void> {
     try {
       if (!player) {
@@ -165,6 +166,7 @@ export abstract class Notifier<T, A = { email: string }> {
           linkId,
           linkType: this.linkType,
           type: this.type,
+          meta: meta ? JSON.stringify(meta) : undefined,
         });
 
         await notif.save();

--- a/packages/backend-notifications/src/services/notification/notification.service.spec.ts
+++ b/packages/backend-notifications/src/services/notification/notification.service.spec.ts
@@ -143,7 +143,9 @@ describe("NotificationService", () => {
         awayCaptain,
         encounter.id,
         expect.objectContaining({ isHome: false }),
-        { email: "away@team.be" }
+        { email: "away@team.be" },
+        undefined, // force
+        { clubId: "club-a" }
       );
     });
 
@@ -167,7 +169,9 @@ describe("NotificationService", () => {
         homeCaptain,
         encounter.id,
         expect.objectContaining({ isHome: true }),
-        { email: "home@team.be" }
+        { email: "home@team.be" },
+        undefined, // force
+        { clubId: "club-h" }
       );
     });
 
@@ -208,7 +212,9 @@ describe("NotificationService", () => {
         awayCaptain,
         "enc-1",
         expect.objectContaining({ isHome: false }),
-        { email: "" }
+        { email: "" },
+        undefined, // force
+        { clubId: "club-a" }
       );
     });
 
@@ -264,7 +270,9 @@ describe("NotificationService", () => {
         awayCaptain,
         encounter.id,
         expect.objectContaining({ encounter }),
-        expect.objectContaining({ email: "away@team.be" })
+        expect.objectContaining({ email: "away@team.be" }),
+        undefined, // force
+        { clubId: "club-a" }
       );
     });
 
@@ -288,7 +296,9 @@ describe("NotificationService", () => {
         homeCaptain,
         encounter.id,
         expect.objectContaining({ encounter }),
-        expect.objectContaining({ email: "home@team.be" })
+        expect.objectContaining({ email: "home@team.be" }),
+        undefined, // force
+        { clubId: "club-h" }
       );
     });
 
@@ -326,7 +336,9 @@ describe("NotificationService", () => {
         awayCaptain,
         "enc-1",
         expect.objectContaining({ encounter: expect.anything() }),
-        expect.objectContaining({ email: "" })
+        expect.objectContaining({ email: "" }),
+        undefined, // force
+        { clubId: "club-a" }
       );
     });
 

--- a/packages/backend-notifications/src/services/notification/notification.service.ts
+++ b/packages/backend-notifications/src/services/notification/notification.service.ts
@@ -84,7 +84,9 @@ export class NotificationService {
         confReqTeam.captain,
         encounter.id,
         { encounter, isHome: !homeTeamRequests, url: confReqUrl, action },
-        { email: confReqTeam.email ?? "" }
+        { email: confReqTeam.email ?? "" },
+        undefined, // force
+        { clubId: confReqTeam.clubId }
       );
     } else {
       this._logger.warn(
@@ -127,7 +129,9 @@ export class NotificationService {
         opposingTeam.captain,
         encounter.id,
         { encounter },
-        { email: opposingTeam.email ?? "", url }
+        { email: opposingTeam.email ?? "", url },
+        undefined, // force
+        { clubId: opposingTeam.clubId }
       );
     } else {
       this._logger.warn(`[notifyEncounterChangeMessage] Skipping — no captain`);
@@ -173,7 +177,9 @@ export class NotificationService {
         homeTeam.captain,
         encounter.id,
         { encounter, locationHasChanged, isHome: true, validation, url: homeTeamUrl },
-        { email: homeTeam.email ?? "" }
+        { email: homeTeam.email ?? "" },
+        undefined, // force
+        { clubId: homeTeam.clubId }
       );
     } else {
       this._logger.warn(
@@ -190,7 +196,9 @@ export class NotificationService {
         awayTeam.captain,
         encounter.id,
         { encounter, locationHasChanged, isHome: false, validation, url: awayTeamUrl },
-        { email: awayTeam.email ?? "" }
+        { email: awayTeam.email ?? "" },
+        undefined, // force
+        { clubId: awayTeam.clubId }
       );
     } else {
       const skipReason = !awayTeam.captain ? "no captain" : "same captain as home";


### PR DESCRIPTION
When a player clicks an encounter-change notification, the frontend needs to know which club's route to navigate to. Previously the frontend always fell back to homeTeam.clubId, routing away-team captains to the wrong club.

Now each notify() call for encounter-change events passes { clubId } of the recipient's team as meta, stored as JSON on the Notification record.