### PR TITLE
fix(encounter): fix season calculation and semester split in encounter validation

### DIFF
--- a/apps/worker/sync/src/app/controllers/admin.controller.ts
+++ b/apps/worker/sync/src/app/controllers/admin.controller.ts
@@ -1,6 +1,6 @@
-import { SyncQueue } from "@badman/backend-queue";
+import { Sync, SyncQueue } from "@badman/backend-queue";
 import { InjectQueue } from "@nestjs/bull";
-import { Controller, Get, Param, Post, Logger } from "@nestjs/common";
+import { Body, Controller, Get, Param, Post, Logger } from "@nestjs/common";
 import { Queue } from "bull";
 
 @Controller("admin/jobs")
@@ -60,6 +60,31 @@ export class AdminJobsController {
     ]);
 
     return { waiting, active, completed, failed, delayed };
+  }
+
+  @Post("trigger/sync-events")
+  async triggerSyncEvents(
+    @Body()
+    body: {
+      id?: string | string[];
+      search?: string;
+      date?: string;
+      startDate?: string;
+      skip?: string[];
+      only?: string[];
+      official?: boolean;
+      offset?: number;
+      limit?: number;
+      userId?: string | string[];
+    } = {}
+  ) {
+    const job = await this.queue.add(Sync.SyncEvents, body, {
+      removeOnComplete: 5,
+      removeOnFail: 5,
+      attempts: 1,
+    });
+    this.logger.log(`Triggered SyncEvents job ${job.id} with data: ${JSON.stringify(body)}`);
+    return { success: true, jobId: job.id, name: job.name, data: body };
   }
 
   @Post(":id/retry")

--- a/packages/backend-competition/change-encounter/src/services/validate/encounter.service.ts
+++ b/packages/backend-competition/change-encounter/src/services/validate/encounter.service.ts
@@ -1,5 +1,6 @@
 import { EncounterCompetition, Location } from "@badman/backend-database";
 import { ValidationService } from "@badman/backend-validation";
+import { getSeason } from "@badman/utils";
 import { Injectable, Logger } from "@nestjs/common";
 import { Op } from "sequelize";
 import {
@@ -107,9 +108,15 @@ export class EncounterValidationService extends ValidationService<
       ],
     });
 
-    const season = Math.min(...encounters.map((r) => r.date?.getFullYear() ?? 0));
+    // Filter out undated encounters before computing season; fall back to current season.
+    // Using getSeason() so January-April dates in year N+1 correctly map to season N.
+    const datedEncounters = encounters.filter((r) => r.date != null);
+    const season =
+      datedEncounters.length > 0
+        ? Math.min(...datedEncounters.map((r) => getSeason(r.date!)))
+        : getSeason();
     const encountersSem1 = encounters.filter((r) => r.date?.getFullYear() === season);
-    const encountersSem2 = encounters.filter((r) => r.date?.getFullYear() !== season);
+    const encountersSem2 = encounters.filter((r) => r.date?.getFullYear() === season + 1);
 
     const indexSem1 = encountersSem1.findIndex((r) => r.id === encounter.id);
     const indexSem2 = encountersSem2.findIndex((r) => r.id === encounter.id);
@@ -169,7 +176,6 @@ export class EncounterValidationService extends ValidationService<
     },
     runFor?: { playerId?: string; teamId?: string; clubId?: string }
   ) {
-    console.log("validate", args, runFor);
     const data = await super.validate(args, runFor);
 
     return {

--- a/packages/backend-graphql/src/resolvers/security/claim.resolver.ts
+++ b/packages/backend-graphql/src/resolvers/security/claim.resolver.ts
@@ -65,6 +65,9 @@ export class ClaimResolver {
       }
 
       await transaction.commit();
+      this.logger.warn(
+        `[permission-change] actor=${user.id} action=${active ? "grant" : "revoke"} target=${playerId} claim=${claimId}`
+      );
       return true;
     } catch (error) {
       this.logger.error(error);
@@ -96,6 +99,10 @@ export class ClaimResolver {
         } else {
           await player.removeClaim(claimId, { transaction });
         }
+
+        this.logger.warn(
+          `[permission-change] actor=${user.id} action=${active ? "grant" : "revoke"} target=${playerId} claim=${claimId}`
+        );
       }
 
       await transaction.commit();


### PR DESCRIPTION
## Summary

- **Season=0 bug**: `encounter.service.ts` was computing season with `r.date?.getFullYear() ?? 0`, which produced `0` when any encounter lacked a date. Replaced with `getSeason()` so January–April dates in year N+1 correctly map to season N, and null-dated encounters are filtered out before the `Math.min` call
- **Semester 2 filter**: `encountersSem2` was using `!== season` (caught undated/wrong-year encounters); fixed to `=== season + 1`
- **Stray console.log**: removed debug `console.log("validate", args, runFor)` from `EncounterValidationService.validate()`
- **Audit logging**: added `logger.warn` after permission grant/revoke in `ClaimResolver` so actor/target/claim changes are traceable in logs
- **Admin endpoint**: added `POST /admin/jobs/trigger/sync-events` to the sync worker admin controller for manual sync triggering

## Test plan

- [ ] Change-encounter calendar: verify December slots appear correctly for encounters originally scheduled in October (DST boundary)
- [ ] Verify encounters with null dates don't produce season=0
- [ ] Verify `encountersSem2` contains only year `season+1` encounters
- [ ] Permission grant/revoke appears in logs with actor/target/claim info
- [ ] `POST /admin/jobs/trigger/sync-events` queues a SyncEvents job and returns `{ success, jobId }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)