### PR TITLE
fix(sync): skip index recalculation hook when saving entry meta in sy…

### DIFF
--- a/apps/worker/sync/src/app/processors/sync-events/competition-sync/processors/entry.ts
+++ b/apps/worker/sync/src/app/processors/sync-events/competition-sync/processors/entry.ts
@@ -518,8 +518,10 @@ export class CompetitionSyncEntryProcessor extends StepProcessor {
         };
 
         // Update entry meta with Visual API data
+        // hooks: false — skips the @BeforeUpdate recalculateCompetitionIndex hook which
+        // requires IndexCalculationService (an enrollment concern not present in the sync worker).
         entry.meta = entryMeta;
-        await entry.save({ transaction: this.transaction });
+        await entry.save({ transaction: this.transaction, hooks: false });
 
         this.logger.debug(
           `Updated entry meta with Visual API data: ${players.length} players for team ${team.name}`


### PR DESCRIPTION
…nc worker

The @BeforeUpdate recalculateCompetitionIndex hook on EventEntry requires IndexCalculationService which is only registered via EnrollmentModule in the API. The sync worker doesn't import EnrollmentModule and shouldn't need to — it's just mirroring player roster data from TS. Use hooks: false on the specific save call in _updateTeamDataFromVisual to bypass the hook.