### PR TITLE
fix(change-encounter): demote current-slot capacity error to warning …

### DIFF
--- a/packages/backend-competition/change-encounter/src/services/validate/rules/location-free.rule.ts
+++ b/packages/backend-competition/change-encounter/src/services/validate/rules/location-free.rule.ts
@@ -56,7 +56,13 @@ export class LocationRule extends Rule {
       false
     );
     if (err.length) {
-      errors.push(...err);
+      // When a date change is being proposed/finalized the current slot will be
+      // replaced — its capacity issues are irrelevant to accepting the new date.
+      if (suggestedDates && suggestedDates.length > 0) {
+        warnings.push(...err);
+      } else {
+        errors.push(...err);
+      }
     }
 
     if (warn.length) {


### PR DESCRIPTION
…when a date change is proposed

When finalizing an encounter date change the LocationRule was checking the *current* (outgoing) slot for capacity and throwing a hard error if it was overbooked. This blocked finalization even though the encounter was being moved away from that slot. Den Willecom - Edegem (12 courts, 8 simultaneous encounters) was the most frequent case (38 Sentry events, 9 users since 22 Jul).

When suggestedDates are present the current slot will be replaced, so its capacity issue is irrelevant. Demote those errors to warnings so only the proposed new slot can block finalization.